### PR TITLE
Add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug Report
+description: File a bug report
+title: ""
+labels: ["bug"]
+body:
+  - type: input
+    id: gyroflow-version
+    attributes:
+      label: Gyroflow version
+      description: What version of Gyroflow are you running?
+      placeholder: Version nr or commit id
+    validations:
+      required: true
+  - type: input
+    id: os
+    attributes:
+      label: What operating system are you using?
+      description: Please be specific, for example "macOS Catalina 10.15.4"
+      placeholder: OS and version nr
+    validations:
+      required: true
+  - type: input
+    id: gpu
+    attributes:
+      label: What GPU are you using?
+      description: If you are using a GPU please tell us what model you have.
+      placeholder: Brand and model
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please try to run Gyroflow via terminal and paste any relevant log output here. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: File a bug report
-title: ""
+title: "[Bug]: "
 labels: ["bug"]
 body:
   - type: input

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Gyroflow documentation
+    url: https://docs.gyroflow.xyz/
+    about: Please read the docs here
+  - name: Gyroflow website
+    url: https://gyroflow.xyz/
+    about: Gyroflow website with general info

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,19 @@
+name: Feature Request
+description: Propose a new feature to the Gyroflow project.
+title: ""
+labels: ["enhancement"]
+body:
+  - type: checkboxes
+  attributes:
+    label: Is there an existing issue for this?
+    description: Please search to see if an issue already exists for the bug you encountered.
+    options:
+    - label: I have searched the existing issues
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Description
+      placeholder: Tell us your idea!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,12 +4,12 @@ title: "[Feature request]: "
 labels: ["enhancement"]
 body:
   - type: checkboxes
-  attributes:
-    label: Is there an existing issue for this?
-    description: Please search to see if an issue already exists for the bug you encountered.
-    options:
-    - label: I have searched the existing issues
-      required: true
+    attributes:
+      label: Is there an existing issue for this?
+      description: Please search to see if an issue already exists for the bug you encountered.
+      options:
+      - label: I have searched the existing issues
+        required: true
   - type: textarea
     id: proposal
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature Request
 description: Propose a new feature to the Gyroflow project.
-title: ""
+title: "[Feature request]: "
 labels: ["enhancement"]
 body:
   - type: checkboxes


### PR DESCRIPTION
In order to maintain relevant information in future issues, I suggest we use Github issue templates.
"Live demo" can be seen here: https://github.com/alexagv/gyroflow-2/issues/new/choose

More info on templates: https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates