### PR TITLE
Improved close confirmation triggering

### DIFF
--- a/src/ui/App.qml
+++ b/src/ui/App.qml
@@ -52,6 +52,8 @@ Rectangle {
     property alias sync: sync;
     property alias stab: stab;
 
+    readonly property bool wasModified: window.videoArea.vid.loaded;
+
     FileDialog {
         id: fileDialog;
         property var extensions: [

--- a/src/ui/main_window.qml
+++ b/src/ui/main_window.qml
@@ -31,17 +31,20 @@ Window {
     Component.onCompleted: ui_tools.set_icon(main_window);
 
     property bool closeConfirmationModal: false;
-    onClosing: (close) => {
+    property bool closeConfirmed: false;
+    onClosing: (close) => {        
         let app = getApp();
-        if (app && !closeConfirmationModal) {
-            app.messageBox(Modal.NoIcon, qsTr("Are you sure you want to exit?"), [
-                { text: qsTr("Yes"), accent: true, clicked: () => main_window.close() },
-                { text: qsTr("No"), clicked: () => main_window.closeConfirmationModal = false },
-            ]);
-            close.accepted = false;
-            closeConfirmationModal = true;
+        if (app) {
+            close.accepted = closeConfirmed || !app.wasModified;
+            if (!close.accepted && !closeConfirmationModal) {
+                closeConfirmationModal = true;
+                app.messageBox(Modal.NoIcon, qsTr("Are you sure you want to exit?"), [
+                    { text: qsTr("Yes"), accent: true, clicked: () => {main_window.closeConfirmed = true; main_window.close();} },
+                    { text: qsTr("No"), clicked: () => main_window.closeConfirmationModal = false }
+                ]);                
+            }
         }
     }
-    
+
     App { objectName: "App"; }
 }


### PR DESCRIPTION
Fix for issue where clicking twice on the windows close button would bypass the close confirmation. 
Allow closing the app without confirmation when nothing was loaded.