### PR TITLE
Separated processing params from lib

### DIFF
--- a/src/core/gyro_source.rs
+++ b/src/core/gyro_source.rs
@@ -6,15 +6,14 @@ use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::fs::File;
 use std::path::Path;
+use std::io::Result;
 use telemetry_parser::{Input, util};
 use telemetry_parser::tags_impl::{GetWithType, GroupId, TagId, TimeQuaternion};
 
-use crate::BasicParams;
+use crate::processing_params::ProcessingParams;
 use crate::camera_identifier::CameraIdentifier;
-
-use super::integration::*;
-use super::smoothing::SmoothingAlgorithm;
-use std::io::Result;
+use crate::integration::*;
+use crate::smoothing::SmoothingAlgorithm;
 
 pub type Quat64 = UnitQuaternion<f64>;
 pub type TimeIMU = telemetry_parser::util::IMUData;
@@ -88,7 +87,7 @@ impl GyroSource {
             ..Default::default()
         }
     }
-    pub fn init_from_params(&mut self, params: &BasicParams) {
+    pub fn init_from_params(&mut self, params: &ProcessingParams) {
         self.fps = params.get_scaled_fps();
         self.duration_ms = params.get_scaled_duration_ms();
         self.offsets.clear();
@@ -201,7 +200,7 @@ impl GyroSource {
         }
     }
 
-    pub fn recompute_smoothness(&mut self, alg: &mut dyn SmoothingAlgorithm, params: &BasicParams) {
+    pub fn recompute_smoothness(&mut self, alg: &mut dyn SmoothingAlgorithm, params: &ProcessingParams) {
         self.smoothed_quaternions = alg.smooth(&self.quaternions, self.duration_ms, params);
         self.max_angles = crate::Smoothing::get_max_angles(&self.quaternions, &self.smoothed_quaternions, params);
         self.org_smoothed_quaternions = self.smoothed_quaternions.clone();

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1,139 +1,47 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
 
+pub mod adaptive_zoom;
+pub mod processing_params;
+pub mod camera_identifier;
+pub mod filtering;
+pub mod gpu;
 pub mod gyro_source;
-pub mod integration;
 pub mod integration_complementary; // TODO: add this to `ahrs` crate
-pub mod lens_profile;
+pub mod integration;
 pub mod lens_profile_database;
-#[cfg(feature = "opencv")]
-pub mod calibration;
+pub mod lens_profile;
+pub mod smoothing;
 pub mod synchronization;
 pub mod undistortion;
-pub mod adaptive_zoom;
-pub mod camera_identifier;
-
-pub mod smoothing;
-pub mod filtering;
-
-pub mod gpu;
-
 pub mod util;
 
-use std::{sync::Arc, collections::BTreeMap};
-use std::sync::atomic::AtomicU64;
-use std::sync::atomic::Ordering::SeqCst;
-use camera_identifier::CameraIdentifier;
+#[cfg(feature = "opencv")]
+pub mod calibration;
+
+use nalgebra::Vector4;
 use parking_lot::RwLock;
-pub use undistortion::PixelType;
+use std::collections::BTreeMap;
+use std::sync::{Arc, atomic::AtomicU64, atomic::Ordering::SeqCst};
 
-use crate::lens_profile_database::LensProfileDatabase;
+use adaptive_zoom::AdaptiveZoom;
+use processing_params::ProcessingParams;
+use camera_identifier::CameraIdentifier;
+use gyro_source::{ GyroSource, Quat64 };
+use lens_profile::LensProfile;
+use lens_profile_database::LensProfileDatabase;
+use smoothing::Smoothing;
+use undistortion::{PixelType, Undistortion};
 
-use self::{ lens_profile::LensProfile, smoothing::Smoothing, undistortion::Undistortion, adaptive_zoom::AdaptiveZoom };
 #[cfg(feature = "opencv")]
 use self::calibration::LensCalibrator;
 
-use nalgebra::Vector4;
-use gyro_source::{ GyroSource, Quat64 };
 
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 lazy_static::lazy_static! {
     static ref THREAD_POOL: rayon::ThreadPool = rayon::ThreadPoolBuilder::new().build().unwrap();
-}
-
-#[derive(Clone)]
-pub struct BasicParams {
-    pub size: (usize, usize), // Processing input size
-    pub output_size: (usize, usize), // Processing output size
-    pub video_size: (usize, usize), // Full resolution input size
-    pub video_output_size: (usize, usize), // Full resoution output size
-
-    pub background: Vector4<f32>,
-
-    pub frame_readout_time: f64,
-    pub adaptive_zoom_window: f64,
-    pub fov: f64,
-    pub fovs: Vec<f64>,
-    pub min_fov: f64,
-    pub fps: f64,
-    pub fps_scale: Option<f64>,
-    pub frame_count: usize,
-    pub duration_ms: f64,
-
-    pub trim_start: f64,
-    pub trim_end: f64,
-
-    pub video_rotation: f64,
-
-    pub framebuffer_inverted: bool,
-    pub is_calibrator: bool,
-    
-    pub stab_enabled: bool,
-    pub show_detected_features: bool,
-    pub show_optical_flow: bool,
-}
-impl Default for BasicParams {
-    fn default() -> Self {
-        Self {
-            fov: 1.0,
-            min_fov: 1.0,
-            fovs: vec![],
-            stab_enabled: true,
-            show_detected_features: true,
-            show_optical_flow: true,
-            frame_readout_time: 0.0, 
-            adaptive_zoom_window: 0.0, 
-
-            size: (0, 0),
-            output_size: (0, 0),
-            video_size: (0, 0),
-            video_output_size: (0, 0),
-
-            video_rotation: 0.0,
-            
-            framebuffer_inverted: false,
-            is_calibrator: false,
-
-            trim_start: 0.0,
-            trim_end: 1.0,
-        
-            background: Vector4::new(0.0, 0.0, 0.0, 0.0),
-    
-            fps: 0.0,
-            fps_scale: None,
-            frame_count: 0,
-            duration_ms: 0.0,
-        }
-    }
-}
-
-impl BasicParams {
-    pub fn get_scaled_duration_ms(&self) -> f64 {
-        match self.fps_scale {
-            Some(scale) => self.duration_ms / scale,
-            None            => self.duration_ms
-        }
-    }
-    pub fn get_scaled_fps(&self) -> f64 {
-        match self.fps_scale {
-            Some(scale) => self.fps * scale,
-            None            => self.fps
-        }
-    }
-
-    pub fn set_fovs(&mut self, fovs: Vec<f64>, mut lens_fov_adjustment: f64) {
-        if let Some(mut min_fov) = fovs.iter().copied().reduce(f64::min) {
-            min_fov *= self.video_size.0 as f64 / self.video_output_size.0.max(1) as f64;
-            if lens_fov_adjustment <= 0.0001 { lens_fov_adjustment = 1.0 };
-            self.min_fov = min_fov / lens_fov_adjustment;
-        }
-        if fovs.is_empty() {
-            self.min_fov = 1.0;
-        }
-        self.fovs = fovs;
-    }
 }
 
 pub struct StabilizationManager<T: PixelType> {
@@ -155,7 +63,7 @@ pub struct StabilizationManager<T: PixelType> {
     pub camera_id: Arc<RwLock<Option<CameraIdentifier>>>,
     pub lens_profile_db: Arc<RwLock<LensProfileDatabase>>,
 
-    pub params: Arc<RwLock<BasicParams>>
+    pub params: Arc<RwLock<ProcessingParams>>
 }
 
 impl<T: PixelType> Default for StabilizationManager<T> {
@@ -163,7 +71,7 @@ impl<T: PixelType> Default for StabilizationManager<T> {
         Self {
             smoothing: Arc::new(RwLock::new(Smoothing::default())),
 
-            params: Arc::new(RwLock::new(BasicParams::default())),
+            params: Arc::new(RwLock::new(ProcessingParams::default())),
             
             undistortion: Arc::new(RwLock::new(Undistortion::<T>::default())),
             gyro: Arc::new(RwLock::new(GyroSource::new())),
@@ -316,7 +224,7 @@ impl<T: PixelType> StabilizationManager<T> {
         }
     }
 
-    pub fn recompute_adaptive_zoom_static(zoom: &mut AdaptiveZoom, params: &RwLock<BasicParams>) -> Vec<f64> {
+    pub fn recompute_adaptive_zoom_static(zoom: &mut AdaptiveZoom, params: &RwLock<ProcessingParams>) -> Vec<f64> {
         let (window, frames, fps) = {
             let params = params.read();
             (params.adaptive_zoom_window, params.frame_count, params.get_scaled_fps())
@@ -366,7 +274,7 @@ impl<T: PixelType> StabilizationManager<T> {
         let mut params = undistortion::ComputeParams::from_manager(self);
 
         let smoothing = self.smoothing.clone();
-        let basic_params = self.params.clone();
+        let processing_params = self.params.clone();
         let gyro = self.gyro.clone();
 
         let compute_id = fastrand::u64(..);
@@ -384,7 +292,7 @@ impl<T: PixelType> StabilizationManager<T> {
             let mut smoothing_changed = false;
             if smoothing.read().get_state_checksum() != smoothness_checksum.load(SeqCst) {
                 let mut smoothing = smoothing.write().current().clone();
-                params.gyro.recompute_smoothness(smoothing.as_mut(), &basic_params.read());
+                params.gyro.recompute_smoothness(smoothing.as_mut(), &processing_params.read());
 
                 let mut lib_gyro = gyro.write();
                 lib_gyro.quaternions = params.gyro.quaternions.clone();
@@ -399,8 +307,8 @@ impl<T: PixelType> StabilizationManager<T> {
 
             let mut zoom = AdaptiveZoom::from_compute_params(params.clone());
             if smoothing_changed || zoom.get_state_checksum() != adaptive_zoom_checksum.load(SeqCst) {
-                params.fovs = Self::recompute_adaptive_zoom_static(&mut zoom, &basic_params);
-                basic_params.write().set_fovs(params.fovs.clone(), params.lens_fov_adjustment);
+                params.fovs = Self::recompute_adaptive_zoom_static(&mut zoom, &processing_params);
+                processing_params.write().set_fovs(params.fovs.clone(), params.lens_fov_adjustment);
             }
             
             if current_compute_id.load(SeqCst) != compute_id { return; }
@@ -652,7 +560,7 @@ impl<T: PixelType> StabilizationManager<T> {
             (params.stab_enabled, params.show_detected_features, params.show_optical_flow, params.background, params.adaptive_zoom_window, params.framebuffer_inverted)
         };
 
-        *self.params.write() = BasicParams {
+        *self.params.write() = ProcessingParams {
             stab_enabled, show_detected_features, show_optical_flow, background, adaptive_zoom_window, framebuffer_inverted, ..Default::default()
         };
         if !self.gyro.read().prevent_next_load {

--- a/src/core/processing_params.rs
+++ b/src/core/processing_params.rs
@@ -1,0 +1,95 @@
+
+use nalgebra::Vector4;
+
+#[derive(Clone)]
+pub struct ProcessingParams {
+    pub size: (usize, usize), // Processing input size
+    pub output_size: (usize, usize), // Processing output size
+    pub video_size: (usize, usize), // Full resolution input size
+    pub video_output_size: (usize, usize), // Full resoution output size
+
+    pub background: Vector4<f32>,
+
+    pub frame_readout_time: f64,
+    pub adaptive_zoom_window: f64,
+    pub fov: f64,
+    pub fovs: Vec<f64>,
+    pub min_fov: f64,
+    pub fps: f64,
+    pub fps_scale: Option<f64>,
+    pub frame_count: usize,
+    pub duration_ms: f64,
+
+    pub trim_start: f64,
+    pub trim_end: f64,
+
+    pub video_rotation: f64,
+
+    pub framebuffer_inverted: bool,
+    pub is_calibrator: bool,
+    
+    pub stab_enabled: bool,
+    pub show_detected_features: bool,
+    pub show_optical_flow: bool,
+}
+impl Default for ProcessingParams {
+    fn default() -> Self {
+        Self {
+            fov: 1.0,
+            min_fov: 1.0,
+            fovs: vec![],
+            stab_enabled: true,
+            show_detected_features: true,
+            show_optical_flow: true,
+            frame_readout_time: 0.0, 
+            adaptive_zoom_window: 0.0, 
+
+            size: (0, 0),
+            output_size: (0, 0),
+            video_size: (0, 0),
+            video_output_size: (0, 0),
+
+            video_rotation: 0.0,
+            
+            framebuffer_inverted: false,
+            is_calibrator: false,
+
+            trim_start: 0.0,
+            trim_end: 1.0,
+        
+            background: Vector4::new(0.0, 0.0, 0.0, 0.0),
+    
+            fps: 0.0,
+            fps_scale: None,
+            frame_count: 0,
+            duration_ms: 0.0,
+        }
+    }
+}
+
+impl ProcessingParams {
+    pub fn get_scaled_duration_ms(&self) -> f64 {
+        match self.fps_scale {
+            Some(scale) => self.duration_ms / scale,
+            None            => self.duration_ms
+        }
+    }
+    pub fn get_scaled_fps(&self) -> f64 {
+        match self.fps_scale {
+            Some(scale) => self.fps * scale,
+            None            => self.fps
+        }
+    }
+
+    pub fn set_fovs(&mut self, fovs: Vec<f64>, mut lens_fov_adjustment: f64) {
+        if let Some(mut min_fov) = fovs.iter().copied().reduce(f64::min) {
+            min_fov *= self.video_size.0 as f64 / self.video_output_size.0.max(1) as f64;
+            if lens_fov_adjustment <= 0.0001 { lens_fov_adjustment = 1.0 };
+            self.min_fov = min_fov / lens_fov_adjustment;
+        }
+        if fovs.is_empty() {
+            self.min_fov = 1.0;
+        }
+        self.fovs = fovs;
+    }
+}

--- a/src/core/smoothing/fixed.rs
+++ b/src/core/smoothing/fixed.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Elvin Chen
 
-use super::*;
 use nalgebra::*;
+
+use super::*;
 use crate::gyro_source::TimeQuat;
 
 #[derive(Clone)]
@@ -83,7 +84,7 @@ impl SmoothingAlgorithm for Fixed {
         hasher.finish()
     }
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat {
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &ProcessingParams) -> TimeQuat {
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         const DEG2RAD: f64 = std::f64::consts::PI / 180.0;

--- a/src/core/smoothing/horizon.rs
+++ b/src/core/smoothing/horizon.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Elvin Chen
 
-use super::*;
 use nalgebra::*;
+
+use super::*;
 use crate::gyro_source::TimeQuat;
 
 #[derive(Clone)]
@@ -57,7 +58,7 @@ impl SmoothingAlgorithm for HorizonLock {
         hasher.finish()
     }
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat { // TODO Result<>?
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::ProcessingParams) -> TimeQuat { // TODO Result<>?
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         let sample_rate: f64 = quats.len() as f64 / (duration / 1000.0);

--- a/src/core/smoothing/mod.rs
+++ b/src/core/smoothing/mod.rs
@@ -11,12 +11,14 @@ pub mod velocity_dampened_axis;
 pub mod velocity_dampened_advanced;
 
 pub use nalgebra::*;
-use super::gyro_source::TimeQuat;
 pub use std::collections::HashMap;
-use dyn_clone::{ clone_trait_object, DynClone };
-
 use std::hash::Hasher;
 use std::collections::hash_map::DefaultHasher;
+use dyn_clone::{ clone_trait_object, DynClone };
+
+use crate::processing_params::ProcessingParams;
+use crate::gyro_source::TimeQuat;
+
 
 fn from_euler_yxz(x: f64, y: f64, z: f64) -> UnitQuaternion<f64> {
 
@@ -61,7 +63,7 @@ pub trait SmoothingAlgorithm: DynClone {
 
     fn get_checksum(&self) -> u64;
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat;
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &ProcessingParams) -> TimeQuat;
 }
 clone_trait_object!(SmoothingAlgorithm);
 
@@ -125,7 +127,7 @@ impl Smoothing {
         self.algs.iter().map(|x| x.get_name()).collect()
     }
 
-    pub fn get_max_angles(quats: &TimeQuat, smoothed_quats: &TimeQuat, params: &crate::BasicParams) -> (f64, f64, f64) { // -> (pitch, yaw, roll) in deg
+    pub fn get_max_angles(quats: &TimeQuat, smoothed_quats: &TimeQuat, params: &ProcessingParams) -> (f64, f64, f64) { // -> (pitch, yaw, roll) in deg
         let start_ts = (params.trim_start * params.get_scaled_duration_ms() * 1000.0) as i64;
         let end_ts   = (params.trim_end   * params.get_scaled_duration_ms() * 1000.0) as i64;
         let identity_quat = crate::Quat64::identity();

--- a/src/core/smoothing/none.rs
+++ b/src/core/smoothing/none.rs
@@ -2,6 +2,7 @@
 // Copyright © 2021-2022 Elvin Chen
 
 use super::*;
+use crate::processing_params::ProcessingParams;
 use crate::gyro_source::TimeQuat;
 
 #[derive(Clone)]
@@ -37,7 +38,7 @@ impl SmoothingAlgorithm for None {
         hasher.write_u64(self.horizonroll.to_bits());
         hasher.finish()
     }
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat {
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &ProcessingParams) -> TimeQuat {
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         if self.horizonlockpercent == 0.0 {

--- a/src/core/smoothing/plain.rs
+++ b/src/core/smoothing/plain.rs
@@ -2,7 +2,6 @@
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
 
 use super::*;
-
 use crate::gyro_source::TimeQuat;
 
 #[derive(Clone)]
@@ -57,7 +56,7 @@ impl SmoothingAlgorithm for Plain {
         hasher.finish()
     }
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat { // TODO Result<>?
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &ProcessingParams) -> TimeQuat { // TODO Result<>?
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         let sample_rate: f64 = quats.len() as f64 / (duration / 1000.0);

--- a/src/core/smoothing/velocity_dampened.rs
+++ b/src/core/smoothing/velocity_dampened.rs
@@ -65,7 +65,7 @@ impl SmoothingAlgorithm for VelocityDampened {
         hasher.finish()
     }
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat { // TODO Result<>?
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &ProcessingParams) -> TimeQuat { // TODO Result<>?
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         const MAX_VELOCITY: f64 = 500.0;

--- a/src/core/smoothing/velocity_dampened_advanced.rs
+++ b/src/core/smoothing/velocity_dampened_advanced.rs
@@ -94,7 +94,7 @@ impl SmoothingAlgorithm for VelocityDampenedAdvanced {
         hasher.finish()
     }
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat { // TODO Result<>?
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &ProcessingParams) -> TimeQuat { // TODO Result<>?
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         const MAX_VELOCITY: f64 = 500.0;

--- a/src/core/smoothing/velocity_dampened_axis.rs
+++ b/src/core/smoothing/velocity_dampened_axis.rs
@@ -8,12 +8,12 @@
 // 5. Perform plain 3D smoothing with varying alpha, where each alpha is interpolated between 1s smoothness at 0 velocity, 0.1s smoothness at max velocity and extrapolated above that
 // 6. This way, low velocities are smoothed using 1s smoothness, but high velocities are smoothed using 0.1s smoothness at max velocity (500 deg/s multiplied by slider) and gradually lower smoothness above that
 
+
+use nalgebra::*;
 use std::collections::BTreeMap;
 
 use super::*;
-use nalgebra::*;
-use crate::gyro_source::TimeQuat;
-use crate::Quat64;
+use crate::gyro_source::{Quat64, TimeQuat};
 
 #[derive(Clone)]
 pub struct VelocityDampenedAxis {
@@ -98,7 +98,7 @@ impl SmoothingAlgorithm for VelocityDampenedAxis {
         hasher.finish()
     }
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &crate::BasicParams) -> TimeQuat { // TODO Result<>?
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, _params: &ProcessingParams) -> TimeQuat { // TODO Result<>?
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         const MAX_VELOCITY: f64 = 500.0;

--- a/src/core/smoothing/velocity_dampened_v1.rs
+++ b/src/core/smoothing/velocity_dampened_v1.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Aphobius
 
+use nalgebra::*;
 use std::collections::BTreeMap;
 
 use super::*;
-use nalgebra::*;
-use crate::gyro_source::TimeQuat;
-use crate::Quat64;
+use crate::gyro_source::{Quat64, TimeQuat};
 
 #[derive(Clone)]
 pub struct VelocityDampened {
@@ -112,7 +111,7 @@ impl SmoothingAlgorithm for VelocityDampened {
         hasher.finish()
     }
 
-    fn smooth(&mut self, quats: &TimeQuat, duration: f64, params: &crate::BasicParams) -> TimeQuat { // TODO Result<>?
+    fn smooth(&mut self, quats: &TimeQuat, duration: f64, params: &ProcessingParams) -> TimeQuat { // TODO Result<>?
         if quats.is_empty() || duration <= 0.0 { return quats.clone(); }
 
         let sample_rate: f64 = quats.len() as f64 / (duration / 1000.0);


### PR DESCRIPTION
Moved BasicParams from lib into separate file. This is in preparation for keyframe automations, where the fields of ProcessingParams will become AutomatableParam's step-by-step. 
Moved some use-statements around for readability