### PR TITLE
Enable ffmpeg threads when decoding

### DIFF
--- a/src/rendering/ffmpeg_processor.rs
+++ b/src/rendering/ffmpeg_processor.rs
@@ -184,7 +184,9 @@ impl<'a> FfmpegProcessor<'a> {
                 }
                 octx.add_stream(codec)?;
 
-                self.video.decoder = Some(stream.codec().decoder().video()?);
+                let mut input_codec = stream.codec();
+                input_codec.set_threading(ffmpeg_next::threading::Config{kind: ffmpeg_next::threading::Type::Frame, count: 3, safe: false});
+                self.video.decoder = Some(input_codec.decoder().video()?);
                 self.video.frame_rate = self.video.decoder.as_ref().unwrap().frame_rate();
                 self.video.time_base = Some(stream.rate().invert());
 


### PR DESCRIPTION
The thread count is set fixed to 3, which gives about 20% performance increase. Anything more doesn't actually improve anything.