### PR TITLE
Added direct FOV estimator and set it to be used by the zooming algo

### DIFF
--- a/src/core/zooming/fov_default.rs
+++ b/src/core/zooming/fov_default.rs
@@ -7,14 +7,14 @@ use enterpolation::{ Curve, bspline::BSpline };
 
 
 #[derive(Clone)]
-pub struct FieldOfView {
+pub struct FovDefault {
     compute_params: ComputeParams,
     input_dim: (f64, f64), 
     output_dim: (f64, f64),
 }
 
-impl FieldOfView { 
-    pub fn compute(&self, timestamps: &[f64], range: (f64, f64)) -> (Vec<f64>, Vec<Point2D>) {
+impl FieldOfViewAlgorithm for FovDefault { 
+    fn compute(&self, timestamps: &[f64], range: (f64, f64)) -> (Vec<f64>, Vec<Point2D>) {
         if timestamps.is_empty() {
             return (Vec::new(), Vec::new());
         }
@@ -45,7 +45,9 @@ impl FieldOfView {
         }
         (fov_values, crop_center_positions)
     }
+}
 
+impl FovDefault { 
     pub fn new(compute_params: ComputeParams) -> Self {
         let ratio = compute_params.video_width as f64 / compute_params.video_output_width.max(1) as f64;
         let input_dim = (compute_params.video_width as f64, compute_params.video_height as f64);

--- a/src/core/zooming/fov_direct.rs
+++ b/src/core/zooming/fov_direct.rs
@@ -1,0 +1,168 @@
+use super::*;
+use crate::undistortion::undistort_points_with_rolling_shutter;
+
+/*
+Direct FOV calculation:
+    - gets polygon points around the outline of the undistorted image
+    - casts an infinite ray from the center point of the view diagonally (with the output aspect ratio determining the angle)
+    - finds the intersections between the ray an the polygon lines
+    - determins if the center point is inside the polygon by counting the intersections in one direction (odd nr = inside)
+    - casts a second mirrored ray and finds intersections with the polygon
+    - gets the nearest intersections from both rays
+    - from the nearest point, draws a symetric rectangle around center
+    - if a polygon point happens to be inside the rectangle, it becomes the nearest point and the rectangle shrinks, repeat for all points
+    - from the nearest point, calculate the FOV
+*/
+
+#[derive(Clone)]
+pub struct FovDirect {
+    input_dim: (f64, f64), 
+    output_dim: (f64, f64),
+    output_inv_aspect: f64,
+    compute_params: ComputeParams
+}
+impl FieldOfViewAlgorithm for FovDirect { 
+    fn compute(&self, timestamps: &[f64], range: (f64, f64)) -> (Vec<f64>, Vec<Point2D>) {
+        if timestamps.is_empty() {
+            return (Vec::new(), Vec::new());
+        }
+        let src_rect = points_around_rect(self.input_dim.0, self.input_dim.1, 9, 9);
+        let polygons: Vec<Vec<(f64, f64)>> = timestamps
+            .iter()
+            .map(|&ts| undistort_points_with_rolling_shutter(&src_rect, ts, &self.compute_params))
+            .collect();
+
+        let cp = Point2D(self.input_dim.0 / 2.0, self.input_dim.1 / 2.0);
+        let center_positions: Vec<Point2D> = polygons.iter().map(|_| cp).collect();
+
+        let mut prev_fov = 1.0;
+        let mut fov_values: Vec<f64> = polygons.iter()
+            .zip(&center_positions)
+            .map(|(polygon, center)| { 
+                prev_fov = self.find_fov(polygon, center, prev_fov);
+                prev_fov
+            })
+            .collect();
+
+        if range.0 > 0.0 || range.1 < 1.0 {
+            // Only within render range.
+            if let Some(max_fov) = fov_values.iter().copied().reduce(f64::max) {
+                let l = (timestamps.len() - 1) as f64;
+                let first_ind = (l * range.0).floor() as usize;
+                let last_ind  = (l * range.1).ceil() as usize;
+                if fov_values.len() > first_ind {
+                    fov_values[0..first_ind].iter_mut().for_each(|v| *v = max_fov);
+                }
+                if fov_values.len() > last_ind {
+                    fov_values[last_ind..].iter_mut().for_each(|v| *v = max_fov);
+                }
+            }
+        }
+
+        (fov_values, center_positions)
+    }
+}
+
+impl FovDirect { 
+    pub fn new(compute_params: ComputeParams) -> Self {
+        let ratio = compute_params.video_width as f64 / compute_params.video_output_width.max(1) as f64;
+        let input_dim = (compute_params.video_width as f64, compute_params.video_height as f64);
+        let output_dim = (compute_params.video_output_width as f64 * ratio, compute_params.video_output_height as f64 * ratio);
+        let output_inv_aspect = output_dim.1 / output_dim.0;
+
+        Self {
+            input_dim,
+            output_dim,
+            output_inv_aspect,
+            compute_params
+        }
+    }
+
+    fn find_fov(&self, polygon: &[(f64,f64)], center: &Point2D, default_fov: f64) -> f64
+    {
+        let relpoints: Vec<(f64,f64)> = polygon.iter().map(|(x,y)| (x-center.0, y-center.1)).collect();
+        let intersections_up = polygon_line_intersections( &(0.0,0.0), self.output_inv_aspect, &relpoints);
+        let left_crossings: u32 = intersections_up.iter().map( |p| if p.0 < 0.0 { 0 } else { 1 } ).sum();
+        if  left_crossings & 1 == 0 { return default_fov; } // center point is outside of polygon
+
+        let intersections_down = polygon_line_intersections( &(0.0,0.0), -self.output_inv_aspect, &relpoints);
+
+        let min_intersection: (f64,f64) = intersections_up
+            .iter()
+            .chain(&intersections_down)
+            .fold(intersections_up[0], |mp, &point| { 
+                if point.0.abs() < mp.0.abs() { point } else { mp } 
+            });
+
+        
+        let nearest_point = relpoints
+            .iter()
+            .fold((min_intersection.0.abs(), min_intersection.1.abs()), |mp, &point| {
+                let ap = (point.0.abs(), point.1.abs());
+                if ap.0 < mp.0 && ap.1 < mp.1 {
+                    if ap.1 > ap.0 * self.output_inv_aspect {
+                        return (ap.1/self.output_inv_aspect, ap.1);
+                    } else {
+                        return (ap.0, ap.0*self.output_inv_aspect);
+                    }
+                }
+                mp
+            });
+
+        nearest_point.0*2.0 / self.output_dim.0
+    }
+}
+
+/*
+    Returns points placed around a rectangle in a continous order
+*/
+fn points_around_rect(w: f64, h: f64, w_div: usize, h_div: usize) -> Vec<(f64, f64)> {
+    let (wcnt, hcnt) = (w_div.max(2)-1, h_div.max(2)-1);
+    let (wstep, hstep) = (w / wcnt as f64, h / hcnt as f64);
+    
+    // ordered!
+    let mut distorted_points: Vec<(f64, f64)> = Vec::with_capacity((wcnt + hcnt) * 2);
+    for i in 0..wcnt { distorted_points.push((i as f64 * wstep,          0.0)); }
+    for i in 0..hcnt { distorted_points.push((w,                         i as f64 * hstep)); }
+    for i in 0..wcnt { distorted_points.push(((wcnt - i) as f64 * wstep, h)); }
+    for i in 0..hcnt { distorted_points.push((0.0,                       (hcnt - i) as f64 * hstep)); }
+
+    distorted_points
+}
+
+/*
+    Return Some( (x,y) ), where the ray p0->[x,x*rise] intersects the line p2->p3
+    Returns None, when they don't intersect
+*/
+fn line_intersection(p0: &(f64,f64), rise: f64, p2: &(f64,f64), p3: &(f64,f64)) -> Option<(f64,f64)>
+{
+	let s32 = (p3.0 - p2.0, p3.1 - p2.1);
+	
+	let denom = s32.0 * rise - s32.1;
+	if denom == 0.0 { return None; }
+	
+	let s20 = (p2.0 - p0.0, p2.1 - p0.1);
+	let numer = s20.1 - rise * s20.0;
+	
+	let t = numer / denom;
+	if t < 0.0 || t > 1.0 {
+        None
+    } else {
+        Some((p2.0 + t * s32.0, p2.1 + t * s32.1))
+    }
+}
+
+/*
+    Return a Vector with all the points where the line p0->[x,x*rise] intersects with the polygon
+*/
+fn polygon_line_intersections(p0: &(f64,f64), rise: f64, polygon: &[(f64,f64)]) -> Vec<(f64,f64)> {
+    let len = polygon.len();
+    polygon
+        .iter()
+        .enumerate()
+        .filter_map(|(i, pp)| {
+            let j = (i + len - 1) % len;
+            line_intersection(p0, rise, pp, &polygon[j])
+        })
+        .collect()
+}

--- a/src/core/zooming/zoom_dynamic.rs
+++ b/src/core/zooming/zoom_dynamic.rs
@@ -1,10 +1,10 @@
 use super::*;
-use super::field_of_view::FieldOfView;
 
 #[derive(Clone)]
 pub struct ZoomDynamic {
-    compute_params: ComputeParams,
     window: f64, 
+    fov_estimator: Box<dyn FieldOfViewAlgorithm>,
+    compute_params: ComputeParams,
 }
 
 impl ZoomingAlgorithm for ZoomDynamic {
@@ -12,8 +12,8 @@ impl ZoomingAlgorithm for ZoomDynamic {
         if timestamps.is_empty() {
             return Vec::new();
         }
-        let fov_est = FieldOfView::new(self.compute_params.clone());
-        let (mut fov_values, center_position) = fov_est.compute(timestamps, (self.compute_params.trim_start, self.compute_params.trim_end));
+
+        let (mut fov_values, center_position) = self.fov_estimator.compute(timestamps, (self.compute_params.trim_start, self.compute_params.trim_end));
 
         let mut frames = (self.window * self.compute_params.scaled_fps).floor() as usize;
         if frames % 2 == 0 {
@@ -40,10 +40,11 @@ impl ZoomingAlgorithm for ZoomDynamic {
 }
 
 impl ZoomDynamic {
-    pub fn new(compute_params: ComputeParams, window: f64) -> Self {
+    pub fn new(window: f64, fov_estimator: Box<dyn FieldOfViewAlgorithm>, compute_params: ComputeParams) -> Self {
         Self {
+            window,
+            fov_estimator,
             compute_params,
-            window
         }
     }
 }

--- a/src/core/zooming/zoom_static.rs
+++ b/src/core/zooming/zoom_static.rs
@@ -1,8 +1,8 @@
 use super::*;
-use super::field_of_view::FieldOfView;
 
 #[derive(Clone)]
 pub struct ZoomStatic {
+    fov_estimator: Box<dyn FieldOfViewAlgorithm>,
     compute_params: ComputeParams
 }
 
@@ -11,8 +11,8 @@ impl ZoomingAlgorithm for ZoomStatic {
         if timestamps.is_empty() {
             return Vec::new();
         }
-        let fov_est = FieldOfView::new(self.compute_params.clone());
-        let (mut fov_values, center_position) = fov_est.compute(timestamps, (self.compute_params.trim_start, self.compute_params.trim_end));
+        
+        let (mut fov_values, center_position) = self.fov_estimator.compute(timestamps, (self.compute_params.trim_start, self.compute_params.trim_end));
 
         if let Some(max_f) = fov_values.iter().copied().reduce(f64::min) {
             fov_values.iter_mut().for_each(|v| *v = max_f);
@@ -35,8 +35,9 @@ impl ZoomingAlgorithm for ZoomStatic {
 }
 
 impl ZoomStatic {
-    pub fn new(compute_params: ComputeParams) -> Self {
+    pub fn new(fov_estimator: Box<dyn FieldOfViewAlgorithm>, compute_params: ComputeParams) -> Self {
         Self {
+            fov_estimator,
             compute_params
         }
     }


### PR DESCRIPTION
Added new `direct` FOV estimator. It's about twice as fast by not using atan2 like the `default` one.
On my tests, the error between the `direct` and the `default` is less than 0.1% for a GoPro lens. It should be carefully tested with more extrem lens distortions.