### PR TITLE
Reduce size recompute, when nothing changed

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -366,7 +366,9 @@ impl Controller {
                         if let Err(e) = stab.init_from_video_data(&s, duration_ms, fps, frame_count, video_size) {
                             err(("An error occured: %1".to_string(), e.to_string()));
                         } else {
-                            stab.set_output_size(video_size.0, video_size.1);
+                            if stab.set_output_size(video_size.0, video_size.1) {
+                                stab.recompute_undistortion();
+                            }
                         }
                     } else if let Err(e) = stab.load_gyro_data(&s) {
                         err(("An error occured: %1".to_string(), e.to_string()));
@@ -669,9 +671,11 @@ impl Controller {
     }
 
     fn set_output_size(&self, w: usize, h: usize) {
-        self.stabilizer.set_output_size(w, h);
-        self.request_recompute();
-        qrhi_undistort::resize_player(self.stabilizer.clone());
+        if self.stabilizer.set_output_size(w, h) {
+            self.stabilizer.recompute_undistortion();
+            self.request_recompute();
+            qrhi_undistort::resize_player(self.stabilizer.clone());
+        }
     }
 
     wrap_simple_method!(override_video_fps,         v: f64; recompute; update_offset_model);


### PR DESCRIPTION
- `recompute_undistortion` was called twice for size changes, in `StabilizationManager::get_render_stabilizator`
- don't `request_recompute` when setting a size but it isn't actually different.
