### PR TITLE
Add value reset shortcut

### DIFF
--- a/src/ui/components/Label.qml
+++ b/src/ui/components/Label.qml
@@ -24,12 +24,8 @@ Grid {
         verticalAlignment: Text.AlignVCenter;
         height: root.position === Label.Top? undefined : inner.height;
         MouseArea {
-            id: ma;
             anchors.fill: t;
-            hoverEnabled: true;
-            acceptedButtons: Qt.LeftButton | Qt.RightButton;
-            propagateComposedEvents: true;
-            preventStealing: true;
+            acceptedButtons: Qt.LeftButton;
 
             onDoubleClicked: (mouse) => {
                 function traverseChildren(node) {

--- a/src/ui/components/Label.qml
+++ b/src/ui/components/Label.qml
@@ -23,6 +23,32 @@ Grid {
         leftPadding: 0;
         verticalAlignment: Text.AlignVCenter;
         height: root.position === Label.Top? undefined : inner.height;
+        MouseArea {
+            id: ma;
+            anchors.fill: t;
+            hoverEnabled: true;
+            acceptedButtons: Qt.LeftButton | Qt.RightButton;
+            propagateComposedEvents: true;
+            preventStealing: true;
+
+            onDoubleClicked: (mouse) => {
+                function traverseChildren(node) {
+                    for (let i = node.children.length; i > 0; --i) {
+                        const child = node.children[i - 1];
+                        if (child) {
+                            if (child.toString().startsWith("NumberField")) {
+                                child.value = child.defaultValue;
+                                return child;
+                            }
+                            const found = traverseChildren(child);
+                            if (found !== null) return found;
+                        }
+                    }
+                    return null;
+                }
+                traverseChildren(inner);
+            }
+        }
     }
 
     Item {

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -98,14 +98,11 @@ TextField {
             if (mouse.button === Qt.RightButton) {
                 contextMenu.popup();
                 mouse.accepted = true;
-            } else if (mouse.button === Qt.LeftButton && (mouse.modifiers & Qt.ControlModifier)) {
-                value = defaultValue;
-                mouse.accepted = true;
             } else {
                 mouse.accepted = false;
             }
         }
-        
+
         onClicked: (mouse) => _onClicked(mouse);
         onPressed: (mouse) => _onClicked(mouse);
     }

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -77,6 +77,52 @@ TextField {
         if (allowText) root.validator = null;
     }
 
+    MouseArea {
+        id: ma;
+        anchors.fill: parent;
+        acceptedButtons: Qt.LeftButton | Qt.RightButton;
+        propagateComposedEvents: true;
+        preventStealing: true;
+        cursorShape: Qt.ibeam;
+
+        onPressAndHold: (mouse) => {
+            if ((Qt.platform.os == "android" || Qt.platform.os == "ios") && mouse.button !== Qt.RightButton) {
+                contextMenu.popup();
+                mouse.accepted = true;
+            } else {
+                mouse.accepted = false;
+            }
+        }
+
+        function _onClicked(mouse) {
+            if (mouse.button === Qt.RightButton) {
+                contextMenu.popup();
+                mouse.accepted = true;
+            } else if (mouse.button === Qt.LeftButton && (mouse.modifiers & Qt.ControlModifier)) {
+                value = defaultValue;
+                mouse.accepted = true;
+            } else {
+                mouse.accepted = false;
+            }
+        }
+        
+        onClicked: (mouse) => _onClicked(mouse);
+        onPressed: (mouse) => _onClicked(mouse);
+    }
+
+    Menu {
+        id: contextMenu;
+        font.pixelSize: 11.5 * dpiScale;
+        Action {
+            icon.name: "undo";
+            text: qsTr("Reset value");
+            enabled: value != defaultValue;
+            onTriggered: {
+                value = defaultValue;
+            }
+        }
+    }
+
     BasicText {
         visible: !!root.unit;
         x: parent.contentWidth;

--- a/src/ui/components/SliderWithField.qml
+++ b/src/ui/components/SliderWithField.qml
@@ -20,7 +20,7 @@ Row {
 
     Slider {
         id: slider;
-        width: parent.width - field.width - root.spacing;
+        width: parent.width - field.width - resetBtn.width - root.spacing * 2;
         anchors.verticalCenter: parent.verticalCenter;
         property bool preventChange: false;
         onValueChanged: if (!preventChange) field.value = value;
@@ -43,23 +43,21 @@ Row {
                     mouse.accepted = false;
                 }
             }
-            onClicked: (mouse) => {
-                if (mouse.button === Qt.RightButton) {
-                    contextMenu.popup();
-                    mouse.accepted = true;
-                } else {
-                    mouse.accepted = false;
-                }
-            }
 
-            onPressed: (mouse) => {
+            function _onClicked(mouse) {
                 if (mouse.button === Qt.RightButton) {
                     contextMenu.popup();
+                    mouse.accepted = true;
+                } else if (mouse.button === Qt.LeftButton && (mouse.modifiers & Qt.ControlModifier)) {
+                    field.value = defaultValue;
                     mouse.accepted = true;
                 } else {
                     mouse.accepted = false;
                 }
             }
+            
+            onClicked: (mouse) => _onClicked(mouse);
+            onPressed: (mouse) => _onClicked(mouse);
         }
 
         Menu {
@@ -68,6 +66,7 @@ Row {
             Action {
                 icon.name: "undo";
                 text: qsTr("Reset value");
+                enabled: field.value != defaultValue;
                 onTriggered: {
                     field.value = defaultValue;
                 }
@@ -87,4 +86,20 @@ Row {
             Qt.callLater(() => { if (slider) slider.preventChange = false; });
         }
     }
+    
+    Button {
+        width: 18 * dpiScale;
+        height: 25 * dpiScale;
+        leftPadding: 4 * dpiScale;
+        rightPadding: 4 * dpiScale;
+        topPadding: 1 * dpiScale;
+        bottomPadding: 1 * dpiScale;
+        font.pixelSize: 3 * dpiScale;
+        id: resetBtn;
+        icon.name: "undo";
+        enabled: field.value != defaultValue;
+        tooltip: qsTr("Reset value");
+        onClicked: field.value = defaultValue;
+    }
+
 }

--- a/src/ui/components/SliderWithField.qml
+++ b/src/ui/components/SliderWithField.qml
@@ -20,7 +20,7 @@ Row {
 
     Slider {
         id: slider;
-        width: parent.width - field.width - resetBtn.width - root.spacing * 2;
+        width: parent.width - field.width - root.spacing;
         anchors.verticalCenter: parent.verticalCenter;
         property bool preventChange: false;
         onValueChanged: if (!preventChange) field.value = value;
@@ -47,9 +47,6 @@ Row {
             function _onClicked(mouse) {
                 if (mouse.button === Qt.RightButton) {
                     contextMenu.popup();
-                    mouse.accepted = true;
-                } else if (mouse.button === Qt.LeftButton && (mouse.modifiers & Qt.ControlModifier)) {
-                    field.value = defaultValue;
                     mouse.accepted = true;
                 } else {
                     mouse.accepted = false;
@@ -86,20 +83,4 @@ Row {
             Qt.callLater(() => { if (slider) slider.preventChange = false; });
         }
     }
-    
-    Button {
-        width: 18 * dpiScale;
-        height: 25 * dpiScale;
-        leftPadding: 4 * dpiScale;
-        rightPadding: 4 * dpiScale;
-        topPadding: 1 * dpiScale;
-        bottomPadding: 1 * dpiScale;
-        font.pixelSize: 3 * dpiScale;
-        id: resetBtn;
-        icon.name: "undo";
-        enabled: field.value != defaultValue;
-        tooltip: qsTr("Reset value");
-        onClicked: field.value = defaultValue;
-    }
-
 }

--- a/src/ui/menu/Export.qml
+++ b/src/ui/menu/Export.qml
@@ -215,6 +215,7 @@ MenuItem {
         NumberField {
             id: bitrate;
             value: 0;
+            defaultValue: 20;
             unit: qsTr("Mbps");
             width: parent.width;
         }

--- a/src/ui/menu/Synchronization.qml
+++ b/src/ui/menu/Synchronization.qml
@@ -82,6 +82,7 @@ MenuItem {
             id: initialOffset;
             width: parent.width;
             height: 25 * dpiScale;
+            defaultValue: 0;
             precision: 1;
             unit: qsTr("s");
         }


### PR DESCRIPTION
Add faster shortcut for reset brought up here: https://github.com/gyroflow/gyroflow/issues/189
Values of sliders and numberfields can be reset through the context menu, ctrl+click or reset button (only enabled when value isn't default):
![image](https://user-images.githubusercontent.com/20195216/154587372-ddc7fcdf-d302-4064-8b92-f6bfb37f46ad.png)
