### PR TITLE
Limit audio bitrate

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,10 +2,25 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Attach to Gyroflow.exe",
+            "name": "Build+Debug GyroFlow",
+            "request": "launch",
+            "preLaunchTask" : "Build GyroFlow (Debug)",
+            "program": "${workspaceFolder}/target/debug/gyroflow.exe",
+            "cwd": "${workspaceFolder}",
+            "type":"cppvsdbg",
+        },
+        {
+            "name": "Debug GyroFlow",
+            "request": "launch",
+            "program": "${workspaceFolder}/target/debug/gyroflow.exe",
+            "cwd": "${workspaceFolder}",
+            "type":"cppvsdbg",
+        },
+        {
+            "name": "Attach to Gyroflow",
             "type": "cppvsdbg",
             "request": "attach",
-            "processName": "Gyroflow.exe"
+            "processName": "gyroflow.exe"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,6 +8,7 @@
             "program": "${workspaceFolder}/target/debug/gyroflow.exe",
             "cwd": "${workspaceFolder}",
             "type":"cppvsdbg",
+            "console": "integratedTerminal",
         },
         {
             "name": "Debug GyroFlow",
@@ -15,12 +16,14 @@
             "program": "${workspaceFolder}/target/debug/gyroflow.exe",
             "cwd": "${workspaceFolder}",
             "type":"cppvsdbg",
+            "console": "integratedTerminal",
         },
         {
             "name": "Attach to Gyroflow",
             "type": "cppvsdbg",
             "request": "attach",
-            "processName": "gyroflow.exe"
+            "processName": "gyroflow.exe",
+            "console": "integratedTerminal",
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,103 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+        {
+            "label": "Build GyroFlow (Debug)",
+            "group": "build",
+            "type": "cargo",
+            "command": "build",
+            "presentation": {
+                "panel": "shared",
+                "reveal": "always",
+                "focus": true
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Build GyroFlow (Release)",
+            "group": "build",
+            "type": "cargo",
+            "command": "build",
+            "args": [
+                "--release"
+            ],
+            "presentation": {
+                "panel": "shared",
+                "reveal": "always",
+                "focus": true
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Build GyroFlow (Profile)",
+            "group": "build",
+            "type": "cargo",
+            "command": "build",
+            "args": [
+                "--profile",
+                "profile"
+            ],
+            "presentation": {
+                "panel": "shared",
+                "reveal": "always",
+                "focus": true
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Run GyroFlow (Debug)",
+            "group": "build",
+            "type": "cargo",
+            "command": "run",
+            "presentation": {
+                "panel": "shared",
+                "reveal": "always",
+                "focus": true
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Run GyroFlow (Release)",
+            "group": "build",
+            "type": "cargo",
+            "command": "run",
+            "args": [
+                "--release"
+            ],
+            "presentation": {
+                "panel": "shared",
+                "reveal": "always",
+                "focus": true
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        },
+        {
+            "label": "Run GyroFlow (Profile)",
+            "group": "build",
+            "type": "cargo",
+            "command": "run",
+            "args": [
+                "--profile",
+                "profile"
+            ],
+            "presentation": {
+                "panel": "shared",
+                "reveal": "always",
+                "focus": true
+            },
+            "problemMatcher": [
+                "$rustc"
+            ]
+        }
+    ]
+}

--- a/src/rendering/ffmpeg_audio.rs
+++ b/src/rendering/ffmpeg_audio.rs
@@ -34,8 +34,8 @@ impl AudioTranscoder {
         encoder.set_channel_layout(channel_layout);
         encoder.set_channels(channel_layout.channels());
         encoder.set_format(codec.formats().expect("unknown supported formats").next().unwrap());
-        encoder.set_bit_rate(decoder.bit_rate());
-        encoder.set_max_bit_rate(decoder.max_bit_rate());
+        encoder.set_bit_rate(decoder.bit_rate().min(320000));
+        encoder.set_max_bit_rate(decoder.max_bit_rate().min(320000));
 
         encoder.set_time_base((1, decoder.rate() as i32));
         output.set_time_base((1, decoder.rate() as i32));


### PR DESCRIPTION
When decoder is `PCM` then the bit rate is way to high for the `AAC` encoder.
This limits it to `320kbps` and stops the codec from complaining.