### PR TITLE
Zero idle CPU/GPU usage

### DIFF
--- a/src/ui/components/LoaderOverlay.qml
+++ b/src/ui/components/LoaderOverlay.qml
@@ -66,8 +66,8 @@ Item {
 
     anchors.fill: parent;
     QQC.ProgressBar { id: pb; anchors.centerIn: parent; value: parent.progress; visible: parent.progress != -1 && !root.canceled; }
-    QQC.BusyIndicator { id: bi; anchors.centerIn: parent; visible: parent.progress == -1 || root.canceled; }
-    
+    QQC.BusyIndicator { id: bi; anchors.centerIn: parent; visible: parent.active && (parent.progress == -1 || root.canceled); }
+
     Column {
         id: c;
         anchors.top: pb.visible? pb.bottom : bi.bottom;


### PR DESCRIPTION
The busy indicators were always running in the background (just with 0 opacity), this stops them and completely zeroes out the idle CPU & GPU usage. 