### PR TITLE
Precache Optical Flow during auto sync

### DIFF
--- a/src/core/synchronization/autosync.rs
+++ b/src/core/synchronization/autosync.rs
@@ -188,6 +188,7 @@ impl AutosyncProcess {
         }
         self.estimator.process_detected_frames(self.frame_count as usize, self.duration_ms, self.org_fps, self.scaled_fps);
         self.estimator.recalculate_gyro_data(self.frame_count as usize, self.duration_ms, self.org_fps, true);
+        self.estimator.optical_flow(1);
 
         if let Some(cb) = &self.finished_cb {
             if self.for_rs {


### PR DESCRIPTION
Precache Optical Flow data during auto sync process, so it isn't required to run it during playback and basically any screen-refresh.