### PR TITLE
Cleanup size input code in export settings

### DIFF
--- a/src/ui/components/Label.qml
+++ b/src/ui/components/Label.qml
@@ -33,11 +33,10 @@ Grid {
                         const child = node.children[i - 1];
                         if (child) {
                             if (child.toString().startsWith("NumberField")) {
-                                child.value = child.defaultValue;
-                                return child;
+                                child.reset();
+                            } else {
+                                traverseChildren(child);
                             }
-                            const found = traverseChildren(child);
-                            if (found !== null) return found;
                         }
                     }
                     return null;

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -16,7 +16,8 @@ TextField {
     property real defaultValue: NaN;
     property bool allowText: false;
     property bool intNoThousandSep: false;
-
+    property var reset: () => {value = defaultValue; };
+    
     Keys.onDownPressed: (e) => {
         const lastDigit = Math.pow(10, precision);
         if (allowText) return;
@@ -114,9 +115,7 @@ TextField {
             icon.name: "undo";
             text: qsTr("Reset value");
             enabled: value != defaultValue;
-            onTriggered: {
-                value = defaultValue;
-            }
+            onTriggered: root.reset()
         }
     }
 

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -16,7 +16,7 @@ TextField {
     property real defaultValue: NaN;
     property bool allowText: false;
     property bool intNoThousandSep: false;
-    property var reset: () => {value = defaultValue; };
+    property var reset: () => { value = defaultValue; };
     
     Keys.onDownPressed: (e) => {
         const lastDigit = Math.pow(10, precision);

--- a/src/ui/menu/Export.qml
+++ b/src/ui/menu/Export.qml
@@ -74,9 +74,9 @@ MenuItem {
         }
     }
 
-    property bool disableUpdate: false;        
+    property bool disableUpdate: false;
     function notifySizeChanged() {
-        Qt.callLater(() => controller.set_output_size(outWidth, outHeight));
+        controller.set_output_size(outWidth, outHeight);
     }
     function ensureAspectRatio(byWidth) {
         if (lockAspectRatio.checked && aspectRatio > 0) {
@@ -99,15 +99,15 @@ MenuItem {
     }
     function videoInfoLoaded(w, h, br) {
         setDefaultSize(w, h);
-        notifySizeChanged();
+        Qt.callLater(notifySizeChanged);
 
         outBitrate     = br;
         defaultBitrate = br;
-        
+
         codec.updateGpuStatus();
     }
     function lensProfileLoaded(w, h) {
-         setDefaultSize(w, h);
+        setDefaultSize(w, h);
     }
 
     ComboBox {
@@ -153,7 +153,14 @@ MenuItem {
                 width: 60 * dpiScale;
                 intNoThousandSep: true;
                 reset: () => { aspectRatio = defaultValue / Math.max(1,outHeight); value = defaultValue; };
-                onValueChanged: if (!disableUpdate) { disableUpdate = true; ensureAspectRatio(true); notifySizeChanged(); disableUpdate = false; }
+                onValueChanged: {
+                    if (!disableUpdate) {
+                        disableUpdate = true;
+                        ensureAspectRatio(true);
+                        Qt.callLater(notifySizeChanged);
+                        disableUpdate = false;
+                    }
+                }
                 live: false;
             }
             BasicText { leftPadding: 0; text: "x"; anchors.verticalCenter: parent.verticalCenter; }
@@ -161,8 +168,15 @@ MenuItem {
                 id: outputHeight;
                 tooltip: qsTr("Height");
                 width: 60 * dpiScale;
-                intNoThousandSep: true;                
-                onValueChanged: if (!disableUpdate) { disableUpdate = true; ensureAspectRatio(false); notifySizeChanged(); disableUpdate = false; }
+                intNoThousandSep: true;
+                onValueChanged: {
+                    if (!disableUpdate) {
+                        disableUpdate = true;
+                        ensureAspectRatio(false);
+                        Qt.callLater(notifySizeChanged);
+                        disableUpdate = false;
+                    }
+                }
                 live: false;
                 reset: () => { aspectRatio = outWidth / Math.max(1,defaultValue); value = defaultValue; };
             }
@@ -190,14 +204,14 @@ MenuItem {
         type: InfoMessage.Error;
         property var maxSize: exportFormats[codec.currentIndex].max_size;
         show: maxSize && (outWidth > maxSize[0] || outHeight > maxSize[1]);
-        text: qsTr("This resolution is not supported by the selected codec.") + "\n" + 
-              qsTr("Maximum supported resolution is %1.").arg(maxSize? maxSize.join("x") : ""); 
+        text: qsTr("This resolution is not supported by the selected codec.") + "\n" +
+              qsTr("Maximum supported resolution is %1.").arg(maxSize? maxSize.join("x") : "");
     }
     InfoMessageSmall {
         id: resolutionWarning2;
         type: InfoMessage.Error;
         show: (outWidth % 2) != 0 || (outHeight % 2) != 0;
-        text: qsTr("Resolution must be divisible by 2."); 
+        text: qsTr("Resolution must be divisible by 2.");
     }
 
     Label {
@@ -219,8 +233,8 @@ MenuItem {
         checked: true;
         property bool enabled2: true;
         enabled: enabled2;
-        tooltip: enabled2? qsTr("GPU encoders typically generate output of lower quality than software encoders, but are significantly faster.") + "\n" + 
-                           qsTr("They require a higher bitrate to make output with the same perceptual quality, or they make output with a lower perceptual quality at the same bitrate.") + "\n" + 
+        tooltip: enabled2? qsTr("GPU encoders typically generate output of lower quality than software encoders, but are significantly faster.") + "\n" +
+                           qsTr("They require a higher bitrate to make output with the same perceptual quality, or they make output with a lower perceptual quality at the same bitrate.") + "\n" +
                            qsTr("Uncheck this option for maximum possible quality.")
                          :
                            qsTr("GPU acceleration is not available for the pixel format of this video.");

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -79,7 +79,7 @@ MenuItem {
                     officialInfo.show = !obj.official;
 
                     if (obj.output_dimension && obj.output_dimension.w > 0 && (obj.calib_dimension.w != obj.output_dimension.w || obj.calib_dimension.h != obj.output_dimension.h)) {
-                        Qt.callLater(() => window.exportSettings.setOutputSize(obj.output_dimension.w, obj.output_dimension.h));
+                        Qt.callLater(() => window.exportSettings.lensProfileLoaded(obj.output_dimension.w, obj.output_dimension.h));
                     }
                     if (+obj.frame_readout_time && Math.abs(+obj.frame_readout_time) > 0) {
                         window.stab.setFrameReadoutTime(obj.frame_readout_time);

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -79,7 +79,7 @@ MenuItem {
                     officialInfo.show = !obj.official;
 
                     if (obj.output_dimension && obj.output_dimension.w > 0 && (obj.calib_dimension.w != obj.output_dimension.w || obj.calib_dimension.h != obj.output_dimension.h)) {
-                        Qt.callLater(() => window.exportSettings.lensProfileLoaded(obj.output_dimension.w, obj.output_dimension.h));
+                        Qt.callLater(window.exportSettings.lensProfileLoaded, obj.output_dimension.w, obj.output_dimension.h);
                     }
                     if (+obj.frame_readout_time && Math.abs(+obj.frame_readout_time) > 0) {
                         window.stab.setFrameReadoutTime(obj.frame_readout_time);

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -39,21 +39,19 @@ MenuItem {
     signal selectFileRequest();
 
     function loadFromVideoMetadata(md) {
-        const framerate = +md["stream.video[0].codec.frame_rate"];
-        const w = md["stream.video[0].codec.width"];
-        const h = md["stream.video[0].codec.height"];
+        const framerate = +md["stream.video[0].codec.frame_rate"] || 0;
+        const w = md["stream.video[0].codec.width"] || 0;
+        const h = md["stream.video[0].codec.height"] || 0;
+        const bitrate = +md["stream.video[0].codec.bit_rate"]? ((+md["stream.video[0].codec.bit_rate"] / 1024 / 1024)) : 200;
 
         if (window) {
-            window.exportSettings.orgWidth  = w || 0;
-            window.exportSettings.orgHeight = h || 0;
-            window.lensProfile.videoWidth   = w || 0;
-            window.lensProfile.videoHeight  = h || 0;
-            window.exportSettings.outBitrate = +md["stream.video[0].codec.bit_rate"]? ((+md["stream.video[0].codec.bit_rate"] / 1024 / 1024)) : 200;
+            window.lensProfile.videoWidth   = w;
+            window.lensProfile.videoHeight  = h;
         }
         if (typeof calibrator_window !== "undefined") {
-            calibrator_window.lensCalib.videoWidth   = w || 0;
-            calibrator_window.lensCalib.videoHeight  = h || 0;
-            calibrator_window.lensCalib.fps = framerate || 0;
+            calibrator_window.lensCalib.videoWidth   = w;
+            calibrator_window.lensCalib.videoHeight  = h;
+            calibrator_window.lensCalib.fps = framerate;
         }
 
         root.pixelFormat = getPixelFormat(md) || "---";
@@ -74,7 +72,7 @@ MenuItem {
         
         controller.set_video_rotation(root.videoRotation)
 
-        Qt.callLater(() => window.exportSettings.vidInfoLoaded());
+        Qt.callLater(() => window.exportSettings.videoInfoLoaded(w, h, bitrate));
     }
     function updateEntry(key, value) {
         if (key == "File name") root.filename = value;

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -72,7 +72,7 @@ MenuItem {
         
         controller.set_video_rotation(root.videoRotation)
 
-        Qt.callLater(() => window.exportSettings.videoInfoLoaded(w, h, bitrate));
+        Qt.callLater(window.exportSettings.videoInfoLoaded, w, h, bitrate);
     }
     function updateEntry(key, value) {
         if (key == "File name") root.filename = value;


### PR DESCRIPTION
- Removed a lot of similar width/height properties, not sure why they were needed in the first place.
- Added possibility to add a custom `reset` function to `NumberField`
- Reset size to initial values when using double click & context menu reset
- Reset Bitrate to source bitrate on reset (instead of fixed 20MBit/s)
