### PR TITLE
Fixed a bug which caused crashes in runtime.

### DIFF
--- a/src/ui_live_reload.cpp
+++ b/src/ui_live_reload.cpp
@@ -36,10 +36,12 @@ void init_live_reload(QQmlApplicationEngine *engine, const QString &path) {
                     delete itm;
                 }
             }
+            /*
             if (previousItem) {
                 previousItem->setParentItem(nullptr);
                 delete previousItem;
             }
+            */
 
             engine->clearComponentCache();
 


### PR DESCRIPTION
previousItem is already deleted by the previous if statement by deleting an item having the same object name "App".