### PR TITLE
Extended keyboard shortcuts

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -10,6 +10,7 @@ qrc!(pub rsrc,
         "src/ui/VideoArea.qml",
         "src/ui/Calibrator.qml",
         "src/ui/CalibrationTarget.qml",
+        "src/ui/Shortcuts.qml",
 
         "src/ui/menu/Advanced.qml",
         "src/ui/menu/Export.qml",

--- a/src/ui/App.qml
+++ b/src/ui/App.qml
@@ -301,6 +301,10 @@ Rectangle {
         }
     }
 
+    Shortcuts {
+        videoArea: videoArea;
+    }
+
     function messageBox(type, text, buttons, parent, textFormat) {
         if (textFormat === undefined ) textFormat = Text.AutoText; // default
         const el = Qt.createComponent("components/Modal.qml").createObject(parent || window, { textFormat: textFormat, text: text, iconType: type});

--- a/src/ui/Calibrator.qml
+++ b/src/ui/Calibrator.qml
@@ -208,6 +208,11 @@ Window {
             }
         }
     }
+    
+    Shortcuts {
+        videoArea: videoArea;
+    }
+
     Connections {
         target: controller;
         function onCalib_progress(progress, rms, ready, total, good) {

--- a/src/ui/Shortcuts.qml
+++ b/src/ui/Shortcuts.qml
@@ -1,0 +1,82 @@
+import QtQuick
+
+import Gyroflow
+
+Item {
+    property VideoArea videoArea;
+
+    Shortcut {
+        sequence: "Space";
+        onActivated: {
+            videoArea.timeline.focus = true;
+            if (videoArea.vid.playing)
+                videoArea.vid.pause();
+            else
+                videoArea.vid.play();
+        }
+    }    
+    Shortcut {
+        sequences: ["Left", "Page Up", ","];
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.vid.currentFrame -= 1;
+        }
+    }
+    Shortcut {
+        sequences: ["Ctrl+Left", "Ctrl+Page Up", "Ctrl+,"];
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.vid.currentFrame -= 10;
+        }
+    }
+    Shortcut {
+        sequences: ["Right", "Page Down","."];
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.vid.currentFrame += 1;
+        }
+    }
+    Shortcut {
+        sequences: ["Ctrl+Right", "Ctrl+Page Down","Ctrl+."];
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.vid.currentFrame += 10;
+        }
+    }
+    Shortcut {
+        sequence: "Home";
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.vid.currentFrame = videoArea.timeline.frameAtPosition(videoArea.timeline.trimStart);
+        }
+    }
+    Shortcut {
+        sequence: "End";
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.vid.currentFrame = videoArea.timeline.frameAtPosition(videoArea.timeline.trimEnd);
+        }
+    }
+    Shortcut {
+        sequences: ["i", "["];
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.timeline.setTrim(videoArea.timeline.position, videoArea.timeline.trimEnd);
+        }
+    }
+    Shortcut {
+        sequences: ["o", "]"];
+        onActivated: {
+            videoArea.timeline.focus = true;
+            videoArea.timeline.setTrim(videoArea.timeline.trimStart, videoArea.timeline.position);
+        }
+    }
+    Shortcut {
+        sequence: "m";
+        onActivated: videoArea.vid.muted = !videoArea.vid.muted;
+    }
+    Shortcut {
+        sequence: "s";
+        onActivated: videoArea.stabEnabledBtn.checked = !videoArea.stabEnabledBtn.checked;
+    }
+}

--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -19,6 +19,7 @@ Item {
     property alias trimStart: timeline.trimStart;
     property alias trimEnd: timeline.trimEnd;
     property alias videoLoader: videoLoader;
+    property alias stabEnabledBtn: stabEnabledBtn;
 
     property int outWidth: window? window.exportSettings.outWidth : 0;
     property int outHeight: window? window.exportSettings.outHeight : 0;
@@ -69,8 +70,7 @@ Item {
                 for (const ts in obj.offsets) {
                     controller.set_offset(ts, obj.offsets[ts]);
                 }
-                timeline.trimStart = obj.trim_start;
-                timeline.trimEnd   = obj.trim_end;
+                timeline.setTrim(obj.trim_start, obj.trim_end);
             }
             return;
         }
@@ -205,8 +205,7 @@ Item {
                     loaded = frameCount > 0;
                     videoLoader.active = false;
                     vidInfo.loader = false;
-                    timeline.trimStart = 0.0;
-                    timeline.trimEnd = 1.0;
+                    timeline.resetTrim();
 
                     controller.load_telemetry(vid.url, true, vid, timeline.getChart());
                     vidInfo.loadFromVideoMetadata(md);
@@ -393,7 +392,7 @@ Item {
                 anchors.centerIn: parent;
                 spacing: 5 * dpiScale;
                 enabled: vid.loaded;
-                Button { text: "["; font.bold: true; onClicked: timeline.trimStart = timeline.position; tooltip: qsTr("Trim start"); }
+                Button { text: "["; font.bold: true; onClicked: timeline.setTrim(timeline.position, timeline.trimEnd); tooltip: qsTr("Trim start"); }
                 Button { icon.name: "chevron-left"; tooltip: qsTr("Previous frame"); onClicked: vid.currentFrame -= 1; }
                 Button {
                     onClicked: if (vid.playing) vid.pause(); else vid.play();
@@ -401,7 +400,7 @@ Item {
                     icon.name: vid.playing? "pause" : "play";
                 }
                 Button { icon.name: "chevron-right"; tooltip: qsTr("Next frame"); onClicked: vid.currentFrame += 1; }
-                Button { text: "]"; font.bold: true; onClicked: timeline.trimEnd = timeline.position; tooltip: qsTr("Trim end"); }
+                Button { text: "]"; font.bold: true; onClicked: timeline.setTrim(timeline.trimStart, timeline.position); tooltip: qsTr("Trim end"); }
             }
             Row {
                 enabled: vid.loaded;

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -45,37 +45,26 @@ Item {
         const time = Math.max(0, durationMs * pos);
         return new Date(time).toISOString().substr(11, 8);
     }
+    
+    function setTrim(start, end) {
+        if (start >= end)
+            resetTrim();
+        else {
+            trimStart = start;
+            trimEnd   = end;
+        }
+    }
+
+    function resetTrim() {
+        root.trimStart = 0;
+        root.trimEnd = 1.0;
+    }
 
     Settings {
         property alias timelineChart: chart.viewMode;
     }
 
     focus: true;
-    Keys.onPressed: (e) => {
-        const vid = window.videoArea.vid;
-        switch (e.key) {
-            case Qt.Key_Left:
-            case Qt.Key_PageUp:       vid.currentFrame -= (e.modifiers & Qt.ControlModifier)? 10 : 1; e.accepted = true; break;
-            case Qt.Key_Right:
-            case Qt.Key_PageDown:     vid.currentFrame += (e.modifiers & Qt.ControlModifier)? 10 : 1; e.accepted = true; break;
-            case Qt.Key_Home:         vid.currentFrame = frameAtPosition(root.trimStart);             e.accepted = true; break;
-            case Qt.Key_End:          vid.currentFrame = frameAtPosition(root.trimEnd);               e.accepted = true; break;
-            // FiXME: these are hard to reach key combinations on certain keyboards (eg. on QWERTZ), find alternative
-            case Qt.Key_BracketLeft:  root.trimStart = root.position;                            e.accepted = true; break;
-            case Qt.Key_BracketRight: root.trimEnd   = root.position;                            e.accepted = true; break;
-        }
-    }
-
-    Shortcut {
-        sequence: "Space";
-        onActivated: (e) => {
-            root.focus = true;
-            if (window.videoArea.vid.playing)
-                window.videoArea.vid.pause();
-            else
-                window.videoArea.vid.play();
-        }
-    }
 
     Column {
         x: 3 * dpiScale;
@@ -370,9 +359,9 @@ Item {
                 trimStart: root.trimStart;
                 trimEnd: root.trimEnd;
                 visible: root.trimActive;
-                onChangeTrimStart: (val) => { root.trimStart = val; if (root.trimStart >= root.trimEnd) { root.trimStart = 0; root.trimEnd = 1.0; } }
-                onChangeTrimEnd:   (val) => { root.trimEnd   = val; if (root.trimStart >= root.trimEnd) { root.trimStart = 0; root.trimEnd = 1.0; } }
-                onReset: () => { root.trimStart = 0; root.trimEnd = 1.0; }
+                onChangeTrimStart: (val) => root.setTrim(val, root.trimEnd);
+                onChangeTrimEnd: (val) => root.setTrim(root.trimStart, val);
+                onReset: root.resetTrim();
             }
         }
 


### PR DESCRIPTION
- replaced key presses with shortcuts
- moved all shortcuts into separate file
- fixed issue where `space` key press in calibrator would trigger play/pause in main window
- fixed issue where clicking `trim start button` and `trim end button` on the same frame would create an empty trim section
- added shortcut `,`, `.`,`Ctrl+,`, `Ctrl.` for prev/next frames
- added shortcut `i`, `o` for set trim start/end
- added shortcut `m` for mute/un-mute
- added shortcut `s` for stabilization enable/disable