### PR TITLE
Consistent drop target style

### DIFF
--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -276,15 +276,9 @@ Item {
         }
         Rectangle {
             id: dropRect;
-            border.width: 3 * dpiScale;
-            border.color: style === "light"? Qt.darker(styleBackground, 1.3) : Qt.lighter(styleBackground, 2);
             anchors.fill: parent;
-            anchors.margins: 20 * dpiScale;
-            anchors.topMargin: 50 * dpiScale;
-            anchors.bottomMargin: 50 * dpiScale;
             color: styleBackground;
-            radius: 5 * dpiScale;
-            opacity: vid.loaded? 0 : da.containsDrag? 0.3 : 1.0;
+            opacity: da.containsDrag? 0.8 : vid.loaded? 0 : 0.3;
             Ease on opacity { duration: 300; }
             visible: opacity > 0;
             onVisibleChanged: if (!visible) dropText.loadingFile = "";
@@ -300,9 +294,9 @@ Item {
             }
             DropTargetRect {
                 visible: !dropText.loadingFile;
-                anchors.fill: dropText;
-                anchors.margins: -30 * dpiScale;
+                anchors.fill: parent;
                 scale: dropText.scale;
+                anchors.margins: 5 * dpiScale;
             }
             MouseArea {
                 visible: !vid.loaded;
@@ -329,6 +323,7 @@ Item {
         }
         LoaderOverlay {
             id: videoLoader;
+            background: styleBackground;
             onActiveChanged: { vid.forceRedraw(); vid.fovChanged(); }
             onCancel: controller.cancel_current_operation();
         }

--- a/src/ui/components/LoaderOverlay.qml
+++ b/src/ui/components/LoaderOverlay.qml
@@ -18,6 +18,7 @@ Item {
     property int currentFrame: 0;
     property int totalFrames: 0;
     property string additional;
+    property alias background: overlay.color;
 
     //onActiveChanged: parent.opacity = Qt.binding(() => (1.5 - opacity));
     onActiveChanged: {
@@ -69,6 +70,7 @@ Item {
     signal cancel();
 
     Rectangle {
+        id: overlay;
         anchors.fill: parent;
         color: styleBackground2;
         opacity: 0.8;

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -241,6 +241,7 @@ MenuItem {
 
     DropTarget {
         parent: root.innerItem;
+        color: styleBackground2;
         z: 999;
         anchors.rightMargin: -28 * dpiScale;
         anchors.topMargin: 35 * dpiScale;

--- a/src/ui/menu/MotionData.qml
+++ b/src/ui/menu/MotionData.qml
@@ -254,6 +254,7 @@ MenuItem {
     }
     DropTarget {
         parent: root.innerItem;
+        color: styleBackground2;
         z: 999;
         anchors.rightMargin: -28 * dpiScale;
         anchors.topMargin: 35 * dpiScale;

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -159,6 +159,7 @@ MenuItem {
 
     DropTarget {
         parent: root.innerItem;
+        color: styleBackground2;
         z: 999;
         anchors.rightMargin: -28 * dpiScale;
         anchors.topMargin: 35 * dpiScale;


### PR DESCRIPTION
- video area drop target is now consistent with the drop targets in the sidebar
- sidebar drop targets use the background color of the sidebar to fade the content below
- loader overlay in video area uses background color of the video area to fade out content below it