### PR TITLE
Fixed permanent auto-sync loader

### DIFF
--- a/src/core/synchronization/autosync.rs
+++ b/src/core/synchronization/autosync.rs
@@ -166,7 +166,7 @@ impl AutosyncProcess {
                     let processed_frames = estimator.processed_frames(current_range.0 as usize..current_range.1 as usize);
                     for x in processed_frames { frame_status.write().insert(x, true); }
 
-                    if total_detected_frames.load(SeqCst) <= total_read_frames.load(SeqCst) {
+                    if total_detected_frames.load(SeqCst) < total_read_frames.load(SeqCst) {
                         if let Some(cb) = &progress_cb {
                             let l = frame_status.read();
                             let total = l.len();


### PR DESCRIPTION
Auto-sync's `LoaderOverlay` would sometimes stay even after the process completed. It happens because `progress_cb` would be called in `AutosyncProcess::feed_frame` after the call in `AutosyncProcess::finished_feeding_frames`.
This is more a workaround rather than a fix, as it just prohibits the last call and rely on `finished_feeding_frames`.