### PR TITLE
Use gravity vector for horizon lock

### DIFF
--- a/src/core/gyro_source.rs
+++ b/src/core/gyro_source.rs
@@ -217,8 +217,7 @@ impl GyroSource {
 
     pub fn recompute_smoothness(&mut self, alg: &mut dyn SmoothingAlgorithm, horizon_lock: super::smoothing::horizon::HorizonLock, stabilization_params: &StabilizationParams) {
         self.smoothed_quaternions = alg.smooth(&self.quaternions, self.duration_ms, stabilization_params);
-
-        horizon_lock.lock(&mut self.smoothed_quaternions, &self.gravity_vectors);
+        horizon_lock.lock(&mut self.smoothed_quaternions, &mut self.quaternions, &self.gravity_vectors, self.integration_method);
 
         self.max_angles = crate::Smoothing::get_max_angles(&self.quaternions, &self.smoothed_quaternions, stabilization_params);
         self.org_smoothed_quaternions = self.smoothed_quaternions.clone();
@@ -376,6 +375,7 @@ impl GyroSource {
             smoothed_quaternions: self.smoothed_quaternions.clone(),            
             offsets:              self.offsets.clone(),
             gravity_vectors:      self.gravity_vectors.clone(),
+            integration_method:   self.integration_method,
             ..Default::default()
         }
     }


### PR DESCRIPTION
Implement https://github.com/gyroflow/gyroflow/issues/24

Notes:
* Although Hero 8 contain the GRAV metadata, it's unfortunately blank, so this only works for hero 9 and newer.
* Gravity vector is given in the body coordinate system, so using it consists of extracting the roll component and correcting for the roll difference between original and smoothed orientations. It seems to work, but math is a bit wonky, so there might be a mistake somewhere.