### PR TITLE
#134 - Bug Fix: Icons missing in Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "qml-video-rs"
 version = "0.1.0"
-source = "git+https://github.com/AdrianEddy/qml-video-rs.git?rev=33eb660#33eb66005d183c0fc40901c6b4cfc8548c9b3b07"
+source = "git+https://github.com/AdrianEddy/qml-video-rs.git?rev=950a5b8#950a5b8a1ff551b12748edaa6e6edbc35180c8eb"
 dependencies = [
  "cpp",
  "cpp_build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2556,7 +2556,7 @@ dependencies = [
 [[package]]
 name = "qml-video-rs"
 version = "0.1.0"
-source = "git+https://github.com/AdrianEddy/qml-video-rs.git?rev=950a5b8#950a5b8a1ff551b12748edaa6e6edbc35180c8eb"
+source = "git+https://github.com/AdrianEddy/qml-video-rs.git?rev=33eb660#33eb66005d183c0fc40901c6b4cfc8548c9b3b07"
 dependencies = [
  "cpp",
  "cpp_build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ breakpad-sys = "0.1.1"
 
 qmetaobject = { version = "*", git = "https://github.com/AdrianEddy/qmetaobject-rs.git", default-features = false, features = ["log"] }
 qttypes     = { version = "*", git = "https://github.com/AdrianEddy/qmetaobject-rs.git", default-features = false, features = ["required", "qtquick", "qtquickcontrols2"]}
-qml-video-rs = { git = "https://github.com/AdrianEddy/qml-video-rs.git", rev = "33eb660" }
+qml-video-rs = { git = "https://github.com/AdrianEddy/qml-video-rs.git", rev = "950a5b8" }
 #qml-video-rs = { path = "../qml-video-rs" }
 
 ffmpeg-next = { version = "5.0.3", default-features = false, features = ["codec", "filter", "format", "software-resampling", "software-scaling"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ breakpad-sys = "0.1.1"
 
 qmetaobject = { version = "*", git = "https://github.com/AdrianEddy/qmetaobject-rs.git", default-features = false, features = ["log"] }
 qttypes     = { version = "*", git = "https://github.com/AdrianEddy/qmetaobject-rs.git", default-features = false, features = ["required", "qtquick", "qtquickcontrols2"]}
-qml-video-rs = { git = "https://github.com/AdrianEddy/qml-video-rs.git", rev = "950a5b8" }
+qml-video-rs = { git = "https://github.com/AdrianEddy/qml-video-rs.git", rev = "33eb660" }
 #qml-video-rs = { path = "../qml-video-rs" }
 
 ffmpeg-next = { version = "5.0.3", default-features = false, features = ["codec", "filter", "format", "software-resampling", "software-scaling"] }

--- a/src/ui/App.qml
+++ b/src/ui/App.qml
@@ -185,7 +185,7 @@ Rectangle {
                     anchors.rightMargin: 55 * dpiScale;
                     anchors.verticalCenter: parent.verticalCenter;
                     text: isAddToQueue? (render_queue.editing_job_id > 0? qsTr("Save") : qsTr("Add to render queue")) : qsTr("Export");
-                    icon.name: "video";
+                    iconName: "video";
                     opacity: enabled? 1.0 : 0.6;
                     Ease on opacity { }
                     fadeWhenDisabled: false;

--- a/src/ui/App.qml
+++ b/src/ui/App.qml
@@ -295,7 +295,7 @@ Rectangle {
                     icon.height: 25 * dpiScale;
                     // textColor: styleTextColor;
                     anchors.verticalCenter: parent.verticalCenter;
-                    icon.name: "queue";
+                    iconName: "queue";
                     tooltip: qsTr("Render queue");
                     onClicked: videoArea.queue.shown = !videoArea.queue.shown;
                 }

--- a/src/ui/App.qml
+++ b/src/ui/App.qml
@@ -186,7 +186,6 @@ Rectangle {
                     anchors.verticalCenter: parent.verticalCenter;
                     text: isAddToQueue? (render_queue.editing_job_id > 0? qsTr("Save") : qsTr("Add to render queue")) : qsTr("Export");
                     icon.name: "video";
-                    icon.source: "qrc:/resources/icons/svg/video.svg";
                     opacity: enabled? 1.0 : 0.6;
                     Ease on opacity { }
                     fadeWhenDisabled: false;
@@ -297,7 +296,6 @@ Rectangle {
                     // textColor: styleTextColor;
                     anchors.verticalCenter: parent.verticalCenter;
                     icon.name: "queue";
-                    icon.source: "qrc:/resources/icons/svg/queue.svg";
                     tooltip: qsTr("Render queue");
                     onClicked: videoArea.queue.shown = !videoArea.queue.shown;
                 }

--- a/src/ui/App.qml
+++ b/src/ui/App.qml
@@ -186,6 +186,7 @@ Rectangle {
                     anchors.verticalCenter: parent.verticalCenter;
                     text: isAddToQueue? (render_queue.editing_job_id > 0? qsTr("Save") : qsTr("Add to render queue")) : qsTr("Export");
                     icon.name: "video";
+                    icon.source: "qrc:/resources/icons/svg/video.svg";
                     opacity: enabled? 1.0 : 0.6;
                     Ease on opacity { }
                     fadeWhenDisabled: false;
@@ -296,6 +297,7 @@ Rectangle {
                     // textColor: styleTextColor;
                     anchors.verticalCenter: parent.verticalCenter;
                     icon.name: "queue";
+                    icon.source: "qrc:/resources/icons/svg/queue.svg";
                     tooltip: qsTr("Render queue");
                     onClicked: videoArea.queue.shown = !videoArea.queue.shown;
                 }

--- a/src/ui/Calibrator.qml
+++ b/src/ui/Calibrator.qml
@@ -200,7 +200,6 @@ Window {
                     Button {
                         text: qsTr("Open calibration target");
                         icon.name: "chessboard"
-                        icon.source: "qrc:/resources/icons/svg/chessboard.svg";
                         onClicked: Qt.createComponent("CalibrationTarget.qml").createObject(calibrator_window).showMaximized();
                     }
                     LinkButton {

--- a/src/ui/Calibrator.qml
+++ b/src/ui/Calibrator.qml
@@ -199,7 +199,7 @@ Window {
                     }
                     Button {
                         text: qsTr("Open calibration target");
-                        icon.name: "chessboard"
+                        iconName: "chessboard"
                         onClicked: Qt.createComponent("CalibrationTarget.qml").createObject(calibrator_window).showMaximized();
                     }
                     LinkButton {

--- a/src/ui/Calibrator.qml
+++ b/src/ui/Calibrator.qml
@@ -200,6 +200,7 @@ Window {
                     Button {
                         text: qsTr("Open calibration target");
                         icon.name: "chessboard"
+                        icon.source: "qrc:/resources/icons/svg/chessboard.svg";
                         onClicked: Qt.createComponent("CalibrationTarget.qml").createObject(calibrator_window).showMaximized();
                     }
                     LinkButton {

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -474,7 +474,7 @@ Item {
                         id: btnsRowInner;
                         IconButton {
                             visible: dlg.isFinished;
-                            icon.name: "play";
+                            iconName: "play";
                             icon.width: 25 * dpiScale;
                             icon.height: 25 * dpiScale;
                             tooltip: qsTr("Open rendered file");
@@ -482,14 +482,14 @@ Item {
                         }
                         IconButton {
                             visible: dlg.isFinished;
-                            icon.name: "folder";
+                            iconName: "folder";
                             tooltip: qsTr("Open file location");
                             onClicked: controller.open_file_externally(Util.getFolder(output_path));
                         }
                         IconButton {
                             tooltip: qsTr("Remove");
                             textColor: "#f67575"
-                            icon.name: dlg.isFinished? "close" : "bin";
+                            iconName: dlg.isFinished? "close" : "bin";
                             onClicked: render_queue.remove(job_id);
                         }
                     }

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -183,7 +183,7 @@ Item {
                 "active":  [qsTr("Pause"),           "pause", "#f6a00b",        "pause"],
             })
             text: statuses[status][0];
-            icon.name: statuses[status][1];
+            iconName: statuses[status][1];
             accentColor: statuses[status][2];
             icon.width: 15 * dpiScale;
             icon.height: 15 * dpiScale;

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -256,13 +256,13 @@ Item {
                 id: contextMenu;
                 font.pixelSize: 11.5 * dpiScale;
                 Action {
-                    icon.name: "play";
+                    iconName: "play";
                     text: qsTr("Render now");
                     enabled: !isFinished && !isInProgress;
                     onTriggered: render_queue.render_job(job_id, true);
                 }
                 Action {
-                    icon.name: "pencil";
+                    iconName: "pencil";
                     text: qsTr("Edit");
                     enabled: !isInProgress;
                     onTriggered:{
@@ -275,7 +275,7 @@ Item {
                     }
                 }
                 Action {
-                    icon.name: isInProgress? "close" : "spinner";
+                    iconName: isInProgress? "close" : "spinner";
                     text: isInProgress? qsTr("Stop") : qsTr("Reset status");
                     enabled: isError || isFinished || isQuestion || isInProgress;
                     onTriggered: render_queue.reset_job(job_id);

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -47,6 +47,7 @@ Item {
         height: 34 * dpiScale;
         textColor: styleTextColor;
         icon.name: "close";
+        icon.source: "qrc:/resources/icons/svg/close.svg";
         leftPadding: 0;
         rightPadding: 0;
         topPadding: 10 * dpiScale;
@@ -184,6 +185,7 @@ Item {
             })
             text: statuses[status][0];
             icon.name: statuses[status][1];
+            icon.source: "qrc:/resources/icons/svg/" + statuses[status][1] + ".svg";
             accentColor: statuses[status][2];
             icon.width: 15 * dpiScale;
             icon.height: 15 * dpiScale;
@@ -257,12 +259,14 @@ Item {
                 font.pixelSize: 11.5 * dpiScale;
                 Action {
                     icon.name: "play";
+                    icon.source: "qrc:/resources/icons/svg/play.svg";
                     text: qsTr("Render now");
                     enabled: !isFinished && !isInProgress;
                     onTriggered: render_queue.render_job(job_id, true);
                 }
                 Action {
                     icon.name: "pencil";
+                    icon.source: "qrc:/resources/icons/svg/pencil.svg";
                     text: qsTr("Edit");
                     enabled: !isInProgress;
                     onTriggered:{
@@ -276,6 +280,7 @@ Item {
                 }
                 Action {
                     icon.name: isInProgress? "close" : "spinner";
+                    icon.source: isInProgress? "qrc:/resources/icons/svg/close.svg" : "qrc:/resources/icons/svg/spinner.svg";
                     text: isInProgress? qsTr("Stop") : qsTr("Reset status");
                     enabled: isError || isFinished || isQuestion || isInProgress;
                     onTriggered: render_queue.reset_job(job_id);
@@ -475,6 +480,7 @@ Item {
                         IconButton {
                             visible: dlg.isFinished;
                             icon.name: "play";
+                            icon.source: "qrc:/resources/icons/svg/play.svg";
                             icon.width: 25 * dpiScale;
                             icon.height: 25 * dpiScale;
                             tooltip: qsTr("Open rendered file");
@@ -483,6 +489,7 @@ Item {
                         IconButton {
                             visible: dlg.isFinished;
                             icon.name: "folder";
+                            icon.source: "qrc:/resources/icons/svg/folder.svg";
                             tooltip: qsTr("Open file location");
                             onClicked: controller.open_file_externally(Util.getFolder(output_path));
                         }
@@ -490,6 +497,7 @@ Item {
                             tooltip: qsTr("Remove");
                             textColor: "#f67575"
                             icon.name: dlg.isFinished? "close" : "bin";
+                            icon.source: dlg.isFinished? "qrc:/resources/icons/svg/close.svg" : "qrc:/resources/icons/svg/bin.svg";
                             onClicked: render_queue.remove(job_id);
                         }
                     }

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -47,7 +47,6 @@ Item {
         height: 34 * dpiScale;
         textColor: styleTextColor;
         icon.name: "close";
-        icon.source: "qrc:/resources/icons/svg/close.svg";
         leftPadding: 0;
         rightPadding: 0;
         topPadding: 10 * dpiScale;
@@ -185,7 +184,6 @@ Item {
             })
             text: statuses[status][0];
             icon.name: statuses[status][1];
-            icon.source: "qrc:/resources/icons/svg/" + statuses[status][1] + ".svg";
             accentColor: statuses[status][2];
             icon.width: 15 * dpiScale;
             icon.height: 15 * dpiScale;
@@ -259,14 +257,12 @@ Item {
                 font.pixelSize: 11.5 * dpiScale;
                 Action {
                     icon.name: "play";
-                    icon.source: "qrc:/resources/icons/svg/play.svg";
                     text: qsTr("Render now");
                     enabled: !isFinished && !isInProgress;
                     onTriggered: render_queue.render_job(job_id, true);
                 }
                 Action {
                     icon.name: "pencil";
-                    icon.source: "qrc:/resources/icons/svg/pencil.svg";
                     text: qsTr("Edit");
                     enabled: !isInProgress;
                     onTriggered:{
@@ -280,7 +276,6 @@ Item {
                 }
                 Action {
                     icon.name: isInProgress? "close" : "spinner";
-                    icon.source: isInProgress? "qrc:/resources/icons/svg/close.svg" : "qrc:/resources/icons/svg/spinner.svg";
                     text: isInProgress? qsTr("Stop") : qsTr("Reset status");
                     enabled: isError || isFinished || isQuestion || isInProgress;
                     onTriggered: render_queue.reset_job(job_id);
@@ -480,7 +475,6 @@ Item {
                         IconButton {
                             visible: dlg.isFinished;
                             icon.name: "play";
-                            icon.source: "qrc:/resources/icons/svg/play.svg";
                             icon.width: 25 * dpiScale;
                             icon.height: 25 * dpiScale;
                             tooltip: qsTr("Open rendered file");
@@ -489,7 +483,6 @@ Item {
                         IconButton {
                             visible: dlg.isFinished;
                             icon.name: "folder";
-                            icon.source: "qrc:/resources/icons/svg/folder.svg";
                             tooltip: qsTr("Open file location");
                             onClicked: controller.open_file_externally(Util.getFolder(output_path));
                         }
@@ -497,7 +490,6 @@ Item {
                             tooltip: qsTr("Remove");
                             textColor: "#f67575"
                             icon.name: dlg.isFinished? "close" : "bin";
-                            icon.source: dlg.isFinished? "qrc:/resources/icons/svg/close.svg" : "qrc:/resources/icons/svg/bin.svg";
                             onClicked: render_queue.remove(job_id);
                         }
                     }

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -46,7 +46,7 @@ Item {
         width: 34 * dpiScale;
         height: 34 * dpiScale;
         textColor: styleTextColor;
-        icon.name: "close";
+        iconName: "close";
         leftPadding: 0;
         rightPadding: 0;
         topPadding: 10 * dpiScale;

--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -519,13 +519,13 @@ Item {
 
                 SmallLinkButton {
                     id: stabEnabledBtn;
-                    icon.name: "gyroflow";
+                    iconName: "gyroflow";
                     onCheckedChanged: { vid.stabEnabled = checked; controller.stab_enabled = checked; vid.forceRedraw(); vid.fovChanged(); }
                     tooltip: qsTr("Toggle stabilization");
                 }
 
                 SmallLinkButton {
-                    icon.name: checked? "sound" : "sound-mute";
+                    iconName: checked? "sound" : "sound-mute";
                     onClicked: vid.muted = !vid.muted;
                     tooltip: checked? qsTr("Mute") : qsTr("Unmute");
                     checked: !vid.muted;

--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -487,24 +487,13 @@ Item {
                 spacing: 5 * dpiScale;
                 enabled: vid.loaded;
                 Button { text: "["; font.bold: true; onClicked: timeline.setTrim(timeline.position, timeline.trimEnd); tooltip: qsTr("Trim start"); }
-                Button {
-                    icon.name: "chevron-left";
-                    icon.source: "qrc:/resources/icons/svg/chevron-left.svg";
-                    tooltip: qsTr("Previous frame");
-                    onClicked: vid.currentFrame -= 1;
-                }
+                Button { icon.name: "chevron-left"; tooltip: qsTr("Previous frame"); onClicked: vid.currentFrame -= 1; }
                 Button {
                     onClicked: if (vid.playing) vid.pause(); else vid.play();
                     tooltip: vid.playing? qsTr("Pause") : qsTr("Play");
                     icon.name: vid.playing? "pause" : "play";
-                    icon.source: vid.playing? "qrc:/resources/icons/svg/pause.svg" : "qrc:/resources/icons/svg/play.svg";
                 }
-                Button {
-                    icon.name: "chevron-right";
-                    icon.source: "qrc:/resources/icons/svg/chevron-right.svg";
-                    tooltip: qsTr("Next frame");
-                    onClicked: vid.currentFrame += 1;
-                }
+                Button { icon.name: "chevron-right"; tooltip: qsTr("Next frame"); onClicked: vid.currentFrame += 1; }
                 Button { text: "]"; font.bold: true; onClicked: timeline.setTrim(timeline.trimStart, timeline.position); tooltip: qsTr("Trim end"); }
             }
             Row {
@@ -531,14 +520,12 @@ Item {
                 SmallLinkButton {
                     id: stabEnabledBtn;
                     icon.name: "gyroflow";
-                    icon.source: "qrc:/resources/icons/svg/gyroflow.svg";
                     onCheckedChanged: { vid.stabEnabled = checked; controller.stab_enabled = checked; vid.forceRedraw(); vid.fovChanged(); }
                     tooltip: qsTr("Toggle stabilization");
                 }
 
                 SmallLinkButton {
                     icon.name: checked? "sound" : "sound-mute";
-                    icon.source: checked? "qrc:/resources/icons/svg/sound.svg" : "qrc:/resources/icons/svg/sound-mute.svg" ;
                     onClicked: vid.muted = !vid.muted;
                     tooltip: checked? qsTr("Mute") : qsTr("Unmute");
                     checked: !vid.muted;

--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -487,13 +487,13 @@ Item {
                 spacing: 5 * dpiScale;
                 enabled: vid.loaded;
                 Button { text: "["; font.bold: true; onClicked: timeline.setTrim(timeline.position, timeline.trimEnd); tooltip: qsTr("Trim start"); }
-                Button { icon.name: "chevron-left"; tooltip: qsTr("Previous frame"); onClicked: vid.currentFrame -= 1; }
+                Button { iconName: "chevron-left"; tooltip: qsTr("Previous frame"); onClicked: vid.currentFrame -= 1; }
                 Button {
                     onClicked: if (vid.playing) vid.pause(); else vid.play();
                     tooltip: vid.playing? qsTr("Pause") : qsTr("Play");
-                    icon.name: vid.playing? "pause" : "play";
+                    iconName: vid.playing? "pause" : "play";
                 }
-                Button { icon.name: "chevron-right"; tooltip: qsTr("Next frame"); onClicked: vid.currentFrame += 1; }
+                Button { iconName: "chevron-right"; tooltip: qsTr("Next frame"); onClicked: vid.currentFrame += 1; }
                 Button { text: "]"; font.bold: true; onClicked: timeline.setTrim(timeline.trimStart, timeline.position); tooltip: qsTr("Trim end"); }
             }
             Row {

--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -487,13 +487,24 @@ Item {
                 spacing: 5 * dpiScale;
                 enabled: vid.loaded;
                 Button { text: "["; font.bold: true; onClicked: timeline.setTrim(timeline.position, timeline.trimEnd); tooltip: qsTr("Trim start"); }
-                Button { icon.name: "chevron-left"; tooltip: qsTr("Previous frame"); onClicked: vid.currentFrame -= 1; }
+                Button {
+                    icon.name: "chevron-left";
+                    icon.source: "qrc:/resources/icons/svg/chevron-left.svg";
+                    tooltip: qsTr("Previous frame");
+                    onClicked: vid.currentFrame -= 1;
+                }
                 Button {
                     onClicked: if (vid.playing) vid.pause(); else vid.play();
                     tooltip: vid.playing? qsTr("Pause") : qsTr("Play");
                     icon.name: vid.playing? "pause" : "play";
+                    icon.source: vid.playing? "qrc:/resources/icons/svg/pause.svg" : "qrc:/resources/icons/svg/play.svg";
                 }
-                Button { icon.name: "chevron-right"; tooltip: qsTr("Next frame"); onClicked: vid.currentFrame += 1; }
+                Button {
+                    icon.name: "chevron-right";
+                    icon.source: "qrc:/resources/icons/svg/chevron-right.svg";
+                    tooltip: qsTr("Next frame");
+                    onClicked: vid.currentFrame += 1;
+                }
                 Button { text: "]"; font.bold: true; onClicked: timeline.setTrim(timeline.trimStart, timeline.position); tooltip: qsTr("Trim end"); }
             }
             Row {
@@ -520,12 +531,14 @@ Item {
                 SmallLinkButton {
                     id: stabEnabledBtn;
                     icon.name: "gyroflow";
+                    icon.source: "qrc:/resources/icons/svg/gyroflow.svg";
                     onCheckedChanged: { vid.stabEnabled = checked; controller.stab_enabled = checked; vid.forceRedraw(); vid.fovChanged(); }
                     tooltip: qsTr("Toggle stabilization");
                 }
 
                 SmallLinkButton {
                     icon.name: checked? "sound" : "sound-mute";
+                    icon.source: checked? "qrc:/resources/icons/svg/sound.svg" : "qrc:/resources/icons/svg/sound-mute.svg" ;
                     onClicked: vid.muted = !vid.muted;
                     tooltip: checked? qsTr("Mute") : qsTr("Unmute");
                     checked: !vid.muted;

--- a/src/ui/components/Action.qml
+++ b/src/ui/components/Action.qml
@@ -3,5 +3,9 @@
 
 import QtQuick
 import QtQuick.Controls as QQC
+import QtQuick.Controls.Material as QQCM
 
-QQC.Action { }
+QQC.Action {
+    id: root;
+    property alias iconName: root.icon.name;
+}

--- a/src/ui/components/Button.qml
+++ b/src/ui/components/Button.qml
@@ -51,6 +51,10 @@ QQC.Button {
     property alias tooltip: tt.text;
     ToolTip { id: tt; visible: text.length > 0 && root.hovered; }
 
+    property string iconName;
+    icon.name: iconName || "";
+    icon.source: iconName ? "qrc:/resources/icons/svg/" + iconName + ".svg" : "";
+
     Keys.onPressed: (e) => {
         if (e.key == Qt.Key_Enter || e.key == Qt.Key_Return) {
             root.clicked();

--- a/src/ui/components/LinkButton.qml
+++ b/src/ui/components/LinkButton.qml
@@ -37,6 +37,10 @@ QQC.Button {
     property alias tooltip: tt.text;
     ToolTip { id: tt; visible: text.length > 0 && root.hovered; }
 
+    property string iconName;
+    icon.name: iconName || "";
+    icon.source: iconName ? "qrc:/resources/icons/svg/" + iconName + ".svg" : "";
+
     Keys.onReturnPressed: checked = !checked;
     Keys.onEnterPressed: checked = !checked;
 }

--- a/src/ui/components/Menu.qml
+++ b/src/ui/components/Menu.qml
@@ -38,9 +38,11 @@ QQC.Menu {
         Component.onCompleted: {
             if (icon.name && icon.name.indexOf(";") > 0) {
                 const parts = icon.name.split(";");
-                dlg.orgIconColor = parts[1];
                 icon.name = parts[0];
                 icon.source = "qrc:/resources/icons/svg/" + parts[0] + ".svg";
+                dlg.orgIconColor = parts[1];
+            } else if (icon.name)  {
+                icon.source = "qrc:/resources/icons/svg/" + icon.name + ".svg";
             }
             Qt.callLater(function() {
                 if (menu && dlg && dlg.implicitContentWidth > menu.maxItemWidth) menu.maxItemWidth = dlg.implicitContentWidth;

--- a/src/ui/components/Menu.qml
+++ b/src/ui/components/Menu.qml
@@ -40,6 +40,7 @@ QQC.Menu {
                 const parts = icon.name.split(";");
                 dlg.orgIconColor = parts[1];
                 icon.name = parts[0];
+                icon.source = "qrc:/resources/icons/svg/" + parts[0] + ".svg";
             }
             Qt.callLater(function() {
                 if (menu && dlg && dlg.implicitContentWidth > menu.maxItemWidth) menu.maxItemWidth = dlg.implicitContentWidth;

--- a/src/ui/components/Menu.qml
+++ b/src/ui/components/Menu.qml
@@ -40,7 +40,6 @@ QQC.Menu {
                 const parts = icon.name.split(";");
                 dlg.orgIconColor = parts[1];
                 icon.name = parts[0];
-                icon.source = "qrc:/resources/icons/svg/" + parts[0] + ".svg";
             }
             Qt.callLater(function() {
                 if (menu && dlg && dlg.implicitContentWidth > menu.maxItemWidth) menu.maxItemWidth = dlg.implicitContentWidth;

--- a/src/ui/components/MenuItem.qml
+++ b/src/ui/components/MenuItem.qml
@@ -11,6 +11,7 @@ Item {
     signal clicked();
     property alias text: btn.text;
     property alias icon: btn.icon.name;
+    property alias iconSource: btn.icon.source;
     property bool opened: col.children.length > 0;
     property alias loader: loader.active;
     property alias loaderProgress: loader.progress;

--- a/src/ui/components/MenuItem.qml
+++ b/src/ui/components/MenuItem.qml
@@ -11,7 +11,6 @@ Item {
     signal clicked();
     property alias text: btn.text;
     property alias icon: btn.icon.name;
-    property alias iconSource: btn.icon.source;
     property bool opened: col.children.length > 0;
     property alias loader: loader.active;
     property alias loaderProgress: loader.progress;

--- a/src/ui/components/MenuItem.qml
+++ b/src/ui/components/MenuItem.qml
@@ -10,13 +10,13 @@ Item {
     id: root;
     signal clicked();
     property alias text: btn.text;
-    property alias icon: btn.icon.name;
     property bool opened: col.children.length > 0;
     property alias loader: loader.active;
     property alias loaderProgress: loader.progress;
     property alias spacing: col.spacing;
     property alias innerItem: innerItem;
     default property alias data: col.data;
+    property string iconName;
 
     Component.onCompleted: {
         const val = window.settings.value(root.objectName + "-opened", root.opened);
@@ -47,6 +47,10 @@ Item {
 
     QQC.Button {
         id: btn;
+
+        icon.name: iconName || "";
+        icon.source: iconName ? "qrc:/resources/icons/svg/" + iconName + ".svg" : "";
+
         width: parent.width;
         height: 36 * dpiScale;
         hoverEnabled: true;

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -37,11 +37,34 @@ Rectangle {
     onVisibleChanged: {
         if (visible && iconType != Modal.NoIcon) {
             switch (iconType) {
-                case Modal.Info:     icon.name = "info";      icon.color = styleAccentColor; break;
-                case Modal.Warning:  icon.name = "warning";   icon.color = "#f6a10c"; break;
-                case Modal.Error:    icon.name = "error";     icon.color = "#d82626"; break;
-                case Modal.Success:  icon.name = "confirmed"; icon.color = "#3cc42f"; break;
-                case Modal.Question: icon.name = "question";  icon.color = styleAccentColor; break;
+                case Modal.Info:
+                    icon.name = "info";
+                    icon.source = "qrc:/resources/icons/svg/info.svg";
+                    icon.color = styleAccentColor; break;
+
+                case Modal.Warning:
+                    icon.name = "warning";
+                    icon.source = "qrc:/resources/icons/svg/warning.svg";
+                    icon.color = "#f6a10c";
+                    break;
+
+                case Modal.Error:
+                    icon.name = "error";
+                    icon.source = "qrc:/resources/icons/svg/error.svg";
+                    icon.color = "#d82626";
+                    break;
+
+                case Modal.Success:
+                    icon.name = "confirmed";
+                    icon.source = "qrc:/resources/icons/svg/confirmed.svg";
+                    icon.color = "#3cc42f";
+                    break;
+
+                case Modal.Question:
+                    icon.name = "question";
+                    icon.source = "qrc:/resources/icons/svg/question.svg";
+                    icon.color = styleAccentColor;
+                    break;
             }
             icon.visible = true;
             ease.enabled = false;

--- a/src/ui/components/Modal.qml
+++ b/src/ui/components/Modal.qml
@@ -37,34 +37,11 @@ Rectangle {
     onVisibleChanged: {
         if (visible && iconType != Modal.NoIcon) {
             switch (iconType) {
-                case Modal.Info:
-                    icon.name = "info";
-                    icon.source = "qrc:/resources/icons/svg/info.svg";
-                    icon.color = styleAccentColor; break;
-
-                case Modal.Warning:
-                    icon.name = "warning";
-                    icon.source = "qrc:/resources/icons/svg/warning.svg";
-                    icon.color = "#f6a10c";
-                    break;
-
-                case Modal.Error:
-                    icon.name = "error";
-                    icon.source = "qrc:/resources/icons/svg/error.svg";
-                    icon.color = "#d82626";
-                    break;
-
-                case Modal.Success:
-                    icon.name = "confirmed";
-                    icon.source = "qrc:/resources/icons/svg/confirmed.svg";
-                    icon.color = "#3cc42f";
-                    break;
-
-                case Modal.Question:
-                    icon.name = "question";
-                    icon.source = "qrc:/resources/icons/svg/question.svg";
-                    icon.color = styleAccentColor;
-                    break;
+                case Modal.Info:     icon.name = "info";      icon.color = styleAccentColor; break;
+                case Modal.Warning:  icon.name = "warning";   icon.color = "#f6a10c"; break;
+                case Modal.Error:    icon.name = "error";     icon.color = "#d82626"; break;
+                case Modal.Success:  icon.name = "confirmed"; icon.color = "#3cc42f"; break;
+                case Modal.Question: icon.name = "question";  icon.color = styleAccentColor; break;
             }
             icon.visible = true;
             ease.enabled = false;

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -116,12 +116,14 @@ TextField {
         font.pixelSize: 11.5 * dpiScale;
         Action {
             icon.name: "undo";
+            icon.source: "qrc:/resources/icons/svg/undo.svg";
             text: qsTr("Reset value");
             enabled: value != defaultValue;
             onTriggered: root.reset()
         }
         Action {
             icon.name: "keyframe";
+            icon.source: "qrc:/resources/icons/svg/keyframe.svg";
             enabled: root.keyframe.length > 0;
             text: qsTr("Enable keyframing");
             checked: root.keyframesEnabled;

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -115,13 +115,13 @@ TextField {
         id: contextMenu;
         font.pixelSize: 11.5 * dpiScale;
         Action {
-            icon.name: "undo";
+            iconName: "undo";
             text: qsTr("Reset value");
             enabled: value != defaultValue;
             onTriggered: root.reset()
         }
         Action {
-            icon.name: "keyframe";
+            iconName: "keyframe";
             enabled: root.keyframe.length > 0;
             text: qsTr("Enable keyframing");
             checked: root.keyframesEnabled;

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -116,14 +116,12 @@ TextField {
         font.pixelSize: 11.5 * dpiScale;
         Action {
             icon.name: "undo";
-            icon.source: "qrc:/resources/icons/svg/undo.svg";
             text: qsTr("Reset value");
             enabled: value != defaultValue;
             onTriggered: root.reset()
         }
         Action {
             icon.name: "keyframe";
-            icon.source: "qrc:/resources/icons/svg/keyframe.svg";
             enabled: root.keyframe.length > 0;
             text: qsTr("Enable keyframing");
             checked: root.keyframesEnabled;

--- a/src/ui/components/Popup.qml
+++ b/src/ui/components/Popup.qml
@@ -39,7 +39,6 @@ QQC.Popup {
                 anchors.fill: parent;
                 text: qsTr(modelData);
                 icon.name: popup.icons[index] || "";
-                icon.source: popup.icons[index] ? "qrc:/resources/icons/svg/" + popup.icons[index] + ".svg" : "";
                 icon.color: c;
                 icon.height: popup.itemHeight / 2 + 5 * dpiScale;
                 icon.width: popup.itemHeight / 2 + 5 * dpiScale;

--- a/src/ui/components/Popup.qml
+++ b/src/ui/components/Popup.qml
@@ -39,6 +39,7 @@ QQC.Popup {
                 anchors.fill: parent;
                 text: qsTr(modelData);
                 icon.name: popup.icons[index] || "";
+                icon.source: popup.icons[index] ? "qrc:/resources/icons/svg/" + popup.icons[index] + ".svg" : "";
                 icon.color: c;
                 icon.height: popup.itemHeight / 2 + 5 * dpiScale;
                 icon.width: popup.itemHeight / 2 + 5 * dpiScale;

--- a/src/ui/components/SliderWithField.qml
+++ b/src/ui/components/SliderWithField.qml
@@ -84,7 +84,7 @@ Row {
             id: contextMenu;
             font.pixelSize: 11.5 * dpiScale;
             Action {
-                icon.name: "undo";
+                iconName: "undo";
                 text: qsTr("Reset value");
                 enabled: field.value != defaultValue;
                 onTriggered: {
@@ -92,7 +92,7 @@ Row {
                 }
             }
             Action {
-                icon.name: "keyframe";
+                iconName: "keyframe";
                 enabled: root.keyframe.length > 0;
                 text: qsTr("Enable keyframing");
                 checked: root.keyframesEnabled;

--- a/src/ui/components/SliderWithField.qml
+++ b/src/ui/components/SliderWithField.qml
@@ -85,6 +85,7 @@ Row {
             font.pixelSize: 11.5 * dpiScale;
             Action {
                 icon.name: "undo";
+                icon.source: "qrc:/resources/icons/svg/undo.svg";
                 text: qsTr("Reset value");
                 enabled: field.value != defaultValue;
                 onTriggered: {
@@ -93,6 +94,7 @@ Row {
             }
             Action {
                 icon.name: "keyframe";
+                icon.source: "qrc:/resources/icons/svg/keyframe.svg";
                 enabled: root.keyframe.length > 0;
                 text: qsTr("Enable keyframing");
                 checked: root.keyframesEnabled;

--- a/src/ui/components/SliderWithField.qml
+++ b/src/ui/components/SliderWithField.qml
@@ -85,7 +85,6 @@ Row {
             font.pixelSize: 11.5 * dpiScale;
             Action {
                 icon.name: "undo";
-                icon.source: "qrc:/resources/icons/svg/undo.svg";
                 text: qsTr("Reset value");
                 enabled: field.value != defaultValue;
                 onTriggered: {
@@ -94,7 +93,6 @@ Row {
             }
             Action {
                 icon.name: "keyframe";
-                icon.source: "qrc:/resources/icons/svg/keyframe.svg";
                 enabled: root.keyframe.length > 0;
                 text: qsTr("Enable keyframing");
                 checked: root.keyframesEnabled;

--- a/src/ui/components/SplitButton.qml
+++ b/src/ui/components/SplitButton.qml
@@ -6,6 +6,11 @@ import QtQuick.Controls as QQC
 
 Button {
     id: root;
+
+    property string iconName;
+    icon.name: iconName || "";
+    icon.source: iconName ? "qrc:/resources/icons/svg/" + iconName + ".svg" : "";
+
     // TODO popup direction
     property alias model: popup.model;
     property alias popup: popup;

--- a/src/ui/components/TableList.qml
+++ b/src/ui/components/TableList.qml
@@ -114,6 +114,7 @@ Row {
                 id: editLinkBtn;
                 anchors.verticalCenter: parent.verticalCenter;
                 icon.name: newValue.visible? "checkmark" : "pencil";
+                icon.source: newValue.visible? "qrc:/resources/icons/svg/checkmark.svg" : "qrc:/resources/icons/svg/pencil.svg";
                 icon.height: parent.height * 0.8;
                 icon.width: parent.height * 0.8;
                 opacity: editLinkBtn.activeFocus ? 0.8 : 1;

--- a/src/ui/components/TableList.qml
+++ b/src/ui/components/TableList.qml
@@ -114,7 +114,6 @@ Row {
                 id: editLinkBtn;
                 anchors.verticalCenter: parent.verticalCenter;
                 icon.name: newValue.visible? "checkmark" : "pencil";
-                icon.source: newValue.visible? "qrc:/resources/icons/svg/checkmark.svg" : "qrc:/resources/icons/svg/pencil.svg";
                 icon.height: parent.height * 0.8;
                 icon.width: parent.height * 0.8;
                 opacity: editLinkBtn.activeFocus ? 0.8 : 1;

--- a/src/ui/components/TableList.qml
+++ b/src/ui/components/TableList.qml
@@ -113,7 +113,7 @@ Row {
             LinkButton {
                 id: editLinkBtn;
                 anchors.verticalCenter: parent.verticalCenter;
-                icon.name: newValue.visible? "checkmark" : "pencil";
+                iconName: newValue.visible? "checkmark" : "pencil";
                 icon.height: parent.height * 0.8;
                 icon.width: parent.height * 0.8;
                 opacity: editLinkBtn.activeFocus ? 0.8 : 1;

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -201,12 +201,14 @@ Item {
                     font.pixelSize: 11.5 * dpiScale;
                     Action {
                         icon.name: "bin;#f67575";
+                        icon.source: "qrc:/resources/icons/svg/bin.svg";
                         text: qsTr("Delete");
                         onTriggered: controller.remove_keyframe(keyframeContextMenu.pressedKeyframe, keyframeContextMenu.pressedKeyframeTs);
                     }
                     Action {
                         id: easeIn;
                         icon.name: "ease_in";
+                        icon.source: "qrc:/resources/icons/svg/ease_in.svg";
                         text: qsTr("Ease in");
                         checkable: true;
                         onTriggered: keyframeContextMenu.updateEasing();
@@ -214,6 +216,7 @@ Item {
                     Action {
                         id: easeOut;
                         icon.name: "ease_out";
+                        icon.source: "qrc:/resources/icons/svg/ease_out.svg";
                         text: qsTr("Ease out");
                         checkable: true;
                         onTriggered: keyframeContextMenu.updateEasing();
@@ -409,6 +412,7 @@ Item {
             Action {
                 id: addCalibAction;
                 icon.name: "plus";
+                icon.source: "qrc:/resources/icons/svg/plus.svg";
                 text: qsTr("Add calibration point");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -419,6 +423,7 @@ Item {
             Action {
                 id: syncHereAction;
                 icon.name: "spinner";
+                icon.source: "qrc:/resources/icons/svg/spinner.svg";
                 text: qsTr("Auto sync here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -428,6 +433,7 @@ Item {
             Action {
                 id: addSyncAction;
                 icon.name: "plus";
+                icon.source: "qrc:/resources/icons/svg/plus.svg";
                 text: qsTr("Add manual sync point here");
                 onTriggered: {
                     const pos = root.position * root.durationMs * 1000; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width)) * root.durationMs * 1000;
@@ -447,6 +453,7 @@ Item {
             Action {
                 id: guessOrientationHere;
                 icon.name: "axes";
+                icon.source: "qrc:/resources/icons/svg/axes.svg";
                 text: qsTr("Guess IMU orientation here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -456,6 +463,7 @@ Item {
             Action {
                 id: estimateRSAction;
                 icon.name: "readout_time";
+                icon.source: "qrc:/resources/icons/svg/readout_time.svg";
                 text: qsTr("Estimate rolling shutter here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -474,11 +482,13 @@ Item {
             Action {
                 id: debiasAction;
                 icon.name: "bias";
+                icon.source: "qrc:/resources/icons/svg/bias.svg";
                 text: qsTr("Estimate gyro bias here");
                 onTriggered: controller.estimate_bias(root.position);
             }
             Action {
                 icon.name: "bin;#f67575";
+                icon.source: "qrc:/resources/icons/svg/bin.svg";
                 text: qsTr("Delete all sync points");
                 onTriggered: controller.clear_offsets();
             }

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -200,20 +200,20 @@ Item {
 
                     font.pixelSize: 11.5 * dpiScale;
                     Action {
-                        icon.name: "bin;#f67575";
+                        iconName: "bin;#f67575";
                         text: qsTr("Delete");
                         onTriggered: controller.remove_keyframe(keyframeContextMenu.pressedKeyframe, keyframeContextMenu.pressedKeyframeTs);
                     }
                     Action {
                         id: easeIn;
-                        icon.name: "ease_in";
+                        iconName: "ease_in";
                         text: qsTr("Ease in");
                         checkable: true;
                         onTriggered: keyframeContextMenu.updateEasing();
                     }
                     Action {
                         id: easeOut;
-                        icon.name: "ease_out";
+                        iconName: "ease_out";
                         text: qsTr("Ease out");
                         checkable: true;
                         onTriggered: keyframeContextMenu.updateEasing();
@@ -408,7 +408,7 @@ Item {
             }
             Action {
                 id: addCalibAction;
-                icon.name: "plus";
+                iconName: "plus";
                 text: qsTr("Add calibration point");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -418,7 +418,7 @@ Item {
             QQC.MenuSeparator { id: msep; verticalPadding: 5 * dpiScale; }
             Action {
                 id: syncHereAction;
-                icon.name: "spinner";
+                iconName: "spinner";
                 text: qsTr("Auto sync here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -427,7 +427,7 @@ Item {
             }
             Action {
                 id: addSyncAction;
-                icon.name: "plus";
+                iconName: "plus";
                 text: qsTr("Add manual sync point here");
                 onTriggered: {
                     const pos = root.position * root.durationMs * 1000; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width)) * root.durationMs * 1000;
@@ -446,7 +446,7 @@ Item {
             }
             Action {
                 id: guessOrientationHere;
-                icon.name: "axes";
+                iconName: "axes";
                 text: qsTr("Guess IMU orientation here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -455,7 +455,7 @@ Item {
             }
             Action {
                 id: estimateRSAction;
-                icon.name: "readout_time";
+                iconName: "readout_time";
                 text: qsTr("Estimate rolling shutter here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -473,12 +473,12 @@ Item {
             }
             Action {
                 id: debiasAction;
-                icon.name: "bias";
+                iconName: "bias";
                 text: qsTr("Estimate gyro bias here");
                 onTriggered: controller.estimate_bias(root.position);
             }
             Action {
-                icon.name: "bin;#f67575";
+                iconName: "bin;#f67575";
                 text: qsTr("Delete all sync points");
                 onTriggered: controller.clear_offsets();
             }

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -201,14 +201,12 @@ Item {
                     font.pixelSize: 11.5 * dpiScale;
                     Action {
                         icon.name: "bin;#f67575";
-                        icon.source: "qrc:/resources/icons/svg/bin.svg";
                         text: qsTr("Delete");
                         onTriggered: controller.remove_keyframe(keyframeContextMenu.pressedKeyframe, keyframeContextMenu.pressedKeyframeTs);
                     }
                     Action {
                         id: easeIn;
                         icon.name: "ease_in";
-                        icon.source: "qrc:/resources/icons/svg/ease_in.svg";
                         text: qsTr("Ease in");
                         checkable: true;
                         onTriggered: keyframeContextMenu.updateEasing();
@@ -216,7 +214,6 @@ Item {
                     Action {
                         id: easeOut;
                         icon.name: "ease_out";
-                        icon.source: "qrc:/resources/icons/svg/ease_out.svg";
                         text: qsTr("Ease out");
                         checkable: true;
                         onTriggered: keyframeContextMenu.updateEasing();
@@ -412,7 +409,6 @@ Item {
             Action {
                 id: addCalibAction;
                 icon.name: "plus";
-                icon.source: "qrc:/resources/icons/svg/plus.svg";
                 text: qsTr("Add calibration point");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -423,7 +419,6 @@ Item {
             Action {
                 id: syncHereAction;
                 icon.name: "spinner";
-                icon.source: "qrc:/resources/icons/svg/spinner.svg";
                 text: qsTr("Auto sync here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -433,7 +428,6 @@ Item {
             Action {
                 id: addSyncAction;
                 icon.name: "plus";
-                icon.source: "qrc:/resources/icons/svg/plus.svg";
                 text: qsTr("Add manual sync point here");
                 onTriggered: {
                     const pos = root.position * root.durationMs * 1000; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width)) * root.durationMs * 1000;
@@ -453,7 +447,6 @@ Item {
             Action {
                 id: guessOrientationHere;
                 icon.name: "axes";
-                icon.source: "qrc:/resources/icons/svg/axes.svg";
                 text: qsTr("Guess IMU orientation here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -463,7 +456,6 @@ Item {
             Action {
                 id: estimateRSAction;
                 icon.name: "readout_time";
-                icon.source: "qrc:/resources/icons/svg/readout_time.svg";
                 text: qsTr("Estimate rolling shutter here");
                 onTriggered: {
                     const pos = root.position; // (root.mapFromVisibleArea(timelineContextMenu.pressedX / ma.width));
@@ -482,13 +474,11 @@ Item {
             Action {
                 id: debiasAction;
                 icon.name: "bias";
-                icon.source: "qrc:/resources/icons/svg/bias.svg";
                 text: qsTr("Estimate gyro bias here");
                 onTriggered: controller.estimate_bias(root.position);
             }
             Action {
                 icon.name: "bin;#f67575";
-                icon.source: "qrc:/resources/icons/svg/bin.svg";
                 text: qsTr("Delete all sync points");
                 onTriggered: controller.clear_offsets();
             }

--- a/src/ui/components/TimelineSyncPoint.qml
+++ b/src/ui/components/TimelineSyncPoint.qml
@@ -83,17 +83,20 @@ Rectangle {
                 id: editAction;
                 text: qsTr("Edit offset");
                 icon.name: "pencil";
+                icon.source: "qrc:/resources/icons/svg/pencil.svg";
                 onTriggered: root.edit(root.org_timestamp_us, root.value);
             }
             Action {
                 text: isCalibPoint? qsTr("Delete calibration point") : qsTr("Delete sync point");
                 icon.name: "bin;#f67575";
+                icon.source: "qrc:/resources/icons/svg/bin.svg";
                 onTriggered: root.remove(root.org_timestamp_us);
             }
             Action {
                 id: zoomAction;
                 text: qsTr("Zoom in");
                 icon.name: "search";
+                icon.source: "qrc:/resources/icons/svg/search.svg";
                 onTriggered: root.zoomIn(root.org_timestamp_us + root.value * 1000.0);
             }
             Component.onCompleted: {

--- a/src/ui/components/TimelineSyncPoint.qml
+++ b/src/ui/components/TimelineSyncPoint.qml
@@ -82,18 +82,18 @@ Rectangle {
             Action {
                 id: editAction;
                 text: qsTr("Edit offset");
-                icon.name: "pencil";
+                iconName: "pencil";
                 onTriggered: root.edit(root.org_timestamp_us, root.value);
             }
             Action {
                 text: isCalibPoint? qsTr("Delete calibration point") : qsTr("Delete sync point");
-                icon.name: "bin;#f67575";
+                iconName: "bin;#f67575";
                 onTriggered: root.remove(root.org_timestamp_us);
             }
             Action {
                 id: zoomAction;
                 text: qsTr("Zoom in");
-                icon.name: "search";
+                iconName: "search";
                 onTriggered: root.zoomIn(root.org_timestamp_us + root.value * 1000.0);
             }
             Component.onCompleted: {

--- a/src/ui/components/TimelineSyncPoint.qml
+++ b/src/ui/components/TimelineSyncPoint.qml
@@ -83,20 +83,17 @@ Rectangle {
                 id: editAction;
                 text: qsTr("Edit offset");
                 icon.name: "pencil";
-                icon.source: "qrc:/resources/icons/svg/pencil.svg";
                 onTriggered: root.edit(root.org_timestamp_us, root.value);
             }
             Action {
                 text: isCalibPoint? qsTr("Delete calibration point") : qsTr("Delete sync point");
                 icon.name: "bin;#f67575";
-                icon.source: "qrc:/resources/icons/svg/bin.svg";
                 onTriggered: root.remove(root.org_timestamp_us);
             }
             Action {
                 id: zoomAction;
                 text: qsTr("Zoom in");
                 icon.name: "search";
-                icon.source: "qrc:/resources/icons/svg/search.svg";
                 onTriggered: root.zoomIn(root.org_timestamp_us + root.value * 1000.0);
             }
             Component.onCompleted: {

--- a/src/ui/menu/Advanced.qml
+++ b/src/ui/menu/Advanced.qml
@@ -9,6 +9,7 @@ import "../components/"
 MenuItem {
     text: qsTr("Advanced");
     icon: "settings";
+    iconSource: "qrc:/resources/icons/svg/settings.svg";
     opened: false;
     objectName: "advanced";
 

--- a/src/ui/menu/Advanced.qml
+++ b/src/ui/menu/Advanced.qml
@@ -9,7 +9,6 @@ import "../components/"
 MenuItem {
     text: qsTr("Advanced");
     icon: "settings";
-    iconSource: "qrc:/resources/icons/svg/settings.svg";
     opened: false;
     objectName: "advanced";
 

--- a/src/ui/menu/Advanced.qml
+++ b/src/ui/menu/Advanced.qml
@@ -8,7 +8,7 @@ import "../components/"
 
 MenuItem {
     text: qsTr("Advanced");
-    icon: "settings";
+    iconName: "settings";
     opened: false;
     objectName: "advanced";
 

--- a/src/ui/menu/Export.qml
+++ b/src/ui/menu/Export.qml
@@ -12,6 +12,7 @@ MenuItem {
     id: root;
     text: qsTr("Export settings");
     icon: "save";
+    iconSource: "qrc:/resources/icons/svg/save.svg";
     innerItem.enabled: window.videoArea.vid.loaded;
     objectName: "export";
 
@@ -226,6 +227,7 @@ MenuItem {
                 checked: true;
                 height: parent.height * 0.75;
                 icon.name: checked? "lock" : "unlocked";
+                icon.source: checked? "qrc:/resources/icons/svg/lock.svg" : "qrc:/resources/icons/svg/unlocked.svg";
                 topPadding: 4 * dpiScale;
                 bottomPadding: 4 * dpiScale;
                 leftPadding: 3 * dpiScale;
@@ -262,6 +264,7 @@ MenuItem {
                 id: sizeMenuBtn;
                 height: parent.height;
                 icon.name: "settings";
+                icon.source: "qrc:/resources/icons/svg/settings.svg";
                 leftPadding: 3 * dpiScale;
                 rightPadding: 3 * dpiScale;
                 anchors.verticalCenter: parent.verticalCenter;
@@ -373,6 +376,7 @@ MenuItem {
                 id: encoderOptionsInfo;
                 height: parent.height;
                 icon.name: "info";
+                icon.source: "qrc:/resources/icons/svg/info.svg";
                 leftPadding: 3 * dpiScale;
                 rightPadding: 3 * dpiScale;
                 y: -encoderOptions.height;

--- a/src/ui/menu/Export.qml
+++ b/src/ui/menu/Export.qml
@@ -11,7 +11,7 @@ import "../Util.js" as Util;
 MenuItem {
     id: root;
     text: qsTr("Export settings");
-    icon: "save";
+    iconName: "save";
     innerItem.enabled: window.videoArea.vid.loaded;
     objectName: "export";
 
@@ -372,7 +372,7 @@ MenuItem {
             LinkButton {
                 id: encoderOptionsInfo;
                 height: parent.height;
-                icon.name: "info";
+                iconName: "info";
                 leftPadding: 3 * dpiScale;
                 rightPadding: 3 * dpiScale;
                 y: -encoderOptions.height;

--- a/src/ui/menu/Export.qml
+++ b/src/ui/menu/Export.qml
@@ -225,7 +225,7 @@ MenuItem {
                 id: lockAspectRatio;
                 checked: true;
                 height: parent.height * 0.75;
-                icon.name: checked? "lock" : "unlocked";
+                iconName: checked? "lock" : "unlocked";
                 topPadding: 4 * dpiScale;
                 bottomPadding: 4 * dpiScale;
                 leftPadding: 3 * dpiScale;
@@ -261,7 +261,7 @@ MenuItem {
             LinkButton {
                 id: sizeMenuBtn;
                 height: parent.height;
-                icon.name: "settings";
+                iconName: "settings";
                 leftPadding: 3 * dpiScale;
                 rightPadding: 3 * dpiScale;
                 anchors.verticalCenter: parent.verticalCenter;

--- a/src/ui/menu/Export.qml
+++ b/src/ui/menu/Export.qml
@@ -12,7 +12,6 @@ MenuItem {
     id: root;
     text: qsTr("Export settings");
     icon: "save";
-    iconSource: "qrc:/resources/icons/svg/save.svg";
     innerItem.enabled: window.videoArea.vid.loaded;
     objectName: "export";
 
@@ -227,7 +226,6 @@ MenuItem {
                 checked: true;
                 height: parent.height * 0.75;
                 icon.name: checked? "lock" : "unlocked";
-                icon.source: checked? "qrc:/resources/icons/svg/lock.svg" : "qrc:/resources/icons/svg/unlocked.svg";
                 topPadding: 4 * dpiScale;
                 bottomPadding: 4 * dpiScale;
                 leftPadding: 3 * dpiScale;
@@ -264,7 +262,6 @@ MenuItem {
                 id: sizeMenuBtn;
                 height: parent.height;
                 icon.name: "settings";
-                icon.source: "qrc:/resources/icons/svg/settings.svg";
                 leftPadding: 3 * dpiScale;
                 rightPadding: 3 * dpiScale;
                 anchors.verticalCenter: parent.verticalCenter;
@@ -376,7 +373,6 @@ MenuItem {
                 id: encoderOptionsInfo;
                 height: parent.height;
                 icon.name: "info";
-                icon.source: "qrc:/resources/icons/svg/info.svg";
                 leftPadding: 3 * dpiScale;
                 rightPadding: 3 * dpiScale;
                 y: -encoderOptions.height;

--- a/src/ui/menu/LensCalibrate.qml
+++ b/src/ui/menu/LensCalibrate.qml
@@ -10,7 +10,7 @@ import "../components/"
 MenuItem {
     id: calib;
     text: qsTr("Calibration");
-    icon: "lens";
+    iconName: "lens";
     innerItem.enabled: !controller.calib_in_progress;
     loader: controller.calib_in_progress;
     objectName: "lenscalib";

--- a/src/ui/menu/LensCalibrate.qml
+++ b/src/ui/menu/LensCalibrate.qml
@@ -11,7 +11,6 @@ MenuItem {
     id: calib;
     text: qsTr("Calibration");
     icon: "lens";
-    iconSource: "qrc:/resources/icons/svg/lens.svg";
     innerItem.enabled: !controller.calib_in_progress;
     loader: controller.calib_in_progress;
     objectName: "lenscalib";
@@ -167,7 +166,6 @@ MenuItem {
         text: qsTr("Auto calibrate");
         enabled: calibrator_window.videoArea.vid.loaded;
         icon.name: "spinner"
-        icon.source: "qrc:/resources/icons/svg/spinner.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: {
             controller.start_autocalibrate(maxPoints.value, everyNthFrame.value, iterations.value, maxSharpness.value, -1, noMarker.checked);
@@ -295,7 +293,6 @@ MenuItem {
         text: qsTr("Export lens profile");
         accent: true;
         icon.name: "save"
-        icon.source: "qrc:/resources/icons/svg/save.svg";
         enabled: rms.value > 0 && rms.value < 100 && calibrator_window.videoArea.vid.loaded;
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: {

--- a/src/ui/menu/LensCalibrate.qml
+++ b/src/ui/menu/LensCalibrate.qml
@@ -11,6 +11,7 @@ MenuItem {
     id: calib;
     text: qsTr("Calibration");
     icon: "lens";
+    iconSource: "qrc:/resources/icons/svg/lens.svg";
     innerItem.enabled: !controller.calib_in_progress;
     loader: controller.calib_in_progress;
     objectName: "lenscalib";
@@ -166,6 +167,7 @@ MenuItem {
         text: qsTr("Auto calibrate");
         enabled: calibrator_window.videoArea.vid.loaded;
         icon.name: "spinner"
+        icon.source: "qrc:/resources/icons/svg/spinner.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: {
             controller.start_autocalibrate(maxPoints.value, everyNthFrame.value, iterations.value, maxSharpness.value, -1, noMarker.checked);
@@ -293,6 +295,7 @@ MenuItem {
         text: qsTr("Export lens profile");
         accent: true;
         icon.name: "save"
+        icon.source: "qrc:/resources/icons/svg/save.svg";
         enabled: rms.value > 0 && rms.value < 100 && calibrator_window.videoArea.vid.loaded;
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: {

--- a/src/ui/menu/LensCalibrate.qml
+++ b/src/ui/menu/LensCalibrate.qml
@@ -165,7 +165,7 @@ MenuItem {
         id: autoCalibBtn;
         text: qsTr("Auto calibrate");
         enabled: calibrator_window.videoArea.vid.loaded;
-        icon.name: "spinner"
+        iconName: "spinner"
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: {
             controller.start_autocalibrate(maxPoints.value, everyNthFrame.value, iterations.value, maxSharpness.value, -1, noMarker.checked);
@@ -292,7 +292,7 @@ MenuItem {
     Button {
         text: qsTr("Export lens profile");
         accent: true;
-        icon.name: "save"
+        iconName: "save"
         enabled: rms.value > 0 && rms.value < 100 && calibrator_window.videoArea.vid.loaded;
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: {

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -9,7 +9,7 @@ import "../components/"
 MenuItem {
     id: root;
     text: qsTr("Lens profile");
-    icon: "lens";
+    iconName: "lens";
     objectName: "lens";
 
     property int calibWidth: 0;

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -137,12 +137,12 @@ MenuItem {
         spacing: 10 * dpiScale;
         Button {
             text: qsTr("Open file");
-            icon.name: "file-empty"
+            iconName: "file-empty"
             onClicked: fileDialog.open2();
         }
         Button {
             text: qsTr("Create new");
-            icon.name: "plus";
+            iconName: "plus";
             icon.width: 15 * dpiScale;
             icon.height: 15 * dpiScale;
             property var calibratorWnd: null;

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -10,6 +10,7 @@ MenuItem {
     id: root;
     text: qsTr("Lens profile");
     icon: "lens";
+    iconSource: "qrc:/resources/icons/svg/lens.svg";
     objectName: "lens";
 
     property int calibWidth: 0;
@@ -138,11 +139,13 @@ MenuItem {
         Button {
             text: qsTr("Open file");
             icon.name: "file-empty"
+            icon.source: "qrc:/resources/icons/svg/file-empty.svg";
             onClicked: fileDialog.open2();
         }
         Button {
             text: qsTr("Create new");
             icon.name: "plus";
+            icon.source: "qrc:/resources/icons/svg/plus.svg";
             icon.width: 15 * dpiScale;
             icon.height: 15 * dpiScale;
             property var calibratorWnd: null;

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -10,7 +10,6 @@ MenuItem {
     id: root;
     text: qsTr("Lens profile");
     icon: "lens";
-    iconSource: "qrc:/resources/icons/svg/lens.svg";
     objectName: "lens";
 
     property int calibWidth: 0;
@@ -139,13 +138,11 @@ MenuItem {
         Button {
             text: qsTr("Open file");
             icon.name: "file-empty"
-            icon.source: "qrc:/resources/icons/svg/file-empty.svg";
             onClicked: fileDialog.open2();
         }
         Button {
             text: qsTr("Create new");
             icon.name: "plus";
-            icon.source: "qrc:/resources/icons/svg/plus.svg";
             icon.width: 15 * dpiScale;
             icon.height: 15 * dpiScale;
             property var calibratorWnd: null;

--- a/src/ui/menu/MotionData.qml
+++ b/src/ui/menu/MotionData.qml
@@ -10,7 +10,6 @@ MenuItem {
     id: root;
     text: qsTr("Motion data");
     icon: "chart";
-    iconSource: "qrc:/resources/icons/svg/chart.svg";
     loader: controller.loading_gyro_in_progress;
     objectName: "motiondata";
 
@@ -115,7 +114,6 @@ MenuItem {
     Button {
         text: qsTr("Open file");
         icon.name: "file-empty"
-        icon.source: "qrc:/resources/icons/svg/file-empty.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: fileDialog.open2();
     }
@@ -223,7 +221,6 @@ MenuItem {
             Action {
                 id: arot_action;
                 icon.name: "axes";
-                icon.source: "qrc:/resources/icons/svg/axes.svg";
                 text: qsTr("Separate accelerometer rotation");
                 checkable: true;
             }

--- a/src/ui/menu/MotionData.qml
+++ b/src/ui/menu/MotionData.qml
@@ -220,7 +220,7 @@ MenuItem {
             font.pixelSize: 11.5 * dpiScale;
             Action {
                 id: arot_action;
-                icon.name: "axes";
+                iconName: "axes";
                 text: qsTr("Separate accelerometer rotation");
                 checkable: true;
             }

--- a/src/ui/menu/MotionData.qml
+++ b/src/ui/menu/MotionData.qml
@@ -9,7 +9,7 @@ import "../components/"
 MenuItem {
     id: root;
     text: qsTr("Motion data");
-    icon: "chart";
+    iconName: "chart";
     loader: controller.loading_gyro_in_progress;
     objectName: "motiondata";
 

--- a/src/ui/menu/MotionData.qml
+++ b/src/ui/menu/MotionData.qml
@@ -10,6 +10,7 @@ MenuItem {
     id: root;
     text: qsTr("Motion data");
     icon: "chart";
+    iconSource: "qrc:/resources/icons/svg/chart.svg";
     loader: controller.loading_gyro_in_progress;
     objectName: "motiondata";
 
@@ -114,6 +115,7 @@ MenuItem {
     Button {
         text: qsTr("Open file");
         icon.name: "file-empty"
+        icon.source: "qrc:/resources/icons/svg/file-empty.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: fileDialog.open2();
     }
@@ -221,6 +223,7 @@ MenuItem {
             Action {
                 id: arot_action;
                 icon.name: "axes";
+                icon.source: "qrc:/resources/icons/svg/axes.svg";
                 text: qsTr("Separate accelerometer rotation");
                 checkable: true;
             }

--- a/src/ui/menu/MotionData.qml
+++ b/src/ui/menu/MotionData.qml
@@ -113,7 +113,7 @@ MenuItem {
 
     Button {
         text: qsTr("Open file");
-        icon.name: "file-empty"
+        iconName: "file-empty"
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: fileDialog.open2();
     }

--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -9,7 +9,7 @@ import "../components/"
 MenuItem {
     id: root;
     text: qsTr("Stabilization");
-    icon: "gyroflow";
+    iconName: "gyroflow";
     innerItem.enabled: window.videoArea.vid.loaded;
     objectName: "stabilization";
 

--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -10,7 +10,6 @@ MenuItem {
     id: root;
     text: qsTr("Stabilization");
     icon: "gyroflow";
-    iconSource: "qrc:/resources/icons/svg/gyroflow.svg";
     innerItem.enabled: window.videoArea.vid.loaded;
     objectName: "stabilization";
 

--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -10,6 +10,7 @@ MenuItem {
     id: root;
     text: qsTr("Stabilization");
     icon: "gyroflow";
+    iconSource: "qrc:/resources/icons/svg/gyroflow.svg";
     innerItem.enabled: window.videoArea.vid.loaded;
     objectName: "stabilization";
 

--- a/src/ui/menu/Synchronization.qml
+++ b/src/ui/menu/Synchronization.qml
@@ -9,7 +9,7 @@ import "../components/"
 MenuItem {
     id: sync;
     text: qsTr("Synchronization");
-    icon: "sync";
+    iconName: "sync";
     innerItem.enabled: window.videoArea.vid.loaded && !controller.sync_in_progress;
     loader: controller.sync_in_progress;
     objectName: "synchronization";

--- a/src/ui/menu/Synchronization.qml
+++ b/src/ui/menu/Synchronization.qml
@@ -10,7 +10,6 @@ MenuItem {
     id: sync;
     text: qsTr("Synchronization");
     icon: "sync";
-    iconSource: "qrc:/resources/icons/svg/sync.svg";
     innerItem.enabled: window.videoArea.vid.loaded && !controller.sync_in_progress;
     loader: controller.sync_in_progress;
     objectName: "synchronization";
@@ -80,7 +79,6 @@ MenuItem {
         id: autosync;
         text: qsTr("Auto sync");
         icon.name: "spinner"
-        icon.source: "qrc:/resources/icons/svg/spinner.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         enabled: controller.gyro_loaded;
         tooltip: !enabled? qsTr("No motion data loaded, cannot sync.") : "";

--- a/src/ui/menu/Synchronization.qml
+++ b/src/ui/menu/Synchronization.qml
@@ -78,7 +78,7 @@ MenuItem {
     Button {
         id: autosync;
         text: qsTr("Auto sync");
-        icon.name: "spinner"
+        iconName: "spinner"
         anchors.horizontalCenter: parent.horizontalCenter;
         enabled: controller.gyro_loaded;
         tooltip: !enabled? qsTr("No motion data loaded, cannot sync.") : "";

--- a/src/ui/menu/Synchronization.qml
+++ b/src/ui/menu/Synchronization.qml
@@ -10,6 +10,7 @@ MenuItem {
     id: sync;
     text: qsTr("Synchronization");
     icon: "sync";
+    iconSource: "qrc:/resources/icons/svg/sync.svg";
     innerItem.enabled: window.videoArea.vid.loaded && !controller.sync_in_progress;
     loader: controller.sync_in_progress;
     objectName: "synchronization";
@@ -79,6 +80,7 @@ MenuItem {
         id: autosync;
         text: qsTr("Auto sync");
         icon.name: "spinner"
+        icon.source: "qrc:/resources/icons/svg/spinner.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         enabled: controller.gyro_loaded;
         tooltip: !enabled? qsTr("No motion data loaded, cannot sync.") : "";

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -10,7 +10,6 @@ MenuItem {
     id: root;
     text: qsTr("Video information");
     icon: "info";
-    iconSource: "qrc:/resources/icons/svg/info.svg";
     objectName: "info";
 
     property real videoRotation: 0;
@@ -126,7 +125,6 @@ MenuItem {
     Button {
         text: qsTr("Open file");
         icon.name: "video"
-        icon.source: "qrc:/resources/icons/svg/video.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: root.selectFileRequest();
     }

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -10,6 +10,7 @@ MenuItem {
     id: root;
     text: qsTr("Video information");
     icon: "info";
+    iconSource: "qrc:/resources/icons/svg/info.svg";
     objectName: "info";
 
     property real videoRotation: 0;
@@ -125,6 +126,7 @@ MenuItem {
     Button {
         text: qsTr("Open file");
         icon.name: "video"
+        icon.source: "qrc:/resources/icons/svg/video.svg";
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: root.selectFileRequest();
     }

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -124,7 +124,7 @@ MenuItem {
 
     Button {
         text: qsTr("Open file");
-        icon.name: "video"
+        iconName: "video"
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: root.selectFileRequest();
     }

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -9,7 +9,7 @@ import "../components/"
 MenuItem {
     id: root;
     text: qsTr("Video information");
-    icon: "info";
+    iconName: "info";
     objectName: "info";
 
     property real videoRotation: 0;


### PR DESCRIPTION
Add backup icon.source in case theme fails to load
https://doc.qt.io/qt-6/qtquickcontrols2-icons.html
"Both icon.name and icon.source can be set to ensure that an icon will always be found. If the icon is found in the theme, it will always be used; even if icon.source is also set."

Update qml-video-rs version to allow build - see:
https://github.com/AdrianEddy/qml-video-rs/pull/2

On opensuse tumbleweed:
![image](https://user-images.githubusercontent.com/33307206/180691992-24ad55e0-b57e-4494-a9bc-5def065bb850.png)
