### PR TITLE
Timeline keyframe navigation shortcuts

### DIFF
--- a/src/core/keyframes.rs
+++ b/src/core/keyframes.rs
@@ -164,6 +164,37 @@ impl KeyframeManager {
             self.keyframes = kf;
         }
     }
+
+    pub fn next_keyframe(&self, ts: i64, typ: Option<KeyframeType>) -> Option<(KeyframeType, i64, Keyframe)> {
+        if let Some(kf) = typ {
+            if let Some(entries) = self.keyframes.get(&kf) {
+                if let Some(res) = entries.range(ts+1..).next() {
+                    return Some((kf, *res.0, *res.1));
+                }
+            }
+        } else {
+            return self.keyframes
+                .iter()
+                .filter_map(|(&k, _)| self.next_keyframe(ts, Some(k)) )
+                .min_by_key(|(_nt, nts, _nk)| (nts - ts).abs());
+        }
+        None
+    }
+    pub fn prev_keyframe(&self, ts: i64, typ: Option<KeyframeType>) -> Option<(KeyframeType, i64, Keyframe)> {
+       if let Some(kf) = typ {
+            if let Some(entries) = self.keyframes.get(&kf) {
+                if let Some(res) = entries.range(..ts).next_back() {
+                    return Some((kf, *res.0, *res.1));
+                }
+            }
+        } else {
+            return self.keyframes
+                .iter()
+                .filter_map(|(&k, _)| self.prev_keyframe(ts, Some(k)) )
+                .min_by_key(|(_nt, nts, _nk)| (nts - ts).abs());
+        }
+        None
+    }
 }
 
 impl FromStr for KeyframeType {

--- a/src/ui/Shortcuts.qml
+++ b/src/ui/Shortcuts.qml
@@ -136,4 +136,14 @@ Item {
         sequence: "Esc";
         onActivated: videoArea.fullScreen = false;
     }
+    // Next keyframe
+    Shortcut {
+        sequence: "Shift+Right";
+        onActivated: videoArea.timeline.jumpToNextKeyframe("");
+    }
+    // Previous keyframe
+    Shortcut {
+        sequence: "Shift+Left";
+        onActivated: videoArea.timeline.jumpToPrevKeyframe("");
+    }
 }

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -90,6 +90,21 @@ Item {
         Qt.callLater(controller.update_keyframes_view, keyframes);
     }
 
+    function jumpToNextKeyframe(typ: string) {
+        const kf = keyframes.nextKeyframe(typ);
+        if (kf) {
+            const [keyframe, timestamp, name, value] = kf.split(":", 4);
+            vid.setTimestamp(timestamp / 1000);
+        }
+    }
+    function jumpToPrevKeyframe(typ: string) {
+        const kf = keyframes.prevKeyframe(typ);
+        if (kf) {
+            const [keyframe, timestamp, name, value] = kf.split(":", 4);
+            vid.setTimestamp(timestamp / 1000);
+        }
+    }
+
     Settings {
         property alias timelineChart: chart.viewMode;
     }

--- a/src/ui/components/TimelineKeyframesView.rs
+++ b/src/ui/components/TimelineKeyframesView.rs
@@ -3,7 +3,7 @@
 
 #![allow(non_snake_case)]
 
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, str::FromStr};
 
 use gyroflow_core::keyframes::*;
 use qmetaobject::*;
@@ -35,6 +35,9 @@ pub struct TimelineKeyframesView {
     setDurationMs: qt_method!(fn(&mut self, v: f64)),
     keyframeAtXY: qt_method!(fn(&self, x: f64, y: f64) -> QJSValue),
 
+    nextKeyframe: qt_method!(fn(&self, typ: String) -> QJSValue),
+    prevKeyframe: qt_method!(fn(&self, typ: String) -> QJSValue),
+
     series: BTreeMap<KeyframeType, Series>,
 
     mgr: KeyframeManager,
@@ -59,6 +62,21 @@ impl TimelineKeyframesView {
             }
         }
 
+        QJSValue::default()
+    }
+
+    fn nextKeyframe(&self, typ: String) -> QJSValue {
+        if let Some(res) = self.mgr.next_keyframe((self.videoTimestamp * 1000.0) as i64, KeyframeType::from_str(&typ).ok()) {
+            dbg!("{:?}",res);
+            return QJSValue::from(QString::from(format!("{:?}:{}:{}:{}", res.0, res.1, keyframe_text(&res.0), keyframe_format_value(&res.0, res.2.value))));
+        }
+        QJSValue::default()
+    }
+    fn prevKeyframe(&self, typ: String) -> QJSValue {
+        if let Some(res) = self.mgr.prev_keyframe((self.videoTimestamp * 1000.0) as i64, KeyframeType::from_str(&typ).ok()) {
+            dbg!("{:?}",res);
+            return QJSValue::from(QString::from(format!("{:?}:{}:{}:{}", res.0, res.1, keyframe_text(&res.0), keyframe_format_value(&res.0, res.2.value))));
+        }
         QJSValue::default()
     }
 

--- a/src/ui/components/TimelineKeyframesView.rs
+++ b/src/ui/components/TimelineKeyframesView.rs
@@ -67,14 +67,12 @@ impl TimelineKeyframesView {
 
     fn nextKeyframe(&self, typ: String) -> QJSValue {
         if let Some(res) = self.mgr.next_keyframe((self.videoTimestamp * 1000.0) as i64, KeyframeType::from_str(&typ).ok()) {
-            dbg!("{:?}",res);
             return QJSValue::from(QString::from(format!("{:?}:{}:{}:{}", res.0, res.1, keyframe_text(&res.0), keyframe_format_value(&res.0, res.2.value))));
         }
         QJSValue::default()
     }
     fn prevKeyframe(&self, typ: String) -> QJSValue {
         if let Some(res) = self.mgr.prev_keyframe((self.videoTimestamp * 1000.0) as i64, KeyframeType::from_str(&typ).ok()) {
-            dbg!("{:?}",res);
             return QJSValue::from(QString::from(format!("{:?}:{}:{}:{}", res.0, res.1, keyframe_text(&res.0), keyframe_format_value(&res.0, res.2.value))));
         }
         QJSValue::default()


### PR DESCRIPTION
Added helper functions for retrieving keyframes before or after a timestamp
- can be used for only one specific keyframe type or all types at once
- added keyboard shortcuts `Shift+Left` & `Shift+Right` to navigate through the keyframes in the timeline