### PR TITLE
Use slider context menu for adjacent number field

### DIFF
--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -21,8 +21,8 @@ TextField {
     property string keyframe: "";
     property bool keyframesEnabled: false;
     property real finalValue: value;
-    
-    property var contextMenu: defaultContextMenu;
+
+    property Menu contextMenu: defaultContextMenu;
 
     onFinalValueChanged: {
         if (keyframe && keyframesEnabled) {

--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -21,6 +21,8 @@ TextField {
     property string keyframe: "";
     property bool keyframesEnabled: false;
     property real finalValue: value;
+    
+    property var contextMenu: defaultContextMenu;
 
     onFinalValueChanged: {
         if (keyframe && keyframesEnabled) {
@@ -112,7 +114,7 @@ TextField {
     }
 
     Menu {
-        id: contextMenu;
+        id: defaultContextMenu;
         font.pixelSize: 11.5 * dpiScale;
         Action {
             iconName: "undo";

--- a/src/ui/components/SliderWithField.qml
+++ b/src/ui/components/SliderWithField.qml
@@ -23,6 +23,8 @@ Row {
     property bool preventChange: false;
 
     property real value: defaultValue;
+    
+    property var contextMenu: defaultContextMenu;
 
     onValueChanged: {
         if (!root.preventChange) {
@@ -81,7 +83,7 @@ Row {
         }
 
         Menu {
-            id: contextMenu;
+            id: defaultContextMenu;
             font.pixelSize: 11.5 * dpiScale;
             Action {
                 iconName: "undo";
@@ -113,6 +115,7 @@ Row {
         precision: 3;
         font.pixelSize: 11 * dpiScale;
         anchors.verticalCenter: parent.verticalCenter;
+        contextMenu: root.contextMenu;
         onValueChanged: {
             slider.preventChange = true;
             slider.value = value;

--- a/src/ui/components/SliderWithField.qml
+++ b/src/ui/components/SliderWithField.qml
@@ -24,7 +24,7 @@ Row {
 
     property real value: defaultValue;
     
-    property var contextMenu: defaultContextMenu;
+    property Menu contextMenu: defaultContextMenu;
 
     onValueChanged: {
         if (!root.preventChange) {


### PR DESCRIPTION
The context menu of number fields adjacent to sliders wasn't showing "Enable Keyframes" as available, because the number fields itself have the keyframe property not set. 

With this change we just use the same context menu for the number field, as we have for the slider.