### PR TITLE
Stop editing sync points, when deleting all of them

### DIFF
--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -495,7 +495,10 @@ Item {
             Action {
                 iconName: "bin;#f67575";
                 text: qsTr("Delete all sync points");
-                onTriggered: controller.clear_offsets();
+                onTriggered: {
+                    root.editingSyncPoint = false;
+                    controller.clear_offsets();
+                }
             }
             QQC.MenuSeparator { verticalPadding: 5 * dpiScale; }
             Menu {


### PR DESCRIPTION
When editing a sync point and then triggering "Delete all sync points" from the timeline, now closes the editing process