### PR TITLE
Update controls for keyframe changes in timeline

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -219,7 +219,7 @@ pub struct Controller {
     keyframe_value_at_video_timestamp: qt_method!(fn(&self, typ: String, timestamp_ms: f64) -> QJSValue),
 
     keyframe_value_updated: qt_signal!(keyframe: String, value: f64),
-    video_position_changed: qt_method!(fn(&self, timestamp_ms: f64)),
+    update_keyframe_values: qt_method!(fn(&self, timestamp_ms: f64)),
 
     preview_resolution: i32,
 
@@ -1344,7 +1344,7 @@ impl Controller {
         QJSValue::default()
     }
 
-    fn video_position_changed(&self, mut timestamp_ms: f64) {
+    fn update_keyframe_values(&self, mut timestamp_ms: f64) {
         let keyframes = self.stabilizer.keyframes.read();
         timestamp_ms /= keyframes.timestamp_scale.unwrap_or(1.0);
         for kf in keyframes.get_all_keys() {

--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -196,6 +196,7 @@ Item {
         }
         function onKeyframes_changed() {
             Qt.callLater(controller.update_keyframes_view, timeline.getKeyframesView());
+            Qt.callLater(controller.update_keyframe_values, vid.timestamp);
         }
     }
     Timer {
@@ -263,7 +264,7 @@ Item {
 
                 onCurrentFrameChanged: {
                     fovChanged();
-                    controller.video_position_changed(timestamp);
+                    controller.update_keyframe_values(timestamp);
                 }
                 onMetadataLoaded: (md) => {
                     loaded = duration > 0;


### PR DESCRIPTION
When keyframes getting changed in timeline (delete / ease), update the controls in the sidepanel.