### PR TITLE
Fix rolling shutter bug

### DIFF
--- a/src/core/stabilization/frame_transform.rs
+++ b/src/core/stabilization/frame_transform.rs
@@ -89,9 +89,9 @@ impl FrameTransform {
             } else {
                 timestamp_ms
             };
-            let quat = quat1
-                     * params.gyro.org_quat_at_timestamp(quat_time)
-                     * params.gyro.smoothed_quat_at_timestamp(quat_time);
+            let quat = params.gyro.smoothed_quat_at_timestamp(quat_time)
+                     * quat1
+                     * params.gyro.org_quat_at_timestamp(quat_time);
 
             let mut r = image_rotation * *quat.to_rotation_matrix().matrix();
             if params.framebuffer_inverted {
@@ -170,9 +170,9 @@ impl FrameTransform {
             } else {
                 timestamp_ms
             };
-            let quat = quat1
-                     * params.gyro.org_quat_at_timestamp(quat_time)
-                     * params.gyro.smoothed_quat_at_timestamp(quat_time);
+            let quat = params.gyro.smoothed_quat_at_timestamp(quat_time)
+                     * quat1
+                     * params.gyro.org_quat_at_timestamp(quat_time);
 
             let mut r = image_rotation * *quat.to_rotation_matrix().matrix();
             r[(0, 1)] *= -1.0; r[(0, 2)] *= -1.0;


### PR DESCRIPTION
Rolling shutter was acting incorrectly when there was a significant roll difference between original and smoothed orientations (see attached clip), indicating the smoothed orientation was incorrectly applied somewhere. Swapping the rotation order in the quaternion multiplication seems to have fixed this (smoothed_quat now applied last instead of first in the sequence)

https://user-images.githubusercontent.com/20195216/185305280-039b41fa-fa11-4c7c-8b5f-e3ab5f4a390f.mp4

https://user-images.githubusercontent.com/20195216/185304995-3c1ccc11-a00e-4414-8ee9-c2ffd2666df8.mp4


