### PR TITLE
Fix default lens correction strength after reset

### DIFF
--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -503,7 +503,7 @@ MenuItem {
             id: correctionAmount;
             from: 0.0;
             to: 100.0;
-            value: 100.0;
+            value: 1.0;
             unit: "%";
             defaultValue: 100.0;
             precision: 0;


### PR DESCRIPTION
Fix https://github.com/gyroflow/gyroflow/issues/439