### PR TITLE
Natural timeline scrolling on MacOS

### DIFF
--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -481,40 +481,38 @@ Item {
                 root.focus = true;
             }
             onDoubleClicked: (mouse) => root.resetZoom();
+            function zoomHorizontally(wheelX: real, delta: real) {
+                const remainingWindow = (root.visibleAreaRight - root.visibleAreaLeft);
+
+                const factor = (delta / 120) / (10 / remainingWindow);
+                const xPosFactor = wheelX / root.width;
+                root.visibleAreaLeft  = Math.min(root.visibleAreaRight, Math.max(0.0, root.visibleAreaLeft  + factor * xPosFactor));
+                root.visibleAreaRight = Math.max(root.visibleAreaLeft,  Math.min(1.0, root.visibleAreaRight - factor * (1.0 - xPosFactor)));
+
+                scrollbar.position = root.visibleAreaLeft;
+            }
+            function zoomVertically(delta: real) {
+                const factor = (delta / 120) / 10;
+                chart.vscale += factor;
+            }
+            function moveHorizontally(delta: real) {
+                const remainingWindow = (root.visibleAreaRight - root.visibleAreaLeft);
+                const factor = (delta / 120) / (50 / remainingWindow);
+                root.visibleAreaLeft  = Math.min(root.visibleAreaRight, Math.max(0.0, Math.min(1 - remainingWindow, root.visibleAreaLeft - factor)));
+                root.visibleAreaRight = Math.max(root.visibleAreaLeft,  Math.min(1.0, Math.max(remainingWindow, root.visibleAreaRight - factor)));
+
+                scrollbar.position = root.visibleAreaLeft;
+            }
             onWheel: (wheel) => {
-                function zoomHorizontally(delta) {
-                    const remainingWindow = (root.visibleAreaRight - root.visibleAreaLeft);
-
-                    const factor = (delta / 120) / (10 / remainingWindow);
-                    const xPosFactor = wheel.x / root.width;
-                    root.visibleAreaLeft  = Math.min(root.visibleAreaRight, Math.max(0.0, root.visibleAreaLeft  + factor * xPosFactor));
-                    root.visibleAreaRight = Math.max(root.visibleAreaLeft,  Math.min(1.0, root.visibleAreaRight - factor * (1.0 - xPosFactor)));
-
-                    scrollbar.position = root.visibleAreaLeft;
-                }
-                function zoomVertically(delta) {
-                    const factor = (delta / 120) / 10;
-                    chart.vscale += factor;
-                }
-                function moveHorizontally(delta) {
-                    const remainingWindow = (root.visibleAreaRight - root.visibleAreaLeft);
-                    const factor = (delta / 120) / (50 / remainingWindow);
-                    root.visibleAreaLeft  = Math.min(root.visibleAreaRight, Math.max(0.0, Math.min(1 - remainingWindow, root.visibleAreaLeft - factor)));
-                    root.visibleAreaRight = Math.max(root.visibleAreaLeft,  Math.min(1.0, Math.max(remainingWindow, root.visibleAreaRight - factor)));
-
-                    scrollbar.position = root.visibleAreaLeft;
-                }
-
-
-                if(Qt.platform.os == "osx") {
-                    if(wheel.angleDelta.x != 0) {
+                if (Qt.platform.os == "osx") {
+                    if (wheel.angleDelta.x != 0) {
                         moveHorizontally(wheel.angleDelta.x);
                     }
-                    if(wheel.angleDelta.y != 0) {
+                    if (wheel.angleDelta.y != 0) {
                         if ((wheel.modifiers & Qt.AltModifier) || (wheel.modifiers & Qt.MetaModifier)) {
                             zoomVertically(wheel.angleDelta.y);
-                        }  else {
-                            zoomHorizontally(wheel.angleDelta.y);
+                        } else {
+                            zoomHorizontally(wheel.x, wheel.angleDelta.y);
                         }
                     }
                 } else {
@@ -523,7 +521,7 @@ Item {
                     } else if ((wheel.modifiers & Qt.ControlModifier)) {
                         moveHorizontally(wheel.angleDelta.y);
                     } else {
-                        zoomHorizontally(wheel.angleDelta.y);
+                        zoomHorizontally(wheel.x, heel.angleDelta.y);
                     }
                 }
             }

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -482,27 +482,49 @@ Item {
             }
             onDoubleClicked: (mouse) => root.resetZoom();
             onWheel: (wheel) => {
-                if ((wheel.modifiers & Qt.AltModifier) || (wheel.modifiers & Qt.MetaModifier)) {
-                    const delta = Qt.platform.os == "osx"? wheel.angleDelta.y : wheel.angleDelta.x;
-
-                    const factor = (delta / 120) / 10;
-                    chart.vscale += factor;
-                } else if ((wheel.modifiers & Qt.ControlModifier)) { // move horizontally
-                    const remainingWindow = (root.visibleAreaRight - root.visibleAreaLeft);
-                    const factor = (wheel.angleDelta.y / 120) / (50 / remainingWindow);
-                    root.visibleAreaLeft  = Math.min(root.visibleAreaRight, Math.max(0.0, Math.min(1 - remainingWindow, root.visibleAreaLeft - factor)));
-                    root.visibleAreaRight = Math.max(root.visibleAreaLeft,  Math.min(1.0, Math.max(remainingWindow, root.visibleAreaRight - factor)));
-
-                    scrollbar.position = root.visibleAreaLeft;
-                } else { // zoom by default
+                function zoomHorizontally(delta) {
                     const remainingWindow = (root.visibleAreaRight - root.visibleAreaLeft);
 
-                    const factor = (wheel.angleDelta.y / 120) / (10 / remainingWindow);
+                    const factor = (delta / 120) / (10 / remainingWindow);
                     const xPosFactor = wheel.x / root.width;
                     root.visibleAreaLeft  = Math.min(root.visibleAreaRight, Math.max(0.0, root.visibleAreaLeft  + factor * xPosFactor));
                     root.visibleAreaRight = Math.max(root.visibleAreaLeft,  Math.min(1.0, root.visibleAreaRight - factor * (1.0 - xPosFactor)));
 
                     scrollbar.position = root.visibleAreaLeft;
+                }
+                function zoomVertically(delta) {
+                    const factor = (delta / 120) / 10;
+                    chart.vscale += factor;
+                }
+                function moveHorizontally(delta) {
+                    const remainingWindow = (root.visibleAreaRight - root.visibleAreaLeft);
+                    const factor = (delta / 120) / (50 / remainingWindow);
+                    root.visibleAreaLeft  = Math.min(root.visibleAreaRight, Math.max(0.0, Math.min(1 - remainingWindow, root.visibleAreaLeft - factor)));
+                    root.visibleAreaRight = Math.max(root.visibleAreaLeft,  Math.min(1.0, Math.max(remainingWindow, root.visibleAreaRight - factor)));
+
+                    scrollbar.position = root.visibleAreaLeft;
+                }
+
+
+                if(Qt.platform.os == "osx") {
+                    if(wheel.angleDelta.x != 0) {
+                        moveHorizontally(wheel.angleDelta.x);
+                    }
+                    if(wheel.angleDelta.y != 0) {
+                        if ((wheel.modifiers & Qt.AltModifier) || (wheel.modifiers & Qt.MetaModifier)) {
+                            zoomVertically(wheel.angleDelta.y);
+                        }  else {
+                            zoomHorizontally(wheel.angleDelta.y);
+                        }
+                    }
+                } else {
+                    if ((wheel.modifiers & Qt.AltModifier) || (wheel.modifiers & Qt.MetaModifier)) {
+                        zoomVertically(wheel.angleDelta.x);
+                    } else if ((wheel.modifiers & Qt.ControlModifier)) {
+                        moveHorizontally(wheel.angleDelta.y);
+                    } else {
+                        zoomHorizontally(wheel.angleDelta.y);
+                    }
                 }
             }
         }
@@ -845,7 +867,7 @@ Item {
             text: qsTr("%1 to zoom horizontally, %2 to zoom vertically, %3 to pan, double click to reset zoom")
                     .arg("<b>" + qsTr("Scroll") + "</b>")
                     .arg("<b>" + (Qt.platform.os == "osx"? qsTr("Option+Scroll") : qsTr("Alt+Scroll")) + "</b>")
-                    .arg("<b>" + (Qt.platform.os == "osx"? qsTr("Command+Scroll") : qsTr("Ctrl+Scroll")) + "</b>");
+                    .arg("<b>" + (Qt.platform.os == "osx"? qsTr("Scroll") : qsTr("Ctrl+Scroll")) + "</b>");
             visible: !isMobile && ma.containsMouse;
             delay: 2000;
         }


### PR DESCRIPTION
I changed the behaviour of the timeline scrolling on MacOS so the movement is more coherent with natural scroll we are used to. 

Managed to change the tooltip so no translation needs to be changed, but the text ends up like _"Scroll to zoom horizontally, Option+Scroll to zoom vertically, Scroll to pan, double click to reset zoom"_


Please check vertical zooming on windows, I did not understand why `wheel.angleDelta.x` is used there, but I kept like it was. 