### PR TITLE
Fix queue progress

### DIFF
--- a/src/rendering/render_queue.rs
+++ b/src/rendering/render_queue.rs
@@ -200,6 +200,7 @@ pub struct RenderQueue {
 
     pub start_timestamp: qt_property!(u64; NOTIFY progress_changed),
     pub end_timestamp: qt_property!(u64; NOTIFY progress_changed),
+    pub start_frame: qt_property!(u64; NOTIFY progress_changed),
     current_frame: qt_property!(u64; READ get_current_frame NOTIFY progress_changed),
     total_frames: qt_property!(u64; READ get_total_frames NOTIFY queue_changed),
     pub status: qt_property!(QString; NOTIFY status_changed),
@@ -492,7 +493,9 @@ impl RenderQueue {
         self.status = QString::from("active");
         self.status_changed();
 
-        if !paused && self.start_timestamp == 0 {
+        self.start_frame = self.get_current_frame();
+
+        if !paused {
             self.start_timestamp = Self::current_timestamp();
             self.progress_changed();
         } else if let Some(paused_timestamp) = self.paused_timestamp.take() {
@@ -527,9 +530,11 @@ impl RenderQueue {
                     self.render_job(job_id);
                 } else {
                     if self.get_active_render_count() == 0 {
+                        
                         self.post_render_action();
                         self.queue_finished();
 
+                        self.start_frame = 0;
                         self.start_timestamp = 0;
                         self.progress_changed();
 

--- a/src/rendering/render_queue.rs
+++ b/src/rendering/render_queue.rs
@@ -200,7 +200,6 @@ pub struct RenderQueue {
 
     pub start_timestamp: qt_property!(u64; NOTIFY progress_changed),
     pub end_timestamp: qt_property!(u64; NOTIFY progress_changed),
-    pub start_frame: qt_property!(u64; NOTIFY progress_changed),
     current_frame: qt_property!(u64; READ get_current_frame NOTIFY progress_changed),
     total_frames: qt_property!(u64; READ get_total_frames NOTIFY queue_changed),
     pub status: qt_property!(QString; NOTIFY status_changed),
@@ -633,7 +632,6 @@ impl RenderQueue {
             itm.status = JobStatus::Queued;
         });
     }
-
     pub fn update_status(&mut self) {
         for v in self.queue.borrow().iter() {
             if v.total_frames > 0 && v.status == JobStatus::Rendering {
@@ -765,6 +763,8 @@ impl RenderQueue {
                         // Start the next one
                         this.start();
                     } else {
+                        this.start_timestamp = 0;
+                        this.start_frame = 0;
                         this.update_status();
                         if is_queue_active {
                             this.post_render_action();
@@ -804,6 +804,9 @@ impl RenderQueue {
                 if this.get_pending_count() > 0 {
                     // Start the next one
                     this.start();
+                } else {
+                    this.start_timestamp = 0;
+                    this.start_frame = 0;
                 }
                 this.update_status();
             });
@@ -822,10 +825,13 @@ impl RenderQueue {
 
                 this.convert_format(job_id, QString::from(format), QString::from(supported));
                 this.render_progress(job_id, 1.0, 0, 0, true, 0.0, false);
-               
+
                 if this.get_pending_count() > 0 {
                     // Start the next one
                     this.start();
+                } else {
+                    this.start_timestamp = 0;
+                    this.start_frame = 0;
                 }
                 this.update_status();
             });

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -106,7 +106,7 @@ Item {
                     leftPadding: 0;
                     anchors.horizontalCenter: parent.horizontalCenter;
                     textFormat: Text.RichText;
-                    text: `<b>${(topCol.progress*100).toFixed(2)}%</b> <small>(${render_queue.current_frame}/${render_queue.total_frames}${totalTime.fpsText})</small>`;
+                    text: `<b>${(topCol.progress*100).toFixed(2)}%</b> <small>(${render_queue.current_frame - render_queue.start_frame}/${render_queue.total_frames - render_queue.start_frame}${totalTime.fpsText})</small>`;
                     y: totalTime.twoLines? progressText1.height + 5 * dpiScale : 0;
                     onWidthChanged: Qt.callLater(totalTime.updateLayout);
                 }

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -106,7 +106,7 @@ Item {
                     leftPadding: 0;
                     anchors.horizontalCenter: parent.horizontalCenter;
                     textFormat: Text.RichText;
-                    text: `<b>${(topCol.progress*100).toFixed(2)}%</b> <small>(${render_queue.current_frame - render_queue.start_frame}/${render_queue.total_frames - render_queue.start_frame}${totalTime.fpsText})</small>`;
+                    text: `<b>${(topCol.progress*100).toFixed(2)}%</b> <small>(${render_queue.current_frame}/${render_queue.total_frames}${totalTime.fpsText})</small>`;
                     y: totalTime.twoLines? progressText1.height + 5 * dpiScale : 0;
                     onWidthChanged: Qt.callLater(totalTime.updateLayout);
                 }

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -66,9 +66,9 @@ Item {
             id: topCol;
             spacing: 5 * dpiScale;
             width: parent.parent.width - x - mainBtn.width - 3 * parent.spacing;
-            property real progress: Math.max(0, Math.min(1, render_queue.current_frame / Math.max(1, render_queue.total_frames)));
+            property real progress: Math.max(0, Math.min(1, (render_queue.current_frame - render_queue.start_frame) / Math.max(1, (render_queue.total_frames - render_queue.start_frame))));
             onProgressChanged: {
-                const times = Util.calculateTimesAndFps(progress, render_queue.current_frame, render_queue.start_timestamp, render_queue.end_timestamp);
+                const times = Util.calculateTimesAndFps(progress, (render_queue.current_frame - render_queue.start_frame), render_queue.start_timestamp, render_queue.end_timestamp);
                 if (times !== false && progress < 1.0) {
                     totalTime.elapsed = times[0];
                     totalTime.remaining = times[1];

--- a/src/ui/RenderQueue.qml
+++ b/src/ui/RenderQueue.qml
@@ -66,9 +66,9 @@ Item {
             id: topCol;
             spacing: 5 * dpiScale;
             width: parent.parent.width - x - mainBtn.width - 3 * parent.spacing;
-            property real progress: Math.max(0, Math.min(1, (render_queue.current_frame - render_queue.start_frame) / Math.max(1, (render_queue.total_frames - render_queue.start_frame))));
+            property real progress: Math.max(0, Math.min(1, render_queue.current_frame / Math.max(1, render_queue.total_frames)));
             onProgressChanged: {
-                const times = Util.calculateTimesAndFps(progress, (render_queue.current_frame - render_queue.start_frame), render_queue.start_timestamp, render_queue.end_timestamp);
+                const times = Util.calculateTimesAndFps(progress, render_queue.current_frame, render_queue.start_timestamp, render_queue.end_timestamp);
                 if (times !== false && progress < 1.0) {
                     totalTime.elapsed = times[0];
                     totalTime.remaining = times[1];


### PR DESCRIPTION
I propose these changes to fix an issue with fps and time remaining estimation in the render queue. 

The problem appears when:
- Add items to the queue, start it and wait all items finished rendering
- wait a little bit (the more you wait, the more the values derives)
- Add new items, start the queue again

Then you'll see fps and time remaining estimation wrong, as they are computed from the time the queue was started first. 

I am naively proposing these changes, looks like it fixes the issue. I decided to run the `start()` function each time a job is finished, as the `start` function does the job of ending queue if no jobs left. Thing is I don't call `update_status()` anymore, I don't know what it was useful for, but I guess `start()` could do the same thing if needed. 