### PR TITLE
Allow undistort with fov

### DIFF
--- a/src/core/stabilization/cpu_undistort.rs
+++ b/src/core/stabilization/cpu_undistort.rs
@@ -401,9 +401,9 @@ impl Stabilization {
     }
 }
 
-pub fn undistort_points_with_rolling_shutter(distorted: &[(f32, f32)], timestamp_ms: f64, params: &ComputeParams, lens_correction_amount: f64) -> Vec<(f32, f32)> {
+pub fn undistort_points_with_rolling_shutter(distorted: &[(f32, f32)], timestamp_ms: f64, params: &ComputeParams, lens_correction_amount: f64, use_fovs: bool) -> Vec<(f32, f32)> {
     if distorted.is_empty() { return Vec::new(); }
-    let (camera_matrix, distortion_coeffs, _p, rotations) = FrameTransform::at_timestamp_for_points(params, distorted, timestamp_ms);
+    let (camera_matrix, distortion_coeffs, _p, rotations) = FrameTransform::at_timestamp_for_points(params, distorted, timestamp_ms, use_fovs);
 
     undistort_points(distorted, camera_matrix, &distortion_coeffs, rotations[0], Some(Matrix3::identity()), Some(rotations), params, lens_correction_amount)
 }

--- a/src/core/stabilization/frame_transform.rs
+++ b/src/core/stabilization/frame_transform.rs
@@ -235,7 +235,7 @@ impl FrameTransform {
         }
     }
 
-    pub fn at_timestamp_for_points(params: &ComputeParams, points: &[(f32, f32)], timestamp_ms: f64) -> (Matrix3<f64>, [f64; 12], Matrix3<f64>, Vec<Matrix3<f64>>) { // camera_matrix, dist_coeffs, p, rotations_per_point
+    pub fn at_timestamp_for_points(params: &ComputeParams, points: &[(f32, f32)], timestamp_ms: f64, use_fovs: bool) -> (Matrix3<f64>, [f64; 12], Matrix3<f64>, Vec<Matrix3<f64>>) { // camera_matrix, dist_coeffs, p, rotations_per_point
         // ----------- Keyframes -----------
         let video_rotation = params.keyframes.value_at_video_timestamp(&KeyframeType::VideoRotation, timestamp_ms).unwrap_or(params.video_rotation);
         // ----------- Keyframes -----------
@@ -245,7 +245,7 @@ impl FrameTransform {
         let (camera_matrix, distortion_coeffs, _, _, _, _) = Self::get_lens_data_at_timestamp(params, timestamp_ms);
 
         let img_dim_ratio = Self::get_ratio(params);
-        let fov = Self::get_fov(params, 0, false, timestamp_ms, false);
+        let fov = Self::get_fov(params, 0, use_fovs, timestamp_ms, false);
 
         let scaled_k = camera_matrix * img_dim_ratio;
         let new_k = Self::get_new_k(params, &camera_matrix, fov);

--- a/src/core/synchronization/find_offset/visual_features.rs
+++ b/src/core/synchronization/find_offset/visual_features.rs
@@ -60,8 +60,8 @@ pub fn find_offsets<F: Fn(f64) + Sync>(estimator: &PoseEstimator, ranges: &[(i64
                 let timestamp_ms  = *ts as f64 / 1000.0;
                 let timestamp_ms2 = *next_ts as f64 / 1000.0;
 
-                let undistorted_points1 = stabilization::undistort_points_with_rolling_shutter(&pts1, timestamp_ms - offs, params_ref, 1.0);
-                let undistorted_points2 = stabilization::undistort_points_with_rolling_shutter(&pts2, timestamp_ms2 - offs, params_ref, 1.0);
+                let undistorted_points1 = stabilization::undistort_points_with_rolling_shutter(&pts1, timestamp_ms - offs, params_ref, 1.0, false);
+                let undistorted_points2 = stabilization::undistort_points_with_rolling_shutter(&pts2, timestamp_ms2 - offs, params_ref, 1.0, false);
 
                 let mut distances = Vec::with_capacity(undistorted_points1.len());
                 for (p1, p2) in undistorted_points1.iter().zip(undistorted_points2.iter()) {

--- a/src/core/zooming/fov_iterative.rs
+++ b/src/core/zooming/fov_iterative.rs
@@ -98,7 +98,7 @@ impl<'a>  FovIterative<'a> {
         let adaptive_zoom_center_y = keyframe_values.1;
         let lens_correction_amount = keyframe_values.2;
 
-        let mut polygon = undistort_points_with_rolling_shutter(&rect, ts, &self.compute_params, lens_correction_amount);
+        let mut polygon = undistort_points_with_rolling_shutter(&rect, ts, &self.compute_params, lens_correction_amount, false);
         for (x, y) in polygon.iter_mut() {
             *x -= adaptive_zoom_center_x as f32 * self.input_dim.0;
             *y -= adaptive_zoom_center_y as f32 * self.input_dim.1;
@@ -122,7 +122,7 @@ impl<'a>  FovIterative<'a> {
                 ];
 
                 let distorted = interpolate_points(&relevant, 30);
-                polygon = undistort_points_with_rolling_shutter(&distorted, ts, &self.compute_params, lens_correction_amount);
+                polygon = undistort_points_with_rolling_shutter(&distorted, ts, &self.compute_params, lens_correction_amount, false);
                 for (x, y) in polygon.iter_mut() {
                     *x -= adaptive_zoom_center_x as f32 * self.input_dim.0;
                     *y -= adaptive_zoom_center_y as f32 * self.input_dim.1;


### PR DESCRIPTION
Added a use_fovs parameter to the at_timstamp_for_points method so that it can be exposed by undistort_points_with_rolling_shutter. All current calls will pass false to preserve existing functionality. External users of the core library can now undistort points correctly wrt fov settings in the ComputeParams.