### PR TITLE
Create devcontainer.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/devcontainers/rust:1-1-bullseye
+
+RUN apt-get update \
+ && DEBIAN_FRONTEND=noninteractive apt-get -y install --no-install-recommends \
+        p7zip-full \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=vscode
+USER $USERNAME
+
+# Save command line history
+RUN echo "export HISTFILE=/home/$USERNAME/commandhistory/.bash_history" >> "/home/$USERNAME/.bashrc" \
+        && echo "export PROMPT_COMMAND='history -a'" >> "/home/$USERNAME/.bashrc" \
+        && mkdir -p /home/$USERNAME/commandhistory \
+        && touch /home/$USERNAME/commandhistory/.bash_history \
+        && chown -R $USERNAME /home/$USERNAME/commandhistory

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+{
+	"name": "GyroFlow",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"mounts": [
+		"source=gyroflow-bashhistory-${devcontainerId},target=/home/vscode/commandhistory,type=volume"
+	],
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"dev.containers.mountWaylandSocket": true,
+				"terminal.integrated.defaultProfile.linux": "bash"
+			}
+		}
+	},
+	// "postCreateCommand": "sudo apt update && just install-deps",
+	"features": {
+		"ghcr.io/devcontainers/features/python:1": {},
+		"ghcr.io/guiyomh/features/just:0": {}
+	}
+}


### PR DESCRIPTION
## What is a Devcontainer

A docker-based development environment.

## References

- https://containers.dev
- https://code.visualstudio.com/docs/devcontainers/containers

## Why

I would like to start contributing to this project! Devcontainers are a favorite tool of mine. Namely because it makes the entire environment a sharable experience.

## What is Here

I attempted to stay fairly minimal while still maintaining a good experience.

- Uses the microsoft base _devcontainers/rust_ image, which is based on Debian bullseye.
- Installs [p7zip-full](https://packages.debian.org/bullseye/p7zip-full) via `apt-get`.
- Mounts a docker volume for bash history. This means that bash history can survive "rebuilds" of the container.
- VSCode settings
    - `mountWaylandSocket` so that the GUI interface can be displayed. More than happy to take a screenshot of this working. Note that this is the default - I'm setting it to override a manual disable.
    - Set the integrated terminal to `bash` to take advantage of the mounted `.bash_history` setup by the Dockerfile.
- Installed the [python feature](https://github.com/devcontainers/features/tree/main/src/python) (maintained by Microsoft).
- Installed the [just feature](https://github.com/guiyomh/features/tree/main/src/just) (maintained by a community member).

## Usage

1. Follow the [devcontainers tutorial](https://code.visualstudio.com/docs/devcontainers/tutorial). At high level that means 1. Docker setup 2. VSCode Setup 3. Install the [remote development](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) extension pack.
2. Create this devcontainer. This is done in vscode or via the [cli](https://github.com/devcontainers/cli).
3. In the shell of the running container finish with `sudo apt update && just install-deps`. The project should be ready to execute now.

## Editor Note

VSCode is the most well supported editor. That's why it appears in my description here.

However, you can still use a devcontainer with any editor. Last I knew JetBrains has every intention of _fully supporting_ the devcontainer ecosystem soon.