### PR TITLE
Enable scrolling using horizontal wheel

### DIFF
--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -516,12 +516,19 @@ Item {
                         }
                     }
                 } else {
-                    if ((wheel.modifiers & Qt.AltModifier) || (wheel.modifiers & Qt.MetaModifier)) {
-                        zoomVertically(wheel.angleDelta.x);
-                    } else if ((wheel.modifiers & Qt.ControlModifier)) {
-                        moveHorizontally(wheel.angleDelta.y);
-                    } else {
-                        zoomHorizontally(wheel.x, wheel.angleDelta.y);
+                    if (wheel.angleDelta.x != 0) {
+                        if ((wheel.modifiers & Qt.AltModifier) || (wheel.modifiers & Qt.MetaModifier)) {
+                            zoomVertically(wheel.angleDelta.x);
+                        } else {
+                            moveHorizontally(wheel.angleDelta.x);
+                        }
+                    }
+                    if (wheel.angleDelta.y != 0) {
+                        if ((wheel.modifiers & Qt.ControlModifier)) {
+                            moveHorizontally(wheel.angleDelta.y);
+                        } else {
+                            zoomHorizontally(wheel.x, wheel.angleDelta.y);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This enables timeline scrolling using horizontal mouse wheel for non-MacOS platforms (there was already code for that).

Tested on Windows using a mouse with a horizontal wheel and with a laptop touchpad.