### PR TITLE
Enable overwrite mode using Insert key

### DIFF
--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -6,6 +6,8 @@ import QtQuick.Controls as QQC
 
 TextField {
     id: root;
+    overwriteMode: false;
+
     property int precision: 0;
     property string unit: "";
     property real value: 0;
@@ -45,6 +47,11 @@ TextField {
         else if (e.modifiers & Qt.ControlModifier) value += 100 / lastDigit;
         else if (e.modifiers & Qt.ShiftModifier) value += 1000 / lastDigit;
         else value += 10 / lastDigit;
+    }
+    Keys.onPressed: (e) => {
+        if (e.key == Qt.Key_Insert) {
+            overwriteMode = !overwriteMode;
+        }
     }
     onValueChanged: {
         if (preventChange || allowText) return;


### PR DESCRIPTION
This enables overwrite mode toggling using Insert key for number fields. It should make it easier to adjust values during keyframing (no need to make text selections to replace or use Delete/Backspace keys in this mode).

Tested on Windows. One issue I found is that in replace mode, if an invalid character is typed, input validator stops it from appearing in the input field, but the previous character at the cursor position is erased anyway. I didn't find an easy way to prevent it from happening.