### PR TITLE
Make linux build more tolerant of non-debian systems

### DIFF
--- a/_scripts/common.just
+++ b/_scripts/common.just
@@ -50,7 +50,7 @@ export LIBCLANG_PATH := if os() == "macos" {
       env_var_or_default("LIBCLANG_PATH", if LlvmConfigExists == "true" {
          `llvm-config --libdir`
       } else {
-         if path_exists("/usr/lib/llvm-12/lib/") == "true" { "/usr/lib/llvm-12/lib/" } else { "" }
+         if path_exists("/usr/lib/llvm-13/lib/") == "true" { "/usr/lib/llvm-13/lib/" } else { "" }
       })
    }
 }

--- a/_scripts/common.just
+++ b/_scripts/common.just
@@ -40,7 +40,20 @@ export MACOSX_DEPLOYMENT_TARGET := "10.15"
 # ――――――――――――――――――――――――――――――――――――――― MacOS ―――――――――――――――――――――――――――――――――――――――――
 
 # ――――――――――――――――――――――――――――――――――――――― Clang ―――――――――――――――――――――――――――――――――――――――――
-export LIBCLANG_PATH := if os() == "macos" { DYLD_FALLBACK_LIBRARY_PATH } else { if path_exists(ExtDir / "llvm/bin") == "true" { ExtDir / "llvm/bin" } else { env_var_or_default("LIBCLANG_PATH", if path_exists("/usr/lib/llvm-13/lib/") == "true" { "/usr/lib/llvm-13/lib/" } else { "" }) } }
+LlvmConfigExists := if os() == "linux" { `which llvm-config &>/dev/null && echo true || echo false` } else { "false" }
+export LIBCLANG_PATH := if os() == "macos" {
+   DYLD_FALLBACK_LIBRARY_PATH
+} else {
+   if path_exists(ExtDir / "llvm/bin") == "true" {
+      ExtDir / "llvm/bin"
+   } else {
+      env_var_or_default("LIBCLANG_PATH", if LlvmConfigExists == "true" {
+         `llvm-config --libdir`
+      } else {
+         if path_exists("/usr/lib/llvm-12/lib/") == "true" { "/usr/lib/llvm-12/lib/" } else { "" }
+      })
+   }
+}
 LLVMPath := LIBCLANG_PATH
 # ――――――――――――――――――――――――――――――――――――――― Clang ―――――――――――――――――――――――――――――――――――――――――
 

--- a/_scripts/linux.just
+++ b/_scripts/linux.just
@@ -49,7 +49,7 @@ install-deps:
 
     if [ ! -d "{{ExtDir}}/{{QtVersion}}" ]; then
         echo "Setting up python venv in {{ExtDir}}/venv"
-        python -m venv "{{ExtDir}}/venv"
+        python3 -m venv "{{ExtDir}}/venv"
         source "{{ExtDir}}/venv/bin/activate"
 
         echo "Installing Qt {{QtVersion}}"

--- a/_scripts/linux.just
+++ b/_scripts/linux.just
@@ -1,5 +1,7 @@
 import 'common.just'
 
+AptGetExists := `which apt-get &>/dev/null && echo true || echo false`
+
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Dependencies ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -9,17 +11,22 @@ install-deps:
     #!/bin/bash
     set -e
 
-    sudo apt-get install -y p7zip-full python3-pip clang libclang-dev bison pkg-config gperf curl unzip zip git
-    sudo apt-get install -y libc++-dev libva-dev libvdpau-dev libvdpau1 mesa-va-drivers ocl-icd-opencl-dev opencl-headers
-    sudo apt-get install -y libpulse-dev libasound-dev libxkbcommon-dev
-    sudo apt-get install -y libfontconfig1 libfreetype6
+    echo "Installing dependencies $LIBCLANG_PATH  {{AptGetExists}}"
+    if [ "{{AptGetExists}}" == "true" ]; then
+        sudo apt-get install -y p7zip-full python3-pip clang libclang-dev bison pkg-config gperf curl unzip zip git
+        sudo apt-get install -y libc++-dev libva-dev libvdpau-dev libvdpau1 mesa-va-drivers ocl-icd-opencl-dev opencl-headers
+        sudo apt-get install -y libpulse-dev libasound-dev libxkbcommon-dev
+        sudo apt-get install -y libfontconfig1 libfreetype6
+    fi
 
     mkdir -p {{ExtDir}}
 
     if [ ! -f "{{OpenCVPath}}/../lib/libopencv_core4.a" ]; then
         echo "Installing OpenCV from vcpkg"
         # OpenCV dependencies
-        sudo apt-get install -y libx11-dev libxft-dev libxext-dev autoconf libtool libglfw3 libgles2-mesa-dev libxrandr-dev libxi-dev libxcursor-dev libxdamage-dev libxinerama-dev libxxf86vm-dev libdbus-1-dev libxtst-dev libdbus-1-dev libxi-dev libxtst-dev libsystemd-dev
+        if [ "{{AptGetExists}}" == "true" ]; then
+            sudo apt-get install -y libx11-dev libxft-dev libxext-dev autoconf libtool libglfw3 libgles2-mesa-dev libxrandr-dev libxi-dev libxcursor-dev libxdamage-dev libxinerama-dev libxxf86vm-dev libdbus-1-dev libxtst-dev libdbus-1-dev libxi-dev libxtst-dev libsystemd-dev
+        fi
 
         # Install vcpkg
         git clone --depth 1 https://github.com/Microsoft/vcpkg.git {{ExtDir}}/vcpkg || true
@@ -33,12 +40,18 @@ install-deps:
     fi
 
     if [[ ! -d "${LIBCLANG_PATH}" ]]; then
-        sudo apt-get install -y libclang-13-dev
+        if [ "{{AptGetExists}}" == "true" ]; then
+            sudo apt-get install -y libclang-13-dev
+        fi
     fi
 
     pushd {{ExtDir}}
 
     if [ ! -d "{{ExtDir}}/{{QtVersion}}" ]; then
+        echo "Setting up python venv in {{ExtDir}}/venv"
+        python -m venv "{{ExtDir}}/venv"
+        source "{{ExtDir}}/venv/bin/activate"
+
         echo "Installing Qt {{QtVersion}}"
         # Install Qt
         pip3 install -U pip
@@ -76,6 +89,11 @@ install-deps:
     fi
 
     popd
+
+    if [ "{{AptGetExists}}" == "false" ]; then
+        echo "Warning: apt-get not found, so build dependencies could not be automatically installed."
+        echo "  Make sure you have installed all required build dependencies using your system's package manager."
+    fi
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ Development ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR changes the Just files to detect whether `apt-get` is present on the user's system. If not, `apt-get install` commands are skipped and a warning is presented to the user that they are responsible for installing required libraries.

Additionally, this PR makes the check for `LIBCLANG_PATH` more robust.

Sidenote: it seems that if `libclang` is not present on the system, libclang-13 is attempted to be installed. However, the lowest version of libclang that I could get to work was `libclang-15`. Should the `-13` version be bumped?