### PR TITLE
Prevent parsing NaN value in number field

### DIFF
--- a/src/ui/components/NumberField.qml
+++ b/src/ui/components/NumberField.qml
@@ -58,11 +58,13 @@ TextField {
     }
     function updateValue(): void {
         if (allowText) return;
+        const textNoSpace = text.replace(/\s+/g, "");
+        if (textNoSpace.length === 0) return;
         preventChange = true;
         let locale = Qt.locale();
         locale.numberOptions = Locale.OmitGroupSeparator;
         try {
-            value = Number.fromLocaleString(locale, text.replace(/\s+/g, ""));
+            value = Number.fromLocaleString(locale, textNoSpace);
         } catch(e) {
             let locale = Qt.locale();
             locale.numberOptions = Locale.OmitGroupSeparator;


### PR DESCRIPTION
This fix should prevent parsing an empty text value, resulting in NaN value. Such situation may occur, for example, if I select a numeric value, hit backspace with the intention of typing in another value, but instead, "NaN" appears in the field, often accompanied by some scary-looking effects onto the image in the viewport. Also, NaN value is not easily correctable, because its text representation are non-numeric characters which do not pass the field validation, the whole value must be selected and a number entered in order to fix the value in the field. 