### PR TITLE
Introducing Gyroflow Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@
     <a href="https://github.com/gyroflow/gyroflow/blob/master/LICENSE">
       <img src="https://img.shields.io/github/license/gyroflow/gyroflow" alt="License">
     </a>
+    <a href="https://gurubase.io/g/gyroflow">
+      <img src="https://img.shields.io/badge/Gurubase-Ask%20Gyroflow%20Guru-006BFF" alt="Gurubase">
+    </a>
   </p>
 </p>
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Gyroflow Guru](https://gurubase.io/g/gyroflow) to Gurubase. Gyroflow Guru uses the data from this repo and data from the [docs](https://docs.gyroflow.xyz) to answer questions by leveraging the LLM.

In this PR, I showcased the "Gyroflow Guru", which highlights that Gyroflow now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Gyroflow Guru in Gurubase, just let me know that's totally fine.
