### PR TITLE
improve "get optimsync point"

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -425,7 +425,7 @@ impl Controller {
                         let sync_data = this.stabilizer.sync_data.read();
                         if !sync_data.rank.is_empty() {
                             let index = ((x.0 - x.1) as f64 / (sync_data.ratio * 1000.0)).round() as usize;
-                            if index < sync_data.rank.len() && sync_data.rank[index] < 20.0 {
+                            if index < sync_data.rank.len() && sync_data.rank[index] < 13.0 {
                                 continue;
                             }
                         }

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1870,9 +1870,9 @@ impl StabilizationManager {
         let trim_ranges = {
             let params = self.params.read();
             if params.trim_ranges.is_empty() {
-                vec![(0.0, dur_ms as f64 / 1000.0)]
+                vec![((0.0 - initial_offset)/1000.0, (dur_ms - initial_offset) / 1000.0)]
             } else {
-                params.trim_ranges.iter().map(|x| (x.0 * dur_ms / 1000.0, x.1 * dur_ms / 1000.0)).collect()
+                params.trim_ranges.iter().map(|x| ((x.0 * dur_ms - initial_offset) / 1000.0, (x.1 * dur_ms - initial_offset) / 1000.0)).collect()
             }
         };
 

--- a/src/core/synchronization/optimsync.rs
+++ b/src/core/synchronization/optimsync.rs
@@ -143,7 +143,7 @@ impl OptimSync {
         let ratio = step_size_samples as f64 / self.sample_rate;
         for i in 0..rank.len() {
             let time = i as f64 * ratio;
-            if rank[i] < 100.0 || !trim_ranges_s.iter().any(|x| time >= x.0 && time <= x.1) {
+            if rank[i] < 50.0 || !trim_ranges_s.iter().any(|x| time >= x.0 && time <= x.1) {
                 rank[i] = 0.0;
             }
         }

--- a/src/rendering/render_queue.rs
+++ b/src/rendering/render_queue.rs
@@ -1468,7 +1468,7 @@ impl RenderQueue {
                                         let sync_data = stab2.sync_data.read();
                                         if !sync_data.rank.is_empty() {
                                             let index = ((x.0 - x.1) as f64 / (sync_data.ratio * 1000.0)).round() as usize;
-                                            if index < sync_data.rank.len() && sync_data.rank[index] < 20.0 {
+                                            if index < sync_data.rank.len() && sync_data.rank[index] < 13.0 {
                                                 continue;
                                             }
                                         }


### PR DESCRIPTION
1.the rank is generally less than 6 when static,and more than 15 when handheld.So 13.0 would be better. 
2.trim ranges should minus initial_offset to convert to gyro data ranges.