### PR TITLE
Adjust timeline tooltip

### DIFF
--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -1030,6 +1030,7 @@ Item {
                     .arg("<b>" + (Qt.platform.os == "osx"? qsTr("Scroll") : qsTr("Ctrl+Scroll")) + "</b>");
             visible: !isMobile && ma.containsMouse;
             delay: 2000;
+            timeout: 5000;
         }
     }
 }


### PR DESCRIPTION
I had some issues with the timeline tooltip: positioned at the bottom, it covered some keyframes and dismissing the tooltip was not reliable, sometimes it just went away on mouse over as it should but other times it just wouldn't and sometimes it would start blinking, making it very difficult to access the keyframes under it.