### PR TITLE
Another keyboard shortcut for keyframes navigation

### DIFF
--- a/src/ui/Shortcuts.qml
+++ b/src/ui/Shortcuts.qml
@@ -175,12 +175,12 @@ Item {
 
     // Next keyframe
     Shortcut {
-        sequence: "Shift+Right";
+        sequences: ["Shift+Right", "Shift+Page Down"];
         onActivated: videoArea.timeline.jumpToNextKeyframe("");
     }
     // Previous keyframe
     Shortcut {
-        sequence: "Shift+Left";
+        sequences: ["Shift+Left", "Shift+Page Up"];
         onActivated: videoArea.timeline.jumpToPrevKeyframe("");
     }
 


### PR DESCRIPTION
This makes shortcuts for keyframes navigation consistent with 1 and 10 frames navigation that have both left/right and page up/page down keys combinations. More importantly, it's now possible to use keyframes shortcuts while the focus is on an input field where arrow keys are used for cursor.