### PR TITLE
Add focal length smoothing for dynamic lens metadata

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -131,6 +131,10 @@ pub struct Controller {
     zooming_center_x: qt_property!(f64; WRITE set_zooming_center_x),
     zooming_center_y: qt_property!(f64; WRITE set_zooming_center_y),
     zooming_method: qt_property!(i32; WRITE set_zooming_method),
+    
+    focal_length_smoothing_enabled: qt_property!(bool; READ get_focal_length_smoothing_enabled WRITE set_focal_length_smoothing_enabled),
+    focal_length_smoothing_strength: qt_property!(f64; READ get_focal_length_smoothing_strength WRITE set_focal_length_smoothing_strength),
+    focal_length_time_window: qt_property!(f64; READ get_focal_length_time_window WRITE set_focal_length_time_window),
 
     additional_rotation_x: qt_property!(f64; WRITE set_additional_rotation_x),
     additional_rotation_y: qt_property!(f64; WRITE set_additional_rotation_y),
@@ -2071,6 +2075,30 @@ impl Controller {
 
     fn has_gravity_vectors(&self) -> bool {
         self.stabilizer.gyro.read().file_metadata.read().gravity_vectors.as_ref().map(|v| !v.is_empty()).unwrap_or_default()
+    }
+
+    fn get_focal_length_smoothing_enabled(&self) -> bool {
+        self.stabilizer.params.read().focal_length_smoothing_enabled
+    }
+    fn set_focal_length_smoothing_enabled(&mut self, v: bool) {
+        self.stabilizer.params.write().focal_length_smoothing_enabled = v;
+        self.request_recompute();
+    }
+
+    fn get_focal_length_smoothing_strength(&self) -> f64 {
+        self.stabilizer.params.read().focal_length_smoothing_strength
+    }
+    fn set_focal_length_smoothing_strength(&mut self, v: f64) {
+        self.stabilizer.params.write().focal_length_smoothing_strength = v.clamp(0.0, 1.0);
+        self.request_recompute();
+    }
+
+    fn get_focal_length_time_window(&self) -> f64 {
+        self.stabilizer.params.read().focal_length_time_window
+    }
+    fn set_focal_length_time_window(&mut self, v: f64) {
+        self.stabilizer.params.write().focal_length_time_window = v.clamp(0.1, 5.0);
+        self.request_recompute();
     }
 
     fn check_external_sdk(&self, filename: QString) -> bool {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -131,10 +131,9 @@ pub struct Controller {
     zooming_center_x: qt_property!(f64; WRITE set_zooming_center_x),
     zooming_center_y: qt_property!(f64; WRITE set_zooming_center_y),
     zooming_method: qt_property!(i32; WRITE set_zooming_method),
-    
+
     focal_length_smoothing_enabled: qt_property!(bool; READ get_focal_length_smoothing_enabled WRITE set_focal_length_smoothing_enabled),
     focal_length_smoothing_strength: qt_property!(f64; READ get_focal_length_smoothing_strength WRITE set_focal_length_smoothing_strength),
-    focal_length_time_window: qt_property!(f64; READ get_focal_length_time_window WRITE set_focal_length_time_window),
 
     additional_rotation_x: qt_property!(f64; WRITE set_additional_rotation_x),
     additional_rotation_y: qt_property!(f64; WRITE set_additional_rotation_y),
@@ -165,7 +164,7 @@ pub struct Controller {
     gyro_changed: qt_signal!(),
 
     has_gravity_vectors: qt_property!(bool; READ has_gravity_vectors NOTIFY gyro_changed),
-    has_per_frame_focal_length: qt_property!(bool; NOTIFY gyro_changed),
+    has_per_frame_focal_length: qt_property!(bool; READ has_per_frame_focal_length NOTIFY gyro_changed),
 
     compute_progress: qt_signal!(id: u64, progress: f64),
     sync_progress: qt_signal!(progress: f64, ready: usize, total: usize),
@@ -1207,20 +1206,13 @@ impl Controller {
 
     fn recompute_threaded(&mut self) {
         if self.stabilizer.params.read().duration_ms <= 0.0 { return; }
-        let stab = self.stabilizer.clone();
         let id = self.stabilizer.recompute_threaded(util::qt_queued_callback_mut(QPointer::from(self as &Self), move |this, (id, _discarded): (u64, bool)| {
             if !this.ongoing_computations.contains(&id) {
                 ::log::error!("Unknown compute_id: {}", id);
             }
             this.ongoing_computations.remove(&id);
             let finished = this.ongoing_computations.is_empty();
-            
-            // Lazy evaluation: Update focal length availability flag only after stabilization is complete
-            if finished {
-                this.has_per_frame_focal_length = !stab.gyro.read().file_metadata.read().lens_params.is_empty();
-                this.gyro_changed();
-            }
-            
+
             this.compute_progress(id, if finished { 1.0 } else { 0.0 });
         }));
         self.ongoing_computations.insert(id);
@@ -2085,6 +2077,9 @@ impl Controller {
     fn has_gravity_vectors(&self) -> bool {
         self.stabilizer.gyro.read().file_metadata.read().gravity_vectors.as_ref().map(|v| !v.is_empty()).unwrap_or_default()
     }
+    fn has_per_frame_focal_length(&self) -> bool {
+        !self.stabilizer.gyro.read().file_metadata.read().lens_params.is_empty()
+    }
 
     fn get_focal_length_smoothing_enabled(&self) -> bool {
         self.stabilizer.params.read().focal_length_smoothing_enabled
@@ -2099,14 +2094,6 @@ impl Controller {
     }
     fn set_focal_length_smoothing_strength(&mut self, v: f64) {
         self.stabilizer.params.write().focal_length_smoothing_strength = v.clamp(0.0, 1.0);
-        self.request_recompute();
-    }
-
-    fn get_focal_length_time_window(&self) -> f64 {
-        self.stabilizer.params.read().focal_length_time_window
-    }
-    fn set_focal_length_time_window(&mut self, v: f64) {
-        self.stabilizer.params.write().focal_length_time_window = v.clamp(0.1, 5.0);
         self.request_recompute();
     }
 

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
-
 #![recursion_limit = "256"]
 
 pub mod gyro_source;
@@ -415,29 +414,101 @@ impl StabilizationManager {
 
     pub fn extract_focal_lengths(compute_params: &ComputeParams) -> Vec<Option<f64>> {
         use crate::util::MapClosest;
-        
+
         let gyro = compute_params.gyro.read();
         let file_metadata = gyro.file_metadata.read();
-        
-        // If no lens params, return empty
+
         if file_metadata.lens_params.is_empty() {
             return vec![];
         }
-        
+
         let mut focal_lengths = Vec::with_capacity(compute_params.frame_count);
-        
+
         for frame in 0..compute_params.frame_count {
             let timestamp_ms = crate::timestamp_at_frame(frame as i32, compute_params.scaled_fps);
             let timestamp_us = (timestamp_ms * 1000.0).round() as i64;
-            
+
             // Try to get focal length from lens_params (within 100ms window)
             let focal_length = file_metadata.lens_params.get_closest(&timestamp_us, 100000)
                 .and_then(|val| val.focal_length.map(|fl| fl as f64));
-            
+
             focal_lengths.push(focal_length);
         }
-        
+
         focal_lengths
+    }
+
+    fn apply_focal_length_smoothing(params: &mut ComputeParams, stabilization_params: &RwLock<StabilizationParams>) {
+        let (enabled, strength) = {
+            let sp = stabilization_params.read();
+            (sp.focal_length_smoothing_enabled, sp.focal_length_smoothing_strength)
+        };
+
+        let focal_lengths = if params.gyro.read().file_metadata.read().lens_params.is_empty() {
+            Vec::new()
+        } else {
+            Self::extract_focal_lengths(params)
+        };
+
+        let smoothing_active = enabled && !focal_lengths.is_empty();
+
+        let (dequantized_focal_lengths, smoothed_focal_lengths) = if smoothing_active {
+            // Dequantize the raw metadata with a short Gaussian. Camera-quantized focal length
+            // values produce visible stairs; the shader samples position depends on the raw
+            // side of the ratio (through scaled_k), so stairs in raw become stairs in output
+            // unless we feed the ratio a smooth estimate of the true optical state.
+            let dequantize_window = ((params.scaled_fps * 0.5).round() as usize).max(5);
+            let dequantized = crate::smoothing::focal_length::smooth_focal_lengths_gaussian(&focal_lengths, 1.0, dequantize_window);
+
+            // Single-knob mapping (`strength` ∈ [0, 1]). All three dials scale together so the
+            // slider feels monotonic: more smoothness = longer stationary time constant, higher
+            // velocity threshold, AND a longer "fast zoom" time constant so transitions round
+            // off instead of snapping to the raw shape.
+            //
+            //   * `max_smoothness_time` — stationary time constant. Exponential 0.1s → 30s so
+            //     the top of the slider gives genuinely extreme smoothness.
+            //   * `min_smoothness_time` — fast-zoom time constant. Scales from ~0.05s at
+            //     strength=0 (near pass-through) up to ~0.4s at strength=1. This is what keeps
+            //     deliberate zoom edges rounded rather than tracking the raw curve tightly.
+            //   * `velocity_threshold` — how fast a zoom has to be to open the filter. Scales
+            //     0.3 → 8.0 so low smoothness opens on any motion, high smoothness only yields
+            //     to very fast zooms.
+            let s = strength.clamp(0.0, 1.0);
+            let max_smoothness_time = 0.1_f64 * 300.0_f64.powf(s);           // 0.1 .. 30
+            let min_smoothness_time = 0.05_f64 + 0.35_f64 * s * s;           // 0.05 .. 0.40
+            let velocity_threshold  = 0.3_f64 + 7.7_f64 * s.powf(1.5);       // 0.3 .. 8.0
+
+            let smoothed = crate::smoothing::focal_length::smooth_focal_lengths_adaptive(
+                &dequantized,
+                params.scaled_fps,
+                max_smoothness_time,
+                min_smoothness_time,
+                velocity_threshold,
+            );
+            (dequantized, smoothed)
+        } else {
+            (Vec::new(), Vec::new())
+        };
+
+        // Rendering-side state: compute_params drives the shader compensation, so only populate
+        // when smoothing is actually active. `focal_lengths` here holds the DEQUANTIZED curve
+        // (used as the ratio denominator), not the raw metadata — see comment above.
+        if smoothing_active {
+            params.focal_lengths = dequantized_focal_lengths;
+            params.smoothed_focal_lengths = smoothed_focal_lengths.clone();
+            params.focal_length_smoothing_enabled = true;
+        } else {
+            params.focal_lengths.clear();
+            params.smoothed_focal_lengths.clear();
+            params.focal_length_smoothing_enabled = false;
+        }
+
+        // Chart-side state: always expose the RAW focal length curve when per-frame data exists,
+        // so the "FL" timeline toggle works regardless of whether smoothing is enabled. Smoothed
+        // curve is only populated when smoothing is active.
+        let mut sp = stabilization_params.write();
+        sp.focal_lengths = focal_lengths;
+        sp.smoothed_focal_lengths = smoothed_focal_lengths;
     }
 
     pub fn recompute_adaptive_zoom_static(compute_params: &ComputeParams, params: &RwLock<StabilizationParams>) -> (Vec<f64>, Vec<f64>, BTreeMap<i64, Vec<(f64, f64)>>) {
@@ -452,6 +523,8 @@ impl StabilizationManager {
     pub fn recompute_adaptive_zoom(&self) {
         let mut params = stabilization::ComputeParams::from_manager(self);
         params.calculate_camera_fovs();
+
+        Self::apply_focal_length_smoothing(&mut params, &self.params);
 
         let lens_fov_adjustment = params.lens.optimal_fov.unwrap_or(1.0);
         let (fovs, minimal_fovs, debug_points) = Self::recompute_adaptive_zoom_static(&params, &self.params);
@@ -513,6 +586,8 @@ impl StabilizationManager {
                     gyro.max_angles = max_angles;
                     gyro.smoothed_quaternions = quats;
                 }
+
+                Self::apply_focal_length_smoothing(&mut params, &self.params);
 
                 // Zooming
                 let lens_fov_adjustment = params.lens.optimal_fov.unwrap_or(1.0);
@@ -606,31 +681,13 @@ impl StabilizationManager {
 
             if current_compute_id.load(SeqCst) != compute_id { return cb((compute_id, true)); }
 
-            if smoothing_changed || zooming::get_checksum(&params) != zooming_checksum.load(SeqCst) {
-                // Extract and smooth focal lengths BEFORE FOV calculation (only if enabled and video has per-frame FL data)
-                let smoothing_enabled = stabilization_params.read().focal_length_smoothing_enabled;
-                if smoothing_enabled && !params.gyro.read().file_metadata.read().lens_params.is_empty() {
-                    let focal_lengths = Self::extract_focal_lengths(&params);
-                    if !focal_lengths.is_empty() {
-                        let (smoothing_strength, time_window) = {
-                            let sp = stabilization_params.read();
-                            (sp.focal_length_smoothing_strength, sp.focal_length_time_window)
-                        };
-                        
-                        let window_frames = (params.scaled_fps * time_window).round() as usize;
-                        let smoothed_focal_lengths = crate::smoothing::focal_length::smooth_focal_lengths_gaussian(&focal_lengths, smoothing_strength, window_frames);
-                        
-                        params.focal_lengths = focal_lengths;
-                        params.smoothed_focal_lengths = smoothed_focal_lengths;
-                        params.focal_length_smoothing_enabled = true;
-                    }
-                } else {
-                    // Clear focal length data when disabled
-                    params.focal_lengths.clear();
-                    params.smoothed_focal_lengths.clear();
-                    params.focal_length_smoothing_enabled = false;
-                }
+            // Run FL smoothing unconditionally so `params.focal_lengths` always carries the
+            // dequantized curve by the time `set_compute_params` stores it. The from_manager
+            // copy pulls raw-for-chart from StabilizationParams, so skipping this step would
+            // leave raw (stair-stepped) values in the rendering-side compute_params.
+            Self::apply_focal_length_smoothing(&mut params, &stabilization_params);
 
+            if smoothing_changed || zooming::get_checksum(&params) != zooming_checksum.load(SeqCst) {
                 let (fovs, minimal_fovs, debug_points) = Self::recompute_adaptive_zoom_static(&params, &stabilization_params);
                 params.fovs = fovs;
                 params.minimal_fovs = minimal_fovs;
@@ -642,13 +699,7 @@ impl StabilizationManager {
                     stab_params.set_fovs(params.fovs.clone(), params.lens.optimal_fov.unwrap_or(1.0));
                     stab_params.minimal_fovs = params.minimal_fovs.clone();
                     stab_params.zooming_debug_points = debug_points;
-                    
-                    // Store focal length data
-                    if !params.focal_lengths.is_empty() {
-                        stab_params.focal_lengths = params.focal_lengths.clone();
-                        stab_params.smoothed_focal_lengths = params.smoothed_focal_lengths.clone();
-                    }
-                    
+
                     zooming_checksum.store(zooming::get_checksum(&params), SeqCst);
                     (
                         stab_params.max_zoom.unwrap_or(0.0),
@@ -708,49 +759,21 @@ impl StabilizationManager {
                             lib_gyro.smoothing_status = smoothing.get_status_json();
                         }
 
-                        // Extract and smooth focal lengths BEFORE FOV calculation for max zoom iterations (only if enabled and video has per-frame FL data)
-                        let smoothing_enabled = stabilization_params.read().focal_length_smoothing_enabled;
-                        if smoothing_enabled && !params.gyro.read().file_metadata.read().lens_params.is_empty() {
-                            let focal_lengths = Self::extract_focal_lengths(&params);
-                            if !focal_lengths.is_empty() {
-                                let (smoothing_strength, time_window) = {
-                                    let sp = stabilization_params.read();
-                                    (sp.focal_length_smoothing_strength, sp.focal_length_time_window)
-                                };
-                                
-                                let window_frames = (params.scaled_fps * time_window).round() as usize;
-                                let smoothed_focal_lengths = crate::smoothing::focal_length::smooth_focal_lengths_gaussian(&focal_lengths, smoothing_strength, window_frames);
-                                
-                                params.focal_lengths = focal_lengths;
-                                params.smoothed_focal_lengths = smoothed_focal_lengths;
-                                params.focal_length_smoothing_enabled = true;
-                            }
-                        } else {
-                            // Clear focal length data when disabled
-                            params.focal_lengths.clear();
-                            params.smoothed_focal_lengths.clear();
-                            params.focal_length_smoothing_enabled = false;
-                        }
+                        // FL smoothing state from the outer apply is reused across iterations —
+                        // settings and raw metadata don't change within max-zoom iterations.
 
-                        // Zooming
                         let (fovs, minimal_fovs, debug_points) = Self::recompute_adaptive_zoom_static(&params, &stabilization_params);
                         params.fovs = fovs;
                         params.minimal_fovs = minimal_fovs;
 
                         if current_compute_id.load(SeqCst) != compute_id { return cb((compute_id, true)); }
-                        
+
                         {
                             let mut stab_params = stabilization_params.write();
                             stab_params.set_fovs(params.fovs.clone(), params.lens.optimal_fov.unwrap_or(1.0));
                             stab_params.minimal_fovs = params.minimal_fovs.clone();
                             stab_params.zooming_debug_points = debug_points;
-                            
-                            // Store focal length data
-                            if !params.focal_lengths.is_empty() {
-                                stab_params.focal_lengths = params.focal_lengths.clone();
-                                stab_params.smoothed_focal_lengths = params.smoothed_focal_lengths.clone();
-                            }
-                            
+
                             zooming_checksum.store(zooming::get_checksum(&params), SeqCst);
                         }
                     }
@@ -1308,7 +1331,6 @@ impl StabilizationManager {
                 "frame_offset":           params.frame_offset,
                 "focal_length_smoothing_enabled":  params.focal_length_smoothing_enabled,
                 "focal_length_smoothing_strength": params.focal_length_smoothing_strength,
-                "focal_length_time_window":        params.focal_length_time_window,
             },
             "gyro_source": {
                 "filepath":           gyro.file_url,
@@ -1347,7 +1369,7 @@ impl StabilizationManager {
 
         if let Some(serde_json::Value::Object(obj)) = obj.get_mut("gyro_source") {
             let file_metadata = gyro.file_metadata.read();
-            
+
             if typ == GyroflowProjectType::Simple {
                 if let Ok(val) = serde_json::to_value(file_metadata.thin()) {
                     obj.insert("file_metadata".into(), val);
@@ -1366,7 +1388,7 @@ impl StabilizationManager {
                 if !params.smoothed_focal_lengths.is_empty() {
                     util::compress_to_base91_cbor(&params.smoothed_focal_lengths).and_then(|s| obj.insert("smoothed_focal_lengths".into(), serde_json::Value::String(s)));
                 }
-                
+
                 let mut imu_timestamps = Vec::with_capacity(gyro.quaternions.len());
                 let mut imu_timestamps_final = Vec::with_capacity(gyro.quaternions.len());
                 for (t, _) in &gyro.quaternions {
@@ -1594,16 +1616,11 @@ impl StabilizationManager {
                 if let Some(v) = obj.get("acc_rotation") { let v: [f64; 3] = serde_json::from_value(v.clone()).unwrap_or_default(); gyro.imu_transforms.set_acc_rotation(v[0], v[1], v[2]); }
                 if let Some(v) = obj.get("gyro_bias")    { gyro.imu_transforms.gyro_bias = serde_json::from_value(v.clone()).ok(); }
 
-                // Load focal length arrays if present (for processed data)
-                if let Some(bytes) = util::decompress_from_base91(obj.get("focal_lengths").and_then(|x| x.as_str()).unwrap_or_default()) {
-                    if let Ok(data) = bincode::serde::decode_from_slice::<Vec<Option<f64>>, _>(&bytes, bincode::config::legacy()) {
-                        self.params.write().focal_lengths = data.0;
-                    }
+                if let Ok(fls) = util::decompress_from_base91_cbor::<Vec<Option<f64>>>(obj.get("focal_lengths").and_then(|x| x.as_str()).unwrap_or_default()) {
+                    self.params.write().focal_lengths = fls;
                 }
-                if let Some(bytes) = util::decompress_from_base91(obj.get("smoothed_focal_lengths").and_then(|x| x.as_str()).unwrap_or_default()) {
-                    if let Ok(data) = bincode::serde::decode_from_slice::<Vec<Option<f64>>, _>(&bytes, bincode::config::legacy()) {
-                        self.params.write().smoothed_focal_lengths = data.0;
-                    }
+                if let Ok(fls) = util::decompress_from_base91_cbor::<Vec<Option<f64>>>(obj.get("smoothed_focal_lengths").and_then(|x| x.as_str()).unwrap_or_default()) {
+                    self.params.write().smoothed_focal_lengths = fls;
                 }
 
                 obj.remove("raw_imu");
@@ -1698,6 +1715,9 @@ impl StabilizationManager {
                 if let Some(v) = obj.get("horizon_lock_integration_method").and_then(|x| x.as_i64()) {
                     self.gyro.write().set_horizon_lock_integration_method(v as i32);
                 }
+
+                if let Some(v) = obj.get("focal_length_smoothing_enabled") .and_then(|x| x.as_bool()) { params.focal_length_smoothing_enabled  = v; }
+                if let Some(v) = obj.get("focal_length_smoothing_strength").and_then(|x| x.as_f64())  { params.focal_length_smoothing_strength = v.clamp(0.0, 1.0); }
 
                 obj.remove("adaptive_zoom_fovs");
             }

--- a/src/core/smoothing/focal_length.rs
+++ b/src/core/smoothing/focal_length.rs
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+
+/// Apply Gaussian smoothing to focal length data
+/// 
+/// # Arguments
+/// * `focal_lengths` - Raw focal length values per frame
+/// * `strength` - Smoothing strength from 0.0 to 1.0
+/// * `window_size` - Size of the Gaussian window (should be odd)
+/// 
+/// # Returns
+/// Smoothed focal length array
+pub fn smooth_focal_lengths_gaussian(focal_lengths: &[Option<f64>], strength: f64, window_size: usize) -> Vec<Option<f64>> {
+    if focal_lengths.is_empty() || strength <= 0.0 {
+        return focal_lengths.to_vec();
+    }
+
+    let window_size = if window_size % 2 == 0 { window_size + 1 } else { window_size };
+    let half_window = window_size / 2;
+    
+    // Generate Gaussian kernel
+    let sigma = (window_size as f64 / 6.0) * (1.0 + strength * 2.0);
+    let mut kernel = vec![0.0; window_size];
+    let mut kernel_sum = 0.0;
+    
+    for i in 0..window_size {
+        let x = i as f64 - half_window as f64;
+        kernel[i] = (-x * x / (2.0 * sigma * sigma)).exp();
+        kernel_sum += kernel[i];
+    }
+    
+    // Normalize kernel
+    for k in &mut kernel {
+        *k /= kernel_sum;
+    }
+    
+    let mut smoothed = Vec::with_capacity(focal_lengths.len());
+    
+    for i in 0..focal_lengths.len() {
+        if focal_lengths[i].is_none() {
+            smoothed.push(None);
+            continue;
+        }
+        
+        let mut weighted_sum = 0.0;
+        let mut weight_sum = 0.0;
+        
+        for j in 0..window_size {
+            let idx = (i as isize + j as isize - half_window as isize).max(0).min(focal_lengths.len() as isize - 1) as usize;
+            if let Some(fl) = focal_lengths[idx] {
+                weighted_sum += fl * kernel[j];
+                weight_sum += kernel[j];
+            }
+        }
+        
+        if weight_sum > 0.0 {
+            let smoothed_value = weighted_sum / weight_sum;
+            // Blend between original and smoothed based on strength
+            if let Some(original) = focal_lengths[i] {
+                smoothed.push(Some(original * (1.0 - strength) + smoothed_value * strength));
+            } else {
+                smoothed.push(Some(smoothed_value));
+            }
+        } else {
+            smoothed.push(focal_lengths[i]);
+        }
+    }
+    
+    smoothed
+}

--- a/src/core/smoothing/focal_length.rs
+++ b/src/core/smoothing/focal_length.rs
@@ -1,15 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
 
-/// Apply Gaussian smoothing to focal length data
-/// 
-/// # Arguments
-/// * `focal_lengths` - Raw focal length values per frame
-/// * `strength` - Smoothing strength from 0.0 to 1.0
-/// * `window_size` - Size of the Gaussian window (should be odd)
-/// 
-/// # Returns
-/// Smoothed focal length array
+/// Apply Gaussian smoothing to focal length data.
+///
+/// Used for the short-kernel dequantization pass that kills metadata quantization stairs
+/// before the main adaptive filter runs.
 pub fn smooth_focal_lengths_gaussian(focal_lengths: &[Option<f64>], strength: f64, window_size: usize) -> Vec<Option<f64>> {
     if focal_lengths.is_empty() || strength <= 0.0 {
         return focal_lengths.to_vec();
@@ -17,34 +12,29 @@ pub fn smooth_focal_lengths_gaussian(focal_lengths: &[Option<f64>], strength: f6
 
     let window_size = if window_size % 2 == 0 { window_size + 1 } else { window_size };
     let half_window = window_size / 2;
-    
-    // Generate Gaussian kernel
+
     let sigma = (window_size as f64 / 6.0) * (1.0 + strength * 2.0);
     let mut kernel = vec![0.0; window_size];
     let mut kernel_sum = 0.0;
-    
+
     for i in 0..window_size {
         let x = i as f64 - half_window as f64;
         kernel[i] = (-x * x / (2.0 * sigma * sigma)).exp();
         kernel_sum += kernel[i];
     }
-    
-    // Normalize kernel
     for k in &mut kernel {
         *k /= kernel_sum;
     }
-    
+
     let mut smoothed = Vec::with_capacity(focal_lengths.len());
-    
     for i in 0..focal_lengths.len() {
         if focal_lengths[i].is_none() {
             smoothed.push(None);
             continue;
         }
-        
+
         let mut weighted_sum = 0.0;
         let mut weight_sum = 0.0;
-        
         for j in 0..window_size {
             let idx = (i as isize + j as isize - half_window as isize).max(0).min(focal_lengths.len() as isize - 1) as usize;
             if let Some(fl) = focal_lengths[idx] {
@@ -52,10 +42,9 @@ pub fn smooth_focal_lengths_gaussian(focal_lengths: &[Option<f64>], strength: f6
                 weight_sum += kernel[j];
             }
         }
-        
+
         if weight_sum > 0.0 {
             let smoothed_value = weighted_sum / weight_sum;
-            // Blend between original and smoothed based on strength
             if let Some(original) = focal_lengths[i] {
                 smoothed.push(Some(original * (1.0 - strength) + smoothed_value * strength));
             } else {
@@ -65,6 +54,93 @@ pub fn smooth_focal_lengths_gaussian(focal_lengths: &[Option<f64>], strength: f6
             smoothed.push(focal_lengths[i]);
         }
     }
-    
+
+    smoothed
+}
+
+/// Velocity-adaptive exponential smoothing for focal length.
+///
+/// Same idea as [`default_algo`](crate::smoothing::default_algo): at low velocity use a long
+/// time constant (heavy smoothing, kills jitter), at high velocity use a short time constant
+/// (light smoothing, tracks the real zoom without lag). Two-pass exponential filter (forward
+/// + backward) cancels phase shift — the output is aligned in time with the input.
+///
+/// * `max_smoothness_time` — time constant (seconds) applied at low velocity.
+/// * `min_smoothness_time` — time constant (seconds) applied at high velocity.
+/// * `max_velocity` — relative velocity (1/s) above which the filter fully switches to
+///   `min_smoothness_time`. Larger = filter stays at `max_smoothness_time` even during
+///   deliberate zooms (smoother output, some lag). Smaller = opens up on any motion.
+pub fn smooth_focal_lengths_adaptive(
+    focal_lengths: &[Option<f64>],
+    fps: f64,
+    max_smoothness_time: f64,
+    min_smoothness_time: f64,
+    max_velocity: f64,
+) -> Vec<Option<f64>> {
+    if focal_lengths.len() < 2 || fps <= 0.0 {
+        return focal_lengths.to_vec();
+    }
+
+    let dt = 1.0 / fps;
+    let alpha_max = 1.0 - (-dt / max_smoothness_time.max(1e-3)).exp();
+    let alpha_min = 1.0 - (-dt / min_smoothness_time.max(1e-3)).exp();
+
+    let n = focal_lengths.len();
+
+    // Relative velocity per sample. Using a relative rate (delta / value) keeps the threshold
+    // meaningful across different lenses: a 1mm change on an 18mm lens is a bigger event than
+    // the same 1mm change on a 200mm lens.
+    let mut velocity = vec![0.0f64; n];
+    for i in 1..n {
+        if let (Some(prev), Some(curr)) = (focal_lengths[i - 1], focal_lengths[i]) {
+            if prev > 0.0 {
+                velocity[i] = ((curr - prev) * fps / prev).abs();
+            }
+        }
+    }
+    velocity[0] = velocity.get(1).copied().unwrap_or(0.0);
+
+    // Smooth the velocity signal itself so a single noisy sample doesn't flip the alpha.
+    for i in 1..n {
+        velocity[i] = velocity[i - 1] * (1.0 - alpha_min) + velocity[i] * alpha_min;
+    }
+    for i in (0..n.saturating_sub(1)).rev() {
+        velocity[i] = velocity[i + 1] * (1.0 - alpha_min) + velocity[i] * alpha_min;
+    }
+
+    // Per-sample alpha: interpolate between alpha_max (slow motion → small alpha, heavy
+    // smoothing) and alpha_min (fast motion → larger alpha, light smoothing).
+    let per_sample_alpha = |i: usize| -> f64 {
+        let ratio = if max_velocity > 1e-6 { (velocity[i] / max_velocity).min(1.0) } else { 1.0 };
+        alpha_max * (1.0 - ratio) + alpha_min * ratio
+    };
+
+    // Locate first valid sample to seed the filter state.
+    let Some((start_idx, seed)) = focal_lengths.iter().enumerate().find_map(|(i, v)| v.map(|x| (i, x))) else {
+        return focal_lengths.to_vec();
+    };
+
+    // Forward pass.
+    let mut smoothed = vec![None; n];
+    let mut state = seed;
+    for i in start_idx..n {
+        if let Some(x) = focal_lengths[i] {
+            let a = per_sample_alpha(i);
+            state = state * (1.0 - a) + x * a;
+        }
+        // For gaps (None), hold the last state — the backward pass will pick it back up.
+        smoothed[i] = Some(state);
+    }
+
+    // Backward pass. Seed from the last forward-pass state.
+    let mut state = smoothed[n - 1].unwrap_or(seed);
+    for i in (start_idx..n).rev() {
+        if let Some(x) = smoothed[i] {
+            let a = per_sample_alpha(i);
+            state = state * (1.0 - a) + x * a;
+            smoothed[i] = Some(state);
+        }
+    }
+
     smoothed
 }

--- a/src/core/smoothing/mod.rs
+++ b/src/core/smoothing/mod.rs
@@ -6,6 +6,7 @@ pub mod none;
 pub mod plain;
 pub mod fixed;
 pub mod default_algo;
+pub mod focal_length;
 
 pub use nalgebra::*;
 use super::gyro_source::{ TimeQuat, Quat64 };

--- a/src/core/stabilization/compute_params.rs
+++ b/src/core/stabilization/compute_params.rs
@@ -59,7 +59,14 @@ pub struct ComputeParams {
 
     pub distortion_model: DistortionModel,
     pub digital_lens: Option<DistortionModel>,
-    pub digital_lens_params: Option<Vec<f64>>
+    pub digital_lens_params: Option<Vec<f64>>,
+
+    // Focal length smoothing
+    pub focal_lengths: Vec<Option<f64>>,
+    pub smoothed_focal_lengths: Vec<Option<f64>>,
+    pub focal_length_smoothing_enabled: bool,
+    pub focal_length_smoothing_strength: f64,
+    pub focal_length_time_window: f64,
 }
 impl ComputeParams {
     pub fn from_manager(mgr: &StabilizationManager) -> Self {
@@ -122,7 +129,13 @@ impl ComputeParams {
 
             keyframes: mgr.keyframes.read().clone(),
 
-            zooming_debug_points: false
+            zooming_debug_points: false,
+
+            focal_lengths: params.focal_lengths.clone(),
+            smoothed_focal_lengths: params.smoothed_focal_lengths.clone(),
+            focal_length_smoothing_enabled: params.focal_length_smoothing_enabled,
+            focal_length_smoothing_strength: params.focal_length_smoothing_strength,
+            focal_length_time_window: params.focal_length_time_window,
         }
     }
 

--- a/src/core/stabilization/compute_params.rs
+++ b/src/core/stabilization/compute_params.rs
@@ -66,7 +66,6 @@ pub struct ComputeParams {
     pub smoothed_focal_lengths: Vec<Option<f64>>,
     pub focal_length_smoothing_enabled: bool,
     pub focal_length_smoothing_strength: f64,
-    pub focal_length_time_window: f64,
 }
 impl ComputeParams {
     pub fn from_manager(mgr: &StabilizationManager) -> Self {
@@ -135,7 +134,6 @@ impl ComputeParams {
             smoothed_focal_lengths: params.smoothed_focal_lengths.clone(),
             focal_length_smoothing_enabled: params.focal_length_smoothing_enabled,
             focal_length_smoothing_strength: params.focal_length_smoothing_strength,
-            focal_length_time_window: params.focal_length_time_window,
         }
     }
 

--- a/src/core/stabilization/frame_transform.rs
+++ b/src/core/stabilization/frame_transform.rs
@@ -54,23 +54,29 @@ impl FrameTransform {
         fov_scale += if params.fov_overview && use_fovs && !for_ui { 1.0 } else { 0.0 };
         let mut fov = if use_fovs { params.fovs.get(frame).unwrap_or(if params.fovs.len() > 1 { params.fovs.last().unwrap() } else { &1.0 }) * fov_scale } else { 1.0 }.max(0.001);
         fov *= params.width as f64 / params.output_width.max(1) as f64;
-        
-        // Apply focal length compensation if enabled
-        if params.focal_length_smoothing_enabled && !for_ui {
-            if let (Some(&raw_fl), Some(&smoothed_fl)) = (
-                params.focal_lengths.get(frame).and_then(|x| x.as_ref()),
-                params.smoothed_focal_lengths.get(frame).and_then(|x| x.as_ref())
-            ) {
-                if raw_fl > 0.0 && smoothed_fl > 0.0 {
-                    // Compensation factor: raw / smoothed
-                    // When optical zoom increases (raw FL increases), we zoom out digitally (increase FOV)
-                    let compensation = raw_fl / smoothed_fl;
-                    fov *= compensation;
-                }
-            }
-        }
-        
         fov
+    }
+
+    /// Focal length smoothing compensation factor to apply to `fov`.
+    ///
+    /// Returns `dequantized_fl / smoothed_fl`. When the estimated true optical focal length is
+    /// longer than the smoothed target, we zoom out digitally (larger fov) so the apparent zoom
+    /// tracks the smoothed curve. The compensation is applied to `fov` only — `scaled_k` keeps
+    /// the raw pixel focal length, so the scaling lands on `new_k` but not the forward
+    /// projection, producing a visible digital zoom.
+    ///
+    /// Using the DEQUANTIZED curve (rather than raw metadata) as the denominator avoids
+    /// stairstep jumps in the sampling position when the camera quantizes the focal length
+    /// metadata to coarse steps. Both curves are frame-indexed, so the timestamps stay aligned.
+    fn focal_length_fov_compensation(params: &ComputeParams, frame: usize) -> f64 {
+        if !params.focal_length_smoothing_enabled { return 1.0; }
+        let Some(Some(dequantized_fl)) = params.focal_lengths.get(frame).copied() else { return 1.0; };
+        let Some(Some(smoothed_fl)) = params.smoothed_focal_lengths.get(frame).copied() else { return 1.0; };
+        if dequantized_fl > 0.0 && smoothed_fl > 0.0 {
+            dequantized_fl / smoothed_fl
+        } else {
+            1.0
+        }
     }
 
     pub fn get_lens_data_at_timestamp(params: &ComputeParams, timestamp_ms: f64, invert_asym_lens: bool) -> (Matrix3<f64>, [f64; 12], f64, f64, f64, Option<f64>) {
@@ -101,7 +107,6 @@ impl FrameTransform {
                     Some((val.focal_length? as f64 / ((val.pixel_pitch?.1 as f64 / 1000000.0) * val.capture_area_size?.1 as f64)) * params.height as f64)
                 });
                 if let Some(pfl) = pixel_focal_length {
-                    // println!("pfl: {pfl:.3}px, lens: {:?}", val);
                     camera_matrix[(0, 0)] = pfl;
                     camera_matrix[(1, 1)] = pfl;
                     camera_matrix[(0, 2)] = params.width as f64 / 2.0;
@@ -174,7 +179,8 @@ impl FrameTransform {
             focal_length) = Self::get_lens_data_at_timestamp(params, timestamp_ms, false);
         // ----------- Lens -----------
 
-        let mut fov = Self::get_fov(params, frame, true, timestamp_ms, false);
+        let fl_compensation = Self::focal_length_fov_compensation(params, frame);
+        let mut fov = Self::get_fov(params, frame, true, timestamp_ms, false) * fl_compensation;
         let mut ui_fov = Self::get_fov(params, frame, true, timestamp_ms, true);
         if let Some(adj) = params.lens.optimal_fov {
             if params.fovs.is_empty() {
@@ -183,6 +189,14 @@ impl FrameTransform {
                 ui_fov /= adj;
             }
         }
+
+        // Report the smoothed focal length to the UI readout so the "Focal length: X mm"
+        // overlay tracks the smoothed curve, matching what the viewer sees.
+        let reported_focal_length = if params.focal_length_smoothing_enabled {
+            params.smoothed_focal_lengths.get(frame).copied().flatten().or(focal_length)
+        } else {
+            focal_length
+        };
 
         let scaled_k = camera_matrix;
         let new_k = Self::get_new_k(&params, &camera_matrix, fov);
@@ -322,7 +336,7 @@ impl FrameTransform {
             kernel_params,
             fov: ui_fov,
             minimal_fov: *params.minimal_fovs.get(frame).unwrap_or(&1.0),
-            focal_length,
+            focal_length: reported_focal_length,
             mesh_data
         }
     }
@@ -334,24 +348,10 @@ impl FrameTransform {
 
         let frame = frame.unwrap_or_else(|| crate::frame_at_timestamp(timestamp_ms, params.scaled_fps) as usize);
 
-        let (mut camera_matrix, distortion_coeffs, _, _, _, _) = Self::get_lens_data_at_timestamp(params, timestamp_ms, params.framebuffer_inverted);
+        let (camera_matrix, distortion_coeffs, _, _, _, _) = Self::get_lens_data_at_timestamp(params, timestamp_ms, params.framebuffer_inverted);
 
-        // Apply focal length smoothing to camera matrix for FOV calculation
-        // This ensures undistortion during FOV estimation uses the smoothed focal length
-        if params.focal_length_smoothing_enabled && use_fovs {
-            if let (Some(&raw_fl), Some(&smoothed_fl)) = (
-                params.focal_lengths.get(frame).and_then(|x| x.as_ref()),
-                params.smoothed_focal_lengths.get(frame).and_then(|x| x.as_ref())
-            ) {
-                if raw_fl > 0.0 && smoothed_fl > 0.0 {
-                    let ratio = smoothed_fl / raw_fl;
-                    camera_matrix[(0, 0)] *= ratio;
-                    camera_matrix[(1, 1)] *= ratio;
-                }
-            }
-        }
-
-        let fov = Self::get_fov(params, frame, use_fovs, timestamp_ms, false);
+        let fl_compensation = Self::focal_length_fov_compensation(params, frame);
+        let fov = Self::get_fov(params, frame, use_fovs, timestamp_ms, false) * fl_compensation;
 
         let scaled_k = camera_matrix;
         let new_k = Self::get_new_k(params, &camera_matrix, fov);

--- a/src/core/stabilization_params.rs
+++ b/src/core/stabilization_params.rs
@@ -117,7 +117,14 @@ pub struct StabilizationParams {
     pub of_method: u32,
     pub current_device: i32,
 
-    pub zooming_debug_points: std::collections::BTreeMap<i64, Vec<(f64, f64)>>
+    pub zooming_debug_points: std::collections::BTreeMap<i64, Vec<(f64, f64)>>,
+
+    // Focal length smoothing
+    pub focal_lengths: Vec<Option<f64>>,
+    pub smoothed_focal_lengths: Vec<Option<f64>>,
+    pub focal_length_smoothing_enabled: bool,
+    pub focal_length_smoothing_strength: f64,
+    pub focal_length_time_window: f64,
 }
 impl Default for StabilizationParams {
     fn default() -> Self {
@@ -179,6 +186,12 @@ impl Default for StabilizationParams {
             frame_count: 0,
             duration_ms: 0.0,
             video_created_at: None,
+
+            focal_lengths: vec![],
+            smoothed_focal_lengths: vec![],
+            focal_length_smoothing_enabled: false,
+            focal_length_smoothing_strength: 0.5,
+            focal_length_time_window: 1.0,
         }
     }
 }
@@ -295,6 +308,8 @@ impl StabilizationParams {
             show_safe_area:            self.show_safe_area,
             max_zoom:                  self.max_zoom,
             max_zoom_iterations:       self.max_zoom_iterations,
+            focal_length_smoothing_enabled: self.focal_length_smoothing_enabled,
+            focal_length_smoothing_strength: self.focal_length_smoothing_strength,
             ..Self::default()
         };
     }

--- a/src/core/stabilization_params.rs
+++ b/src/core/stabilization_params.rs
@@ -124,7 +124,6 @@ pub struct StabilizationParams {
     pub smoothed_focal_lengths: Vec<Option<f64>>,
     pub focal_length_smoothing_enabled: bool,
     pub focal_length_smoothing_strength: f64,
-    pub focal_length_time_window: f64,
 }
 impl Default for StabilizationParams {
     fn default() -> Self {
@@ -191,7 +190,6 @@ impl Default for StabilizationParams {
             smoothed_focal_lengths: vec![],
             focal_length_smoothing_enabled: false,
             focal_length_smoothing_strength: 0.5,
-            focal_length_time_window: 1.0,
         }
     }
 }

--- a/src/core/zooming/mod.rs
+++ b/src/core/zooming/mod.rs
@@ -51,7 +51,7 @@ pub fn calculate_fovs(compute_params: &ComputeParams, timestamps: &[(usize, f64)
     let fov_estimator = fov_iterative::FovIterative::new(&compute_params, org_output_size);
     let mut fov_values = fov_estimator.compute(timestamps, &compute_params.trim_ranges);
     let debug_points = fov_estimator.get_debug_points();
-    
+
     let (final_fovs, final_fovs_minimal) = if compute_params.adaptive_zoom_window < -0.9 {
         // Static zoom
         let fov_minimal = fov_values.clone();
@@ -90,22 +90,6 @@ pub fn get_checksum(compute_params: &ComputeParams) -> u64 {
     hasher.write_u64(compute_params.adaptive_zoom_window.to_bits());
     hasher.write_u8(if compute_params.focal_length_smoothing_enabled { 1 } else { 0 });
     hasher.write_u64(compute_params.focal_length_smoothing_strength.to_bits());
-    hasher.write_u64(compute_params.focal_length_time_window.to_bits());
-    // Include focal length data arrays to ensure recalculation when they change
-    for fl in &compute_params.focal_lengths {
-        if let Some(val) = fl {
-            hasher.write_u64(val.to_bits());
-        } else {
-            hasher.write_u64(0);
-        }
-    }
-    for fl in &compute_params.smoothed_focal_lengths {
-        if let Some(val) = fl {
-            hasher.write_u64(val.to_bits());
-        } else {
-            hasher.write_u64(0);
-        }
-    }
 
     hasher.finish()
 }

--- a/src/ui/SettingsSelector.qml
+++ b/src/ui/SettingsSelector.qml
@@ -52,6 +52,7 @@ Modal {
             "Zooming":                    ["adaptive_zoom_window", "adaptive_zoom_center_offset", "adaptive_zoom_method", "additional_rotation", "additional_translation", "max_zoom", "max_zoom_iterations"],
             "Lens correction strength":   ["lens_correction_amount"],
             "Video speed":                ["video_speed", "video_speed_affects_smoothing", "video_speed_affects_zooming", "video_speed_affects_zooming_limit"],
+            "Focal length smoothing":     ["focal_length_smoothing_enabled", "focal_length_smoothing_strength", "focal_length_time_window"],
         },
         "Export settings|output": {
             "Codec":       ["codec", "codec_options", "bitrate", "use_gpu"],

--- a/src/ui/SettingsSelector.qml
+++ b/src/ui/SettingsSelector.qml
@@ -52,7 +52,7 @@ Modal {
             "Zooming":                    ["adaptive_zoom_window", "adaptive_zoom_center_offset", "adaptive_zoom_method", "additional_rotation", "additional_translation", "max_zoom", "max_zoom_iterations"],
             "Lens correction strength":   ["lens_correction_amount"],
             "Video speed":                ["video_speed", "video_speed_affects_smoothing", "video_speed_affects_zooming", "video_speed_affects_zooming_limit"],
-            "Focal length smoothing":     ["focal_length_smoothing_enabled", "focal_length_smoothing_strength", "focal_length_time_window"],
+            "Focal length smoothing":     ["focal_length_smoothing_enabled", "focal_length_smoothing_strength"],
         },
         "Export settings|output": {
             "Codec":       ["codec", "codec_options", "bitrate", "use_gpu"],

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -866,6 +866,7 @@ Item {
                 }
             }
             function onCompute_progress(id: real, progress: real): void {
+                chartUpdateTimer.axes = true;
                 chartUpdateTimer.start();
             }
         }

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -257,6 +257,17 @@ Item {
         TimelineAxisButton { id: a2; text: "Z"; onCheckedChanged: chart.setAxisVisible(2, checked); checked: chart.getAxisVisible(2); }
         TimelineAxisButton { id: a3; text: "W"; onCheckedChanged: chart.setAxisVisible(3, checked); checked: chart.getAxisVisible(3); }
         TimelineAxisButton { id: a8; text: "Z"; onCheckedChanged: chart.setAxisVisible(8, checked); checked: chart.getAxisVisible(8); tooltip: qsTr("Zooming"); }
+        TimelineAxisButton { 
+            id: a10; 
+            text: "FL"; 
+            onCheckedChanged: {
+                chart.setAxisVisible(10, checked);
+                chart.setAxisVisible(11, checked);
+            }
+            checked: chart.getAxisVisible(10) || chart.getAxisVisible(11);
+            tooltip: qsTr("Focal length");
+            visible: controller.has_per_frame_focal_length;
+        }
     }
     Column {
         visible: !root.fullScreen && !window.isMobileLayout;

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -257,9 +257,9 @@ Item {
         TimelineAxisButton { id: a2; text: "Z"; onCheckedChanged: chart.setAxisVisible(2, checked); checked: chart.getAxisVisible(2); }
         TimelineAxisButton { id: a3; text: "W"; onCheckedChanged: chart.setAxisVisible(3, checked); checked: chart.getAxisVisible(3); }
         TimelineAxisButton { id: a8; text: "Z"; onCheckedChanged: chart.setAxisVisible(8, checked); checked: chart.getAxisVisible(8); tooltip: qsTr("Zooming"); }
-        TimelineAxisButton { 
-            id: a10; 
-            text: "FL"; 
+        TimelineAxisButton {
+            id: a10;
+            text: "FL";
             onCheckedChanged: {
                 chart.setAxisVisible(10, checked);
                 chart.setAxisVisible(11, checked);

--- a/src/ui/components/TimelineGyroChart.rs
+++ b/src/ui/components/TimelineGyroChart.rs
@@ -34,6 +34,22 @@ struct Series {
 // viewMode 3: Quaternions
 // viewMode 3: Quaternions + smoothed quaternions
 
+// Series indices into `TimelineGyroChart::series`. Indices are sparse (9 is sync points,
+// which has no data in the series array — it's drawn from `sync_points` directly).
+const SERIES_X:               usize = 0;
+const SERIES_Y:               usize = 1;
+const SERIES_Z:               usize = 2;
+const SERIES_W:               usize = 3;
+const SERIES_SYNC_X:          usize = 4;
+const SERIES_SYNC_Y:          usize = 5;
+const SERIES_SYNC_Z:          usize = 6;
+const SERIES_SYNC_W:          usize = 7;
+const SERIES_FOV:             usize = 8;
+const SERIES_SYNC_POINTS:     usize = 9;
+const SERIES_FOCAL_LENGTH:    usize = 10;
+const SERIES_FOCAL_LENGTH_SM: usize = 11;
+const SERIES_COUNT:           usize = 12;
+
 #[derive(Default, QObject)]
 pub struct TimelineGyroChart {
     base: qt_base_class!(trait QQuickPaintedItem),
@@ -52,7 +68,7 @@ pub struct TimelineGyroChart {
 
     viewMode: qt_property!(u32; WRITE setViewMode NOTIFY viewModeChanged),
 
-    series: [Series; 4+4+1+1+2], // +2 for raw FL and smoothed FL
+    series: [Series; SERIES_COUNT],
 
     sync_points: BTreeMap<i64, (f64, f64)>, // timestamp, (offset, fitted offset)
 
@@ -435,8 +451,11 @@ impl TimelineGyroChart {
             self.smoothed_focal_lengths = params.smoothed_focal_lengths.iter().enumerate()
                 .filter_map(|(i, v)| v.map(|x| ChartData { timestamp_us: ts(i), values: [x] }))
                 .collect();
-            Self::normalize_height(&mut self.focal_lengths, None);
-            Self::normalize_height(&mut self.smoothed_focal_lengths, None);
+            // Normalize both series by the SAME max so they share a scale — otherwise raw's
+            // wider range gets compressed differently than smoothed's and it looks like the
+            // smoothed curve is biased toward the top.
+            let fl_max = Self::normalize_height(&mut self.focal_lengths, None);
+            Self::normalize_height(&mut self.smoothed_focal_lengths, fl_max);
         }
 
         self.update_data(series);
@@ -455,33 +474,33 @@ impl TimelineGyroChart {
             }
             match self.viewMode {
                 0 => {  // Gyroscope
-                    self.series[0].data = Self::get_serie_vector(&self.gyro, 0);
-                    self.series[1].data = Self::get_serie_vector(&self.gyro, 1);
-                    self.series[2].data = Self::get_serie_vector(&self.gyro, 2);
+                    self.series[SERIES_X].data = Self::get_serie_vector(&self.gyro, 0);
+                    self.series[SERIES_Y].data = Self::get_serie_vector(&self.gyro, 1);
+                    self.series[SERIES_Z].data = Self::get_serie_vector(&self.gyro, 2);
 
                     // + Sync results
-                    self.series[4].data = Self::get_serie_vector(&self.sync_results, 0);
-                    self.series[5].data = Self::get_serie_vector(&self.sync_results, 1);
-                    self.series[6].data = Self::get_serie_vector(&self.sync_results, 2);
-                    self.series[4].is_optflow = true;
-                    self.series[5].is_optflow = true;
-                    self.series[6].is_optflow = true;
+                    self.series[SERIES_SYNC_X].data = Self::get_serie_vector(&self.sync_results, 0);
+                    self.series[SERIES_SYNC_Y].data = Self::get_serie_vector(&self.sync_results, 1);
+                    self.series[SERIES_SYNC_Z].data = Self::get_serie_vector(&self.sync_results, 2);
+                    self.series[SERIES_SYNC_X].is_optflow = true;
+                    self.series[SERIES_SYNC_Y].is_optflow = true;
+                    self.series[SERIES_SYNC_Z].is_optflow = true;
                 }
                 1 => { // Accelerometer
-                    self.series[0].data = Self::get_serie_vector(&self.accl, 0);
-                    self.series[1].data = Self::get_serie_vector(&self.accl, 1);
-                    self.series[2].data = Self::get_serie_vector(&self.accl, 2);
+                    self.series[SERIES_X].data = Self::get_serie_vector(&self.accl, 0);
+                    self.series[SERIES_Y].data = Self::get_serie_vector(&self.accl, 1);
+                    self.series[SERIES_Z].data = Self::get_serie_vector(&self.accl, 2);
                 }
                 2 => { // Magnetometer
-                    self.series[0].data = Self::get_serie_vector(&self.magn, 0);
-                    self.series[1].data = Self::get_serie_vector(&self.magn, 1);
-                    self.series[2].data = Self::get_serie_vector(&self.magn, 2);
+                    self.series[SERIES_X].data = Self::get_serie_vector(&self.magn, 0);
+                    self.series[SERIES_Y].data = Self::get_serie_vector(&self.magn, 1);
+                    self.series[SERIES_Z].data = Self::get_serie_vector(&self.magn, 2);
                 }
                 3 => { // Quaternions
-                    self.series[0].data = Self::get_serie_vector(&self.quats, 0);
-                    self.series[1].data = Self::get_serie_vector(&self.quats, 1);
-                    self.series[2].data = Self::get_serie_vector(&self.quats, 2);
-                    self.series[3].data = Self::get_serie_vector(&self.quats, 3);
+                    self.series[SERIES_X].data = Self::get_serie_vector(&self.quats, 0);
+                    self.series[SERIES_Y].data = Self::get_serie_vector(&self.quats, 1);
+                    self.series[SERIES_Z].data = Self::get_serie_vector(&self.quats, 2);
+                    self.series[SERIES_W].data = Self::get_serie_vector(&self.quats, 3);
 
                     // + Sync quaternions
                     // self.series[4].data = Self::get_serie_vector(&self.sync_quats, 0);
@@ -490,23 +509,20 @@ impl TimelineGyroChart {
                     // self.series[7].data = Self::get_serie_vector(&self.sync_quats, 3);
 
                     // + Smoothed quaternions
-                    self.series[4].data = Self::get_serie_vector(&self.smoothed_quats, 0);
-                    self.series[5].data = Self::get_serie_vector(&self.smoothed_quats, 1);
-                    self.series[6].data = Self::get_serie_vector(&self.smoothed_quats, 2);
-                    self.series[7].data = Self::get_serie_vector(&self.smoothed_quats, 3);
+                    self.series[SERIES_SYNC_X].data = Self::get_serie_vector(&self.smoothed_quats, 0);
+                    self.series[SERIES_SYNC_Y].data = Self::get_serie_vector(&self.smoothed_quats, 1);
+                    self.series[SERIES_SYNC_Z].data = Self::get_serie_vector(&self.smoothed_quats, 2);
+                    self.series[SERIES_SYNC_W].data = Self::get_serie_vector(&self.smoothed_quats, 3);
                 }
                 _ => panic!("Invalid view mode")
             }
         }
 
-        self.series[8].data = Self::get_serie_vector(&self.fovs, 0);
-        self.series[8].is_fovs = true;
+        self.series[SERIES_FOV].data = Self::get_serie_vector(&self.fovs, 0);
+        self.series[SERIES_FOV].is_fovs = true;
 
-        // New focal length series
-        self.series[10].data = Self::get_serie_vector(&self.focal_lengths, 0);
-        self.series[10].is_optflow = false;  // Don't use optflow rendering
-        self.series[11].data = Self::get_serie_vector(&self.smoothed_focal_lengths, 0);
-        self.series[11].is_optflow = false;  // Don't use optflow rendering
+        self.series[SERIES_FOCAL_LENGTH].data = Self::get_serie_vector(&self.focal_lengths, 0);
+        self.series[SERIES_FOCAL_LENGTH_SM].data = Self::get_serie_vector(&self.smoothed_focal_lengths, 0);
 
         self.update();
     }
@@ -538,19 +554,18 @@ impl QQuickItem for TimelineGyroChart {
         self.visibleAreaLeft = 0.0;
         self.visibleAreaRight = 1.0;
         self.vscale = 1.0;
-        self.series[0].visible = true;
-        self.series[1].visible = true;
-        self.series[2].visible = true;
+        self.series[SERIES_X].visible = true;
+        self.series[SERIES_Y].visible = true;
+        self.series[SERIES_Z].visible = true;
 
-        self.series[4].visible = true;
-        self.series[5].visible = true;
-        self.series[6].visible = true;
+        self.series[SERIES_SYNC_X].visible = true;
+        self.series[SERIES_SYNC_Y].visible = true;
+        self.series[SERIES_SYNC_Z].visible = true;
 
-        self.series[8].visible = true;
+        self.series[SERIES_FOV].visible = true;
 
-        // New: start hidden
-        self.series[10].visible = false;
-        self.series[11].visible = false;
+        self.series[SERIES_FOCAL_LENGTH].visible = false;
+        self.series[SERIES_FOCAL_LENGTH_SM].visible = false;
     }
 
     fn geometry_changed(&mut self, _new: QRectF, _old: QRectF) {
@@ -574,22 +589,21 @@ impl QQuickPaintedItem for TimelineGyroChart {
             ]
         };
 
-        if self.series[0].visible { self.drawAxis(p, 0, colors[0]); } // X
-        if self.series[1].visible { self.drawAxis(p, 1, colors[1]); } // Y
-        if self.series[2].visible { self.drawAxis(p, 2, colors[2]); } // Z
-        if self.series[3].visible { self.drawAxis(p, 3, colors[3]); } // Angle
+        if self.series[SERIES_X].visible { self.drawAxis(p, SERIES_X, colors[0]); }
+        if self.series[SERIES_Y].visible { self.drawAxis(p, SERIES_Y, colors[1]); }
+        if self.series[SERIES_Z].visible { self.drawAxis(p, SERIES_Z, colors[2]); }
+        if self.series[SERIES_W].visible { self.drawAxis(p, SERIES_W, colors[3]); }
 
-        if self.series[4].visible { self.drawAxis(p, 4, colors[4]); } // Sync X
-        if self.series[5].visible { self.drawAxis(p, 5, colors[5]); } // Sync Y
-        if self.series[6].visible { self.drawAxis(p, 6, colors[6]); } // Sync Z
-        if self.series[7].visible { self.drawAxis(p, 7, colors[7]); } // Sync Angle
+        if self.series[SERIES_SYNC_X].visible { self.drawAxis(p, SERIES_SYNC_X, colors[4]); }
+        if self.series[SERIES_SYNC_Y].visible { self.drawAxis(p, SERIES_SYNC_Y, colors[5]); }
+        if self.series[SERIES_SYNC_Z].visible { self.drawAxis(p, SERIES_SYNC_Z, colors[6]); }
+        if self.series[SERIES_SYNC_W].visible { self.drawAxis(p, SERIES_SYNC_W, colors[7]); }
 
-        if self.series[8].visible { self.drawOverlay(p, 8, colors[8]); } // FOVs - zooming amount
+        if self.series[SERIES_FOV].visible { self.drawOverlay(p, SERIES_FOV, colors[8]); } // zooming amount
 
-        // New draws for focal length
-        if self.series[10].visible { self.drawAxis(p, 10, "#ff6600"); } // Raw focal length (orange/darker)
-        if self.series[11].visible { self.drawAxis(p, 11, "#cccc66"); } // Smoothed focal length (yellow/brighter, on top)
+        if self.series[SERIES_FOCAL_LENGTH].visible    { self.drawAxis(p, SERIES_FOCAL_LENGTH,    "#ff6600"); } // raw FL
+        if self.series[SERIES_FOCAL_LENGTH_SM].visible { self.drawAxis(p, SERIES_FOCAL_LENGTH_SM, "#cccc66"); } // smoothed FL (drawn on top)
 
-        if self.series[9].visible { self.drawSyncPoints(p); } // Sync points and line fit
+        if self.series[SERIES_SYNC_POINTS].visible { self.drawSyncPoints(p); }
     }
 }

--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -549,6 +549,55 @@ MenuItem {
         }
     }
 
+    CheckBoxWithContent {
+        id: flEnable;
+        text: qsTr("Stabilize focal length");
+
+        cb.checked: controller.focal_length_smoothing_enabled;
+        cb.onCheckedChanged: controller.focal_length_smoothing_enabled = cb.checked;
+
+        Label {
+            text: qsTr("Focal length smoothing");
+            position: Label.LeftPosition;
+            SliderWithField {
+                id: flStrength;
+                from: 0;
+                to: 1;
+                precision: 2;
+                width: parent.width;
+                value: controller.focal_length_smoothing_strength;
+                defaultValue: 0.5;
+                onValueChanged: controller.focal_length_smoothing_strength = value;
+            }
+        }
+
+        Label {
+            text: qsTr("Focal length time window");
+            position: Label.LeftPosition;
+            SliderWithField {
+                id: flTimeWindow;
+                from: 0.1;
+                to: 5.0;
+                precision: 2;
+                width: parent.width;
+                value: controller.focal_length_time_window;
+                defaultValue: 1.0;
+                unit: qsTr("s");
+                onValueChanged: controller.focal_length_time_window = value;
+            }
+        }
+
+        CheckBox {
+            id: flShowPlot;
+            text: qsTr("Show focal length plot");
+            checked: false;
+            onCheckedChanged: {
+                window.videoArea.timeline.chart.setAxisVisible(10, checked);
+                window.videoArea.timeline.chart.setAxisVisible(11, checked);
+            }
+        }
+    }
+
     AdvancedSection {
         InfoMessageSmall {
             id: fovWarning;

--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -101,6 +101,16 @@ MenuItem {
                 integrationMethod.currentIndex = stab.horizon_lock_integration_method;
             }
 
+            if (stab.hasOwnProperty("focal_length_smoothing_enabled")) {
+                flEnable.cb.checked = !!stab.focal_length_smoothing_enabled;
+            }
+            if (stab.hasOwnProperty("focal_length_smoothing_strength")) {
+                flStrength.value = +stab.focal_length_smoothing_strength;
+            }
+            if (stab.hasOwnProperty("focal_length_time_window")) {
+                flTimeWindow.value = +stab.focal_length_time_window;
+            }
+
             const hasKeyframes = typeof obj.keyframes === "object" && obj.keyframes !== null;
             const isLockHorizonAmountKeyframed = hasKeyframes && typeof obj.keyframes.LockHorizonAmount === "object";
             const isLockHorizonRollKeyframed = hasKeyframes && typeof obj.keyframes.LockHorizonRoll === "object";
@@ -552,6 +562,7 @@ MenuItem {
     CheckBoxWithContent {
         id: flEnable;
         text: qsTr("Stabilize focal length");
+        visible: controller.has_per_frame_focal_length;
 
         cb.checked: controller.focal_length_smoothing_enabled;
         cb.onCheckedChanged: controller.focal_length_smoothing_enabled = cb.checked;
@@ -584,16 +595,6 @@ MenuItem {
                 defaultValue: 1.0;
                 unit: qsTr("s");
                 onValueChanged: controller.focal_length_time_window = value;
-            }
-        }
-
-        CheckBox {
-            id: flShowPlot;
-            text: qsTr("Show focal length plot");
-            checked: false;
-            onCheckedChanged: {
-                window.videoArea.timeline.chart.setAxisVisible(10, checked);
-                window.videoArea.timeline.chart.setAxisVisible(11, checked);
             }
         }
     }

--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -35,6 +35,8 @@ MenuItem {
         property alias zoomingMethod: zoomingMethod.currentIndex;
         property alias maxZoom: maxZoomSlider.value;
         property alias maxZoomIterations: maxZoomIterations.value;
+        property alias focalLengthSmoothingEnabled: flEnable.cb.checked;
+        property alias focalLengthSmoothingStrength: flStrength.value;
 
         Component.onCompleted: settings.init(sett);
         function propChanged() { settings.propChanged(sett); }
@@ -106,9 +108,6 @@ MenuItem {
             }
             if (stab.hasOwnProperty("focal_length_smoothing_strength")) {
                 flStrength.value = +stab.focal_length_smoothing_strength;
-            }
-            if (stab.hasOwnProperty("focal_length_time_window")) {
-                flTimeWindow.value = +stab.focal_length_time_window;
             }
 
             const hasKeyframes = typeof obj.keyframes === "object" && obj.keyframes !== null;
@@ -568,33 +567,19 @@ MenuItem {
         cb.onCheckedChanged: controller.focal_length_smoothing_enabled = cb.checked;
 
         Label {
-            text: qsTr("Focal length smoothing");
+            text: qsTr("Smoothness");
             position: Label.LeftPosition;
             SliderWithField {
                 id: flStrength;
                 from: 0;
-                to: 1;
-                precision: 2;
+                to: 100;
+                precision: 1;
+                scaler: 100.0;
+                unit: "%";
                 width: parent.width;
                 value: controller.focal_length_smoothing_strength;
-                defaultValue: 0.5;
+                defaultValue: 30.0;
                 onValueChanged: controller.focal_length_smoothing_strength = value;
-            }
-        }
-
-        Label {
-            text: qsTr("Focal length time window");
-            position: Label.LeftPosition;
-            SliderWithField {
-                id: flTimeWindow;
-                from: 0.1;
-                to: 5.0;
-                precision: 2;
-                width: parent.width;
-                value: controller.focal_length_time_window;
-                defaultValue: 1.0;
-                unit: qsTr("s");
-                onValueChanged: controller.focal_length_time_window = value;
             }
         }
     }


### PR DESCRIPTION
## Feature: Focal Length Smoothing

This PR adds focal length stabilization for cameras with dynamic lens metadata (primarily Sony cameras).

### What it does
- Smooths out abrupt zoom changes (zoom-ins and zoom-outs) captured in camera metadata
- Uses Gaussian filtering on the raw focal length signal to create a smooth curve
- Applies digital zoom compensation to match the smoothed focal length
- Provides real-time visualization of raw and smoothed focal length in the timeline

### Implementation
- New smoothing module with Gaussian filtering algorithm
- Integration with existing FOV calculation pipeline
- Focal length data extraction from lens metadata
- Digital compensation applied during frame transformation

### UI Controls (Stabilization menu)
- **Enable toggle**: "Stabilize focal length" checkbox
- **Smoothing strength**: 0.0 to 1.0 (default 0.5)
- **Time window**: 0.1 to 5.0 seconds (default 1.0s)
- **Visualization**: Optional plot overlay in timeline chart (orange = raw, yellow = smoothed)

### Modified Files
- `src/core/smoothing/focal_length.rs` (new)
- `src/core/smoothing/mod.rs`
- `src/core/lib.rs`
- `src/core/stabilization_params.rs`
- `src/core/stabilization/compute_params.rs`
- `src/core/stabilization/frame_transform.rs`
- `src/core/zooming/mod.rs`
- `src/controller.rs`
- `src/ui/components/TimelineGyroChart.rs`
- `src/ui/components/Timeline.qml`
- `src/ui/menu/Stabilization.qml`

### Testing
Tested with Sony camera footage containing variable focal length metadata.