### PR TITLE
Add third party sdk and plugins download base

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -2083,7 +2083,8 @@ impl Controller {
         let progress = util::qt_queued_callback_mut(QPointer::from(self as &Self), move |this, (percent, sdk_name, error_string): (f64, &'static str, String)| {
             this.external_sdk_progress(percent, QString::from(sdk_name), QString::from(error_string), QString::from(url.clone()));
         });
-        crate::external_sdk::install(&filename, progress);
+        let sdkbase = gyroflow_core::settings::get_str("sdkBase", "");
+        crate::external_sdk::install(&filename, &sdkbase, progress);
     }
 
     fn mp4_merge(&self, file_list: QStringList, output_folder: QUrl, output_filename: QString) {
@@ -2357,8 +2358,9 @@ impl Controller {
                         this.nle_plugins_result(command2.clone(), QString::from(r));
                     });
                     core::run_threaded(move || {
+                        let plugins_base = gyroflow_core::settings::get_str("pluginsBase", "");
                         let result = match command.as_ref() {
-                            "install" => crate::nle_plugins::install(&typ),
+                            "install" => crate::nle_plugins::install(&typ, plugins_base),
                             "latest_version" => crate::nle_plugins::latest_version().ok_or(std::io::Error::new(std::io::ErrorKind::Other, "Failed to check version")),
                             _ => Err(std::io::Error::new(std::io::ErrorKind::Other, format!("Unknown command {command}")))
                         };

--- a/src/external_sdk/braw.rs
+++ b/src/external_sdk/braw.rs
@@ -31,15 +31,21 @@ impl BrawSdk {
         true
     }
 
-    pub fn get_download_url() -> Option<&'static str> {
-        if cfg!(target_os = "windows") {
-            Some("https://api.gyroflow.xyz/sdk/Blackmagic_RAW_SDK_Windows_5.0.0.tar.gz")
+    pub fn get_download_url(sdk_base: &str) -> Option<String> {
+        let filename = if cfg!(target_os = "windows") {
+            "Blackmagic_RAW_SDK_Windows_5.0.0.tar.gz"
         } else if cfg!(target_os = "macos") {
-            Some("https://api.gyroflow.xyz/sdk/Blackmagic_RAW_SDK_MacOS_5.0.0.tar.gz")
+            "Blackmagic_RAW_SDK_MacOS_5.0.0.tar.gz"
         } else if cfg!(target_os = "linux") {
-            Some("https://api.gyroflow.xyz/sdk/Blackmagic_RAW_SDK_Linux_5.0.0.tar.gz")
+            "Blackmagic_RAW_SDK_Linux_5.0.0.tar.gz"
         } else {
-            None
+            return None;
+        };
+
+        if !sdk_base.is_empty() {
+            Some(format!("{}/{}", sdk_base.trim_end_matches('/'), filename))
+        } else {
+            Some(format!("https://api.gyroflow.xyz/sdk/{}", filename))
         }
     }
 }

--- a/src/external_sdk/ffmpeg_gpl.rs
+++ b/src/external_sdk/ffmpeg_gpl.rs
@@ -16,15 +16,21 @@ impl FfmpegGpl {
         true
     }
 
-    pub fn get_download_url() -> Option<&'static str> {
-        if cfg!(target_os = "windows") {
-            Some("https://api.gyroflow.xyz/sdk/ffmpeg_gpl_Windows.tar.gz")
+    pub fn get_download_url(sdk_base: &str) -> Option<String> {
+        let filename = if cfg!(target_os = "windows") {
+            "ffmpeg_gpl_Windows.tar.gz"
         } else if cfg!(target_os = "macos") {
-            Some("https://api.gyroflow.xyz/sdk/ffmpeg_gpl_MacOS.tar.gz")
+            "ffmpeg_gpl_MacOS.tar.gz"
         } else if cfg!(target_os = "linux") {
-            Some("https://api.gyroflow.xyz/sdk/ffmpeg_gpl_Linux.tar.gz")
+            "ffmpeg_gpl_Linux.tar.gz"
         } else {
-            None
+            return None;
+        };
+
+        if !sdk_base.is_empty() {
+            Some(format!("{}/{}", sdk_base.trim_end_matches('/'), filename))
+        } else {
+            Some(format!("https://api.gyroflow.xyz/sdk/{}", filename))
         }
     }
 }

--- a/src/external_sdk/mod.rs
+++ b/src/external_sdk/mod.rs
@@ -49,13 +49,13 @@ pub fn requires_install(filename: &str) -> bool {
     false
 }
 
-pub fn install<F: Fn((f64, &'static str, String)) + Send + Sync + Clone + 'static>(filename: &str, cb: F) {
+pub fn install<F: Fn((f64, &'static str, String)) + Send + Sync + Clone + 'static>(filename: &str,sdkbase: &str,cb: F) {
     let (url, sdk_name) = if filename.to_lowercase().ends_with(".braw") {
-        (braw::BrawSdk::get_download_url(), "Blackmagic RAW SDK")
+        (braw::BrawSdk::get_download_url(sdkbase), "Blackmagic RAW SDK")
     } else if filename.to_lowercase().ends_with(".r3d") || filename.to_lowercase().ends_with(".nev") {
-        (r3d::REDSdk::get_download_url(), "RED SDK")
+        (r3d::REDSdk::get_download_url(sdkbase), "RED SDK")
     } else if filename == "ffmpeg_gpl" {
-        (FfmpegGpl::get_download_url(), "FFmpeg GPL codecs (x264, x265)")
+        (FfmpegGpl::get_download_url(sdkbase), "FFmpeg GPL codecs (x264, x265)")
     } else {
         (None, "")
     };

--- a/src/external_sdk/r3d.rs
+++ b/src/external_sdk/r3d.rs
@@ -36,15 +36,21 @@ impl REDSdk {
         true
     }
 
-    pub fn get_download_url() -> Option<&'static str> {
-        if cfg!(target_os = "windows") {
-            Some("https://api.gyroflow.xyz/sdk/RED_SDK_Windows_9.1.2.tar.gz")
+    pub fn get_download_url(sdk_base: &str) -> Option<String> {
+        let filename = if cfg!(target_os = "windows") {
+            "RED_SDK_Windows_9.1.2.tar.gz"
         } else if cfg!(target_os = "macos") {
-            Some("https://api.gyroflow.xyz/sdk/RED_SDK_MacOS_9.1.2.tar.gz")
+            "RED_SDK_MacOS_9.1.2.tar.gz"
         } else if cfg!(target_os = "linux") {
-            Some("https://api.gyroflow.xyz/sdk/RED_SDK_Linux_9.1.2.tar.gz")
+            "RED_SDK_Linux_9.1.2.tar.gz"
         } else {
-            None
+            return None;
+        };
+
+        if !sdk_base.is_empty() {
+            Some(format!("{}/{}", sdk_base.trim_end_matches('/'), filename))
+        } else {
+            Some(format!("https://api.gyroflow.xyz/sdk/{}", filename))
         }
     }
 

--- a/src/nle_plugins.rs
+++ b/src/nle_plugins.rs
@@ -147,8 +147,11 @@ fn copy_files(tempdir: &str, extract_path: &str, typ: &str) -> io::Result<()> {
     }
 }
 
-pub fn install(typ: &str) -> io::Result<String> {
-    let nightly_base = "https://nightly.link/gyroflow/gyroflow-plugins/workflows/release/main/";
+pub fn install(typ: &str, plugins_base: String) -> io::Result<String> {
+    let mut nightly_base = "https://nightly.link/gyroflow/gyroflow-plugins/workflows/release/main/";
+    if !plugins_base.is_empty() {
+        nightly_base = &plugins_base;
+    }
     let release_base = "https://github.com/gyroflow/gyroflow-plugins/releases/latest/download/";
     let (download_url, extract_path) = match typ {
         "openfx" => {


### PR DESCRIPTION
Add "sdkBase" and "pluginsBase" in settings.json to open the third party download address. If they are empty, the original settings will be maintained.