### PR TITLE
Filtering of DIS Optical Flow Algorithm Results

### DIFF
--- a/src/nle_plugins.rs
+++ b/src/nle_plugins.rs
@@ -225,6 +225,8 @@ pub fn is_nle_installed(typ: &str) -> bool {
             } else {
                 Path::new("/Applications/DaVinci Resolve/").exists() ||
                 Path::new("/Applications/DaVinci Resolve.app/").exists() ||
+                Path::new("/Applications/DaVinci Resolve Studio/").exists() ||
+                Path::new("/Applications/DaVinci Resolve Studio.app/").exists() ||
                 Path::new("/Library/OFX/Plugins").exists()
             }
         }


### PR DESCRIPTION
Through the variance method, filter out the parts with weak texture in the results. Tests have shown that this can significantly improve the success rate of synchronization.

The following is a comparison. Some incorrect results are filtered out.

<img width="1056" height="630" alt="before" src="https://github.com/user-attachments/assets/0428b855-dc01-4476-aa92-0d94c1c628d9" />
<img width="1040" height="635" alt="after" src="https://github.com/user-attachments/assets/7cd8d085-bc1a-4ad4-bde0-1f463f11647f" />
