### PR TITLE
Add optional “Automatic lock” for horizon locking (dynamic tilt + smoothing)

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -78,7 +78,10 @@ pub struct Controller {
     get_smoothing_max_angles: qt_method!(fn(&self) -> QJsonArray),
     get_smoothing_status: qt_method!(fn(&self) -> QJsonArray),
     set_smoothing_param: qt_method!(fn(&self, name: QString, val: f64)),
-    set_horizon_lock: qt_method!(fn(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64)),
+    set_horizon_lock: qt_method!(fn(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64)),    
+    generate_automatic_lock_keyframes: qt_method!(fn(&self, threshold_deg_s: f64, interval_ms: f64)),
+    get_turn_speed: qt_method!(fn(&self, timestamp_ms: f64) -> f64),
+    get_x_angle: qt_method!(fn(&self, timestamp_ms: f64) -> f64),
     set_use_gravity_vectors: qt_method!(fn(&self, v: bool)),
     set_horizon_lock_integration_method: qt_method!(fn(&self, v: i32)),
     set_preview_resolution: qt_method!(fn(&mut self, target_height: i32, player: QJSValue)),
@@ -1196,7 +1199,7 @@ impl Controller {
         self.chart_data_changed();
         self.request_recompute();
     }
-    wrap_simple_method!(set_horizon_lock, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64; recompute; chart_data_changed);
+    wrap_simple_method!(set_horizon_lock, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64; recompute; chart_data_changed);
     wrap_simple_method!(set_use_gravity_vectors, v: bool; recompute; chart_data_changed);
     wrap_simple_method!(set_horizon_lock_integration_method, v: i32; recompute; chart_data_changed);
     pub fn get_smoothing_algs(&self) -> QVariantList {
@@ -1504,6 +1507,73 @@ impl Controller {
             QVariantList::from_iter(mc.1.iter())
         } else {
             QVariantList::default()
+        }
+    }
+    fn get_turn_speed(&self, timestamp_ms: f64) -> f64 {
+        let params = self.stabilizer.params.read();
+        let fps = params.fps;
+        let frame_duration_ms = 1000.0 / fps;
+        let lookback_ms = 60.0 * frame_duration_ms;
+        if timestamp_ms < lookback_ms {
+            return f64::NAN;
+        }
+        let current_timestamp_ms = timestamp_ms;
+        let past_timestamp_ms = timestamp_ms - lookback_ms;
+        let gyro = self.stabilizer.gyro.read();
+        let quat_org_current = gyro.org_quat_at_timestamp(current_timestamp_ms);
+        let quat_smooth_current = gyro.smoothed_quat_at_timestamp(current_timestamp_ms);
+        let quat_org_past = gyro.org_quat_at_timestamp(past_timestamp_ms);
+        let quat_smooth_past = gyro.smoothed_quat_at_timestamp(past_timestamp_ms);
+        let quat_stab_current = (quat_smooth_current / quat_org_current).inverse();
+        let quat_stab_past = (quat_smooth_past / quat_org_past).inverse();
+        let euler_current = quat_stab_current.euler_angles();
+        let euler_past = quat_stab_past.euler_angles();
+        let roll_current = euler_current.2;
+        let roll_past = euler_past.2;
+        let mut angle_change_deg = (roll_current - roll_past).to_degrees();
+        while angle_change_deg > 180.0 {
+            angle_change_deg -= 360.0;
+        }
+        while angle_change_deg < -180.0 {
+            angle_change_deg += 360.0;
+        }
+        let time_diff_s = lookback_ms / 1000.0;
+        angle_change_deg / time_diff_s
+    }
+    fn get_x_angle(&self, timestamp_ms: f64) -> f64 {
+        let gyro = self.stabilizer.gyro.read();
+        let quat_org = gyro.org_quat_at_timestamp(timestamp_ms);
+        let quat_smooth = gyro.smoothed_quat_at_timestamp(timestamp_ms);
+        let quat_stab = (quat_smooth / quat_org).inverse();
+        let euler = quat_stab.euler_angles();
+        let roll = euler.2;
+        roll.to_degrees()
+    }
+    pub fn generate_automatic_lock_keyframes(&self, threshold_deg_s: f64, interval_ms: f64) {
+        if threshold_deg_s <= 0.0 {
+            return;
+        }
+        let duration_ms = self.stabilizer.params.read().duration_ms;
+        if duration_ms <= 0.0 {
+            return;
+        }
+        self.stabilizer.keyframes.write().clear_type(&KeyframeType::LockHorizonAmount);
+        let mut current_ms = 0.0;
+        while current_ms <= duration_ms {
+            let turn_speed = self.get_turn_speed(current_ms);
+            if !turn_speed.is_nan() {
+                let current_speed = turn_speed.abs();
+                let lock_amount = if current_speed >= threshold_deg_s {
+                    0.0
+                } else if threshold_deg_s > 0.0 {
+                    (100.0 * (1.0 - current_speed / threshold_deg_s)).max(0.0).min(100.0)
+                } else {
+                    100.0
+                };
+                let timestamp_us = (current_ms * 1000.0) as i64;
+                self.stabilizer.keyframes.write().set(&KeyframeType::LockHorizonAmount, timestamp_us, lock_amount);
+            }
+            current_ms += interval_ms;
         }
     }
     fn set_lens_param(&self, param: QString, value: f64) {

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -78,7 +78,7 @@ pub struct Controller {
     get_smoothing_max_angles: qt_method!(fn(&self) -> QJsonArray),
     get_smoothing_status: qt_method!(fn(&self) -> QJsonArray),
     set_smoothing_param: qt_method!(fn(&self, name: QString, val: f64)),
-    set_horizon_lock: qt_method!(fn(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64)),    
+    set_horizon_lock: qt_method!(fn(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64, tilt_accel_limit: f64)),    
     generate_automatic_lock_keyframes: qt_method!(fn(&self, threshold_deg_s: f64, interval_ms: f64)),
     get_turn_speed: qt_method!(fn(&self, timestamp_ms: f64) -> f64),
     get_x_angle: qt_method!(fn(&self, timestamp_ms: f64) -> f64),
@@ -1199,7 +1199,7 @@ impl Controller {
         self.chart_data_changed();
         self.request_recompute();
     }
-    wrap_simple_method!(set_horizon_lock, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64; recompute; chart_data_changed);
+    wrap_simple_method!(set_horizon_lock, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64, tilt_accel_limit: f64; recompute; chart_data_changed);
     wrap_simple_method!(set_use_gravity_vectors, v: bool; recompute; chart_data_changed);
     wrap_simple_method!(set_horizon_lock_integration_method, v: i32; recompute; chart_data_changed);
     pub fn get_smoothing_algs(&self) -> QVariantList {

--- a/src/core/calibration/mod.rs
+++ b/src/core/calibration/mod.rs
@@ -177,7 +177,7 @@ impl LensCalibrator {
 
                         for (_pos, mut pt) in corners.iter::<Point2f>()? {
                             if let Some(digital) = &digital_lens {
-                                if let Some(mut pt2) = digital.undistort_point((pt.x,  pt.y), &kernel_params) {
+                                if let Some(pt2) = digital.undistort_point((pt.x, pt.y), &kernel_params) {
                                     // TODO
                                     // Move from center to the left, because we trim the right part making it 4:3
                                     //pt2.0 -= 0.125; // (16-4) / (9-3) / 16
@@ -214,8 +214,8 @@ impl LensCalibrator {
         let find_min = |a: (f64, Matrix3::<f64>, Vector4::<f64>, Vec<i32>), b: (f64, Matrix3::<f64>, Vector4::<f64>, Vec<i32>)| -> (f64, Matrix3::<f64>, Vector4::<f64>, Vec<i32>) { if a.0 < b.0 { a } else { b } };
 
         let image_points = self.image_points.read().clone();
-        let mut width = self.width as i32;
-        if let Some(digital) = self.digital_lens.as_ref().map(|x| DistortionModel::from_name(&x)) {
+        let width = self.width as i32;
+        if let Some(__digital) = self.digital_lens.as_ref().map(|x| DistortionModel::from_name(&x)) {
             // TODO
             //width = (width as f32 / 1.33333333).round() as i32;
         }

--- a/src/core/filesystem/apple.rs
+++ b/src/core/filesystem/apple.rs
@@ -205,18 +205,18 @@ pub fn resolve_bookmark(bookmark_data: &str, project_url: Option<&str>) -> (Stri
 }
 
 unsafe fn get_error(err: CFErrorRef) -> String {
-    let cf_str = CFErrorCopyDescription(err);
-    let c_string = CFStringGetCStringPtr(cf_str, kCFStringEncodingUTF8);
+    let cf_str = unsafe { CFErrorCopyDescription(err) };
+    let c_string = unsafe { CFStringGetCStringPtr(cf_str, kCFStringEncodingUTF8) };
     let ret = if !c_string.is_null() {
-        std::ffi::CStr::from_ptr(c_string).to_string_lossy().into()
+        unsafe { std::ffi::CStr::from_ptr(c_string).to_string_lossy().into() }
     } else {
-        let range = CFRange { location: 0, length: CFStringGetLength(cf_str) };
+        let range = CFRange { location: 0, length: unsafe { CFStringGetLength(cf_str) } };
         let mut len: CFIndex = 0;
-        CFStringGetBytes(cf_str, range, kCFStringEncodingUTF8, 0, false as Boolean, ptr::null_mut(), 0, &mut len);
+        unsafe { CFStringGetBytes(cf_str, range, kCFStringEncodingUTF8, 0, false as Boolean, ptr::null_mut(), 0, &mut len); }
         let mut buffer = vec![0u8; len as usize];
-        CFStringGetBytes(cf_str, range, kCFStringEncodingUTF8, 0, false as Boolean, buffer.as_mut_ptr(), buffer.len() as isize, ptr::null_mut());
-        String::from_utf8_unchecked(buffer)
+        unsafe { CFStringGetBytes(cf_str, range, kCFStringEncodingUTF8, 0, false as Boolean, buffer.as_mut_ptr(), buffer.len() as isize, ptr::null_mut()); }
+        unsafe { String::from_utf8_unchecked(buffer) }
     };
-    CFRelease(cf_str as CFTypeRef);
+    unsafe { CFRelease(cf_str as CFTypeRef); }
     ret
 }

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1024,8 +1024,8 @@ impl StabilizationManager {
         self.smoothing.write().current_mut().as_mut().set_parameter(name, val);
         self.invalidate_smoothing();
     }
-    pub fn set_horizon_lock(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64) {
-        self.smoothing.write().horizon_lock.set_horizon(lock_percent, roll, lock_pitch, pitch);
+    pub fn set_horizon_lock(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64) {
+        self.smoothing.write().horizon_lock.set_horizon(lock_percent, roll, lock_pitch, pitch, automatic_lock, turn_threshold, turn_smoothing_ms, turn_multiplier);
         self.invalidate_smoothing();
     }
     pub fn set_use_gravity_vectors(&self, v: bool) {
@@ -1581,7 +1581,11 @@ impl StabilizationManager {
                     if let Some(horizon_roll) = obj.get("horizon_lock_roll").and_then(|x| x.as_f64()) {
                         let horizon_pitch_enabled = obj.get("horizon_lock_pitch_enabled").and_then(|x| x.as_bool()).unwrap_or(false);
                         let horizon_pitch = obj.get("horizon_lock_pitch").and_then(|x| x.as_f64()).unwrap_or(0.0);
-                        smoothing.horizon_lock.set_horizon(horizon_amount, horizon_roll, horizon_pitch_enabled, horizon_pitch);
+                        let turn_threshold = obj.get("turn_threshold").and_then(|x| x.as_f64()).unwrap_or(5.0);
+                        let turn_smoothing_ms = obj.get("turn_smoothing_ms").and_then(|x| x.as_f64()).unwrap_or(500.0);
+                        let turn_multiplier = obj.get("turn_multiplier").and_then(|x| x.as_f64()).unwrap_or(1.0);
+                        let automatic_lock = obj.get("automatic_lock").and_then(|x| x.as_bool()).unwrap_or(false);
+                        smoothing.horizon_lock.set_horizon(horizon_amount, horizon_roll, horizon_pitch_enabled, horizon_pitch, automatic_lock, turn_threshold, turn_smoothing_ms, turn_multiplier);
                     }
                 }
                 if let Some(v) = obj.get("use_gravity_vectors").and_then(|x| x.as_bool()) {

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1024,8 +1024,8 @@ impl StabilizationManager {
         self.smoothing.write().current_mut().as_mut().set_parameter(name, val);
         self.invalidate_smoothing();
     }
-    pub fn set_horizon_lock(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64) {
-        self.smoothing.write().horizon_lock.set_horizon(lock_percent, roll, lock_pitch, pitch, automatic_lock, turn_threshold, turn_smoothing_ms, turn_multiplier);
+    pub fn set_horizon_lock(&self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64, tilt_accel_limit: f64) {
+        self.smoothing.write().horizon_lock.set_horizon(lock_percent, roll, lock_pitch, pitch, automatic_lock, turn_threshold, turn_smoothing_ms, turn_multiplier, tilt_accel_limit);
         self.invalidate_smoothing();
     }
     pub fn set_use_gravity_vectors(&self, v: bool) {
@@ -1584,8 +1584,9 @@ impl StabilizationManager {
                         let turn_threshold = obj.get("turn_threshold").and_then(|x| x.as_f64()).unwrap_or(5.0);
                         let turn_smoothing_ms = obj.get("turn_smoothing_ms").and_then(|x| x.as_f64()).unwrap_or(500.0);
                         let turn_multiplier = obj.get("turn_multiplier").and_then(|x| x.as_f64()).unwrap_or(1.0);
+                        let tilt_accel_limit = obj.get("tilt_accel_limit").and_then(|x| x.as_f64()).unwrap_or(f64::INFINITY);
                         let automatic_lock = obj.get("automatic_lock").and_then(|x| x.as_bool()).unwrap_or(false);
-                        smoothing.horizon_lock.set_horizon(horizon_amount, horizon_roll, horizon_pitch_enabled, horizon_pitch, automatic_lock, turn_threshold, turn_smoothing_ms, turn_multiplier);
+                        smoothing.horizon_lock.set_horizon(horizon_amount, horizon_roll, horizon_pitch_enabled, horizon_pitch, automatic_lock, turn_threshold, turn_smoothing_ms, turn_multiplier, tilt_accel_limit);
                     }
                 }
                 if let Some(v) = obj.get("use_gravity_vectors").and_then(|x| x.as_bool()) {

--- a/src/core/smoothing/horizon.rs
+++ b/src/core/smoothing/horizon.rs
@@ -6,8 +6,6 @@ use nalgebra::*;
 use crate::keyframes::*;
 
 pub fn lock_horizon_angle(q: &UnitQuaternion<f64>, roll_correction: f64, lock_pitch: bool, pitch_correction: f64) -> UnitQuaternion<f64> {
-    // z axis points in view direction, use as reference
-
     let x_axis = nalgebra::Vector3::<f64>::x_axis();
     let y_axis = nalgebra::Vector3::<f64>::y_axis();
     let z_axis = nalgebra::Vector3::<f64>::z_axis();
@@ -32,6 +30,10 @@ pub struct HorizonLock {
     pub horizonroll: f64,
     pub lock_pitch: bool,
     pub horizonpitch: f64,
+    pub automatic_lock: bool,
+    pub turn_threshold: f64,
+    pub turn_smoothing_ms: f64,
+    pub turn_multiplier: f64,
 }
 
 impl Default for HorizonLock {
@@ -41,16 +43,24 @@ impl Default for HorizonLock {
         horizonroll: 0.0,
         lock_pitch: false,
         horizonpitch: 0.0,
+        automatic_lock: false,
+        turn_threshold: 5.0,
+        turn_smoothing_ms: 500.0,
+        turn_multiplier: 1.0,
     } }
 }
 
 impl HorizonLock {
-    pub fn set_horizon(&mut self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64) {
+    pub fn set_horizon(&mut self, lock_percent: f64, roll: f64, lock_pitch: bool, pitch: f64, automatic_lock: bool, turn_threshold: f64, turn_smoothing_ms: f64, turn_multiplier: f64) {
         self.horizonroll = roll;
         self.horizonlockpercent = lock_percent;
         self.lock_enabled = self.horizonlockpercent > 1e-6;
         self.horizonpitch = pitch;
         self.lock_pitch = lock_pitch;
+        self.automatic_lock = automatic_lock;
+        self.turn_threshold = turn_threshold;
+        self.turn_smoothing_ms = turn_smoothing_ms;
+        self.turn_multiplier = turn_multiplier;
     }
 
     pub fn get_checksum(&self) -> u64 {
@@ -59,23 +69,58 @@ impl HorizonLock {
         hasher.write_u64(self.horizonroll.to_bits());
         hasher.write_u8(self.lock_pitch as u8);
         hasher.write_u64(self.horizonpitch.to_bits());
+        hasher.write_u64(self.turn_threshold.to_bits());
+        hasher.write_u64(self.turn_smoothing_ms.to_bits());
+        hasher.write_u64(self.turn_multiplier.to_bits());
         hasher.finish()
     }
 
     pub fn lock(&self, quats: &mut TimeQuat, org_quats: &TimeQuat, grav: &Option<crate::gyro_source::TimeVec>, use_grav: bool, _int_method: usize, compute_params: &ComputeParams) {
         let keyframes = &compute_params.keyframes;
         if self.lock_enabled || keyframes.is_keyframed(&KeyframeType::LockHorizonAmount) {
+            let mut roll_rates: std::collections::BTreeMap<i64, f64> = std::collections::BTreeMap::new();
+            let mut prev_roll: Option<f64> = None;
+            let mut prev_ts: Option<i64> = None;
+            let mut prev_smoothed: Option<f64> = None;
+            let tau_s: f64 = self.turn_smoothing_ms / 1000.0;
+            for (ts, org_quat) in org_quats.iter() {
+                let current_euler = org_quat.euler_angles();
+                let current_roll: f64 = current_euler.2;
+                if let (Some(pr), Some(pt)) = (prev_roll, prev_ts) {
+                    let dt = (*ts as f64 - pt as f64) / 1_000_000.0;
+                    if dt > 0.0 && dt < 1.0 {
+                        let mut diff_deg: f64 = (current_roll - pr).to_degrees();
+                        while diff_deg > 180.0 { diff_deg -= 360.0; }
+                        while diff_deg < -180.0 { diff_deg += 360.0; }
+                        let rate = diff_deg / dt;
+
+                        let alpha = if tau_s <= 0.0 { 1.0 } else { dt / (tau_s + dt) };
+                        let smoothed = if let Some(prev) = prev_smoothed {
+                            prev * (1.0 - alpha) + rate * alpha
+                        } else {
+                            rate
+                        };
+                        prev_smoothed = Some(smoothed);
+                        roll_rates.insert(*ts, smoothed);
+                    }
+                }
+                prev_roll = Some(current_roll);
+                prev_ts = Some(*ts);
+            }
+
+            // Prepare tilt-smoothing state for gravity branch
+            let mut prev_tilt_smoothed_grav: Option<f64> = None;
+            let mut prev_tilt_ts_grav: Option<i64> = None;
+
             if let Some(gvec) = grav {
                 if !gvec.is_empty() && use_grav {
                     let z_axis = nalgebra::Vector3::<f64>::z_axis();
                     let y_axis = nalgebra::Vector3::<f64>::y_axis();
-                    // let corr = Rotation3::from_axis_angle(&z_axis, std::f64::consts::PI);
 
                     for (ts, smoothed_ori) in quats.iter_mut() {
                         let gv = Self::interpolate_gravity_vector(&gvec, *ts).unwrap_or(*y_axis);
                         let ori = org_quats.get(ts).unwrap_or(&smoothed_ori).to_rotation_matrix();
 
-                        // Correct for angle difference between original and smoothed orientation
                         let correction = ori.inverse() * smoothed_ori.to_rotation_matrix();
                         let angle_corr = (-correction[(0, 1)]).simd_atan2(correction[(0, 0)]);
 
@@ -84,14 +129,41 @@ impl HorizonLock {
                         let horizonroll = keyframes.value_at_gyro_timestamp(&KeyframeType::LockHorizonRoll, timestamp_ms).unwrap_or(self.horizonroll) + video_rotation;
                         let horizonlockpercent = keyframes.value_at_gyro_timestamp(&KeyframeType::LockHorizonAmount, timestamp_ms).unwrap_or(self.horizonlockpercent);
 
-                        // let gv_corrected = corr.inverse() * correction * corr * gv; // Alternative matrix approach
-                        // let locked_ori = smoothed_ori.to_rotation_matrix() * Rotation3::from_axis_angle(&z_axis, gv_corrected[0].simd_atan2(gv_corrected[1]) + horizonroll * std::f64::consts::PI / 180.0);
-                        let locked_ori = smoothed_ori.to_rotation_matrix() * Rotation3::from_axis_angle(&z_axis, -angle_corr + gv[0].simd_atan2(gv[1]) + horizonroll * std::f64::consts::PI / 180.0);
+                        // Smooth ramping for dynamic tilt so threshold crossing isn't instantaneous
+                        let mut dynamic_tilt_deg: f64 = 0.0;
+                        if self.automatic_lock {
+                            // Target tilt (deg): proportional to roll rate if above threshold, otherwise 0
+                            let target = if let Some(&roll_rate) = roll_rates.get(ts) {
+                                if roll_rate.abs() > self.turn_threshold { roll_rate * self.turn_multiplier } else { 0.0 }
+                            } else { 0.0 };
+
+                            // Compute smoothing alpha based on time since previous tilt sample
+                            let alpha = if let Some(prev_ts_val) = prev_tilt_ts_grav {
+                                let dt = (*ts as f64 - prev_ts_val as f64) / 1_000_000.0;
+                                if tau_s <= 0.0 { 1.0 } else { (dt / (tau_s + dt)).max(0.0).min(1.0) }
+                            } else { 1.0 };
+
+                            let smoothed = if let Some(prev) = prev_tilt_smoothed_grav {
+                                prev * (1.0 - alpha) + target * alpha
+                            } else { target };
+
+                            prev_tilt_smoothed_grav = Some(smoothed);
+                            prev_tilt_ts_grav = Some(*ts);
+                            dynamic_tilt_deg = smoothed;
+                        }
+
+                        let total_horizonroll_deg = horizonroll + dynamic_tilt_deg;
+
+                        let locked_ori = smoothed_ori.to_rotation_matrix() * Rotation3::from_axis_angle(&z_axis, -angle_corr + gv[0].simd_atan2(gv[1]) + total_horizonroll_deg * std::f64::consts::PI / 180.0);
                         *smoothed_ori = UnitQuaternion::from_rotation_matrix(&locked_ori).slerp(&smoothed_ori, 1.0 - horizonlockpercent / 100.0)
                     }
                     return;
                 }
             }
+
+            // Prepare tilt-smoothing state for non-gravity branch
+            let mut prev_tilt_smoothed: Option<f64> = None;
+            let mut prev_tilt_ts: Option<i64> = None;
 
             for (ts, smoothed_ori) in quats.iter_mut() {
                 let timestamp_ms = *ts as f64 / 1000.0;
@@ -101,7 +173,29 @@ impl HorizonLock {
                 let lock_pitch = keyframes.value_at_gyro_timestamp(&KeyframeType::LockHorizonPitchEnabled, timestamp_ms).unwrap_or(if self.lock_pitch { 1.0 } else { 0.0 }) != 0.0;
                 let horizonlockpercent = keyframes.value_at_gyro_timestamp(&KeyframeType::LockHorizonAmount, timestamp_ms).unwrap_or(self.horizonlockpercent);
 
-                *smoothed_ori = lock_horizon_angle(smoothed_ori, horizonroll * std::f64::consts::PI / 180.0, lock_pitch, horizonpitch * std::f64::consts::PI / 180.0).slerp(&smoothed_ori, 1.0 - horizonlockpercent / 100.0);
+                // Smooth ramping for dynamic tilt
+                let mut dynamic_tilt_deg: f64 = 0.0;
+                if self.automatic_lock {
+                    let target = if let Some(&roll_rate) = roll_rates.get(ts) {
+                        if roll_rate.abs() > self.turn_threshold { roll_rate * self.turn_multiplier } else { 0.0 }
+                    } else { 0.0 };
+
+                    let alpha = if let Some(prev_ts_val) = prev_tilt_ts {
+                        let dt = (*ts as f64 - prev_ts_val as f64) / 1_000_000.0;
+                        if tau_s <= 0.0 { 1.0 } else { (dt / (tau_s + dt)).max(0.0).min(1.0) }
+                    } else { 1.0 };
+
+                    let smoothed = if let Some(prev) = prev_tilt_smoothed {
+                        prev * (1.0 - alpha) + target * alpha
+                    } else { target };
+                    prev_tilt_smoothed = Some(smoothed);
+                    prev_tilt_ts = Some(*ts);
+                    dynamic_tilt_deg = smoothed;
+                }
+
+                let total_horizonroll_deg = horizonroll + dynamic_tilt_deg;
+
+                *smoothed_ori = lock_horizon_angle(smoothed_ori, total_horizonroll_deg * std::f64::consts::PI / 180.0, lock_pitch, horizonpitch * std::f64::consts::PI / 180.0).slerp(&smoothed_ori, 1.0 - horizonlockpercent / 100.0);
             }
         }
     }
@@ -131,5 +225,4 @@ impl HorizonLock {
             }
         }
     }
-
 }

--- a/src/core/stabilization/cpu_undistort.rs
+++ b/src/core/stabilization/cpu_undistort.rs
@@ -88,7 +88,7 @@ pub const COEFFS: [f32; 64+128+256 + 9*4 + 4] = [
 // const ALPHAS: [f32; 4] = [ 1.0, 0.75, 0.50, 0.25 ];
 
 impl Stabilization {
-    pub fn undistort_image_cpu_spirv<T: PixelType>(buffers: &mut Buffers, params: &KernelParams, distortion_model: &DistortionModel, digital_lens: Option<&DistortionModel>, matrices: &[[f32; 14]], drawing: &[u8]) -> bool {
+    pub fn undistort_image_cpu_spirv<T: PixelType>(buffers: &mut Buffers, params: &KernelParams, _distortion_model: &DistortionModel, _digital_lens: Option<&DistortionModel>, matrices: &[[f32; 14]], drawing: &[u8]) -> bool {
         if let BufferSource::Cpu { buffer: input } = &mut buffers.input.data {
             if let BufferSource::Cpu { buffer: output } = &mut buffers.output.data {
                 if buffers.output.size.2 <= 0 {

--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -677,10 +677,27 @@ Item {
                         }
                     }
 
+                    function updateTurnSpeed(): void {
+                        const turnSpeed = controller.get_turn_speed(vid.timestamp);
+                        if (isNaN(turnSpeed)) {
+                            turnSpeedValue.text = "---";
+                        } else {
+                            const xAngle = controller.get_x_angle(vid.timestamp);
+                            turnSpeedValue.text = turnSpeed.toFixed(2) + "°/s (" + xAngle.toFixed(2) + "°)";
+                        }
+                    }
+
                     onCurrentFrameChanged: {
                         fovChanged();
                         controller.update_keyframe_values(timestamp);
                         window.motionData.orientationIndicator.updateOrientation(timeline.position * timeline.durationMs * 1000);
+                        updateTurnSpeed();
+                        if (!vid.playing) {
+                            Qt.callLater(function() {
+                                window.stab.updateHorizonLock();
+                                vid.seekToFrameDelta(0);
+                            });
+                        }
                     }
                     onMetadataLoaded: (md) => {
                         Qt.callLater(fileLoaded, md);
@@ -929,6 +946,21 @@ Item {
                     }
                     BasicText {
                         text: `(${vid.currentFrame+1}/${vid.frameCount})`;
+                        leftPadding: 5 * dpiScale;
+                        font.pixelSize: 11 * dpiScale;
+                        anchors.verticalCenter: parent.verticalCenter;
+                    }
+                }
+                Row {
+                    BasicText {
+                        text: qsTr("Turn Speed (ROLL):");
+                        leftPadding: 0;
+                        font.pixelSize: 11 * dpiScale;
+                        anchors.verticalCenter: parent.verticalCenter;
+                    }
+                    BasicText {
+                        id: turnSpeedValue;
+                        text: "---";
                         leftPadding: 5 * dpiScale;
                         font.pixelSize: 11 * dpiScale;
                         anchors.verticalCenter: parent.verticalCenter;


### PR DESCRIPTION
This pull request introduces significant enhancements to the horizon lock stabilization feature, particularly by adding support for automatic horizon lock adjustment based on camera turn speed. It also adds new methods to expose turn speed and angle data, and improves the smoothing logic for dynamic tilt during camera turns. There are also minor code cleanups and improvements to safety in FFI calls.

**Horizon Lock and Stabilization Enhancements:**

* Extended the `HorizonLock` struct and its related methods to support automatic locking, with new parameters: `automatic_lock`, `turn_threshold`, `turn_smoothing_ms`, and `turn_multiplier`. This enables dynamic adjustment of horizon lock based on detected turn rates. [[1]](diffhunk://#diff-aff4517bad730102ba3508c80c02e5e263c9259c58ec2a7dcc609772645d1021R33-R36) [[2]](diffhunk://#diff-aff4517bad730102ba3508c80c02e5e263c9259c58ec2a7dcc609772645d1021R46-R63) [[3]](diffhunk://#diff-aff4517bad730102ba3508c80c02e5e263c9259c58ec2a7dcc609772645d1021R72-L78) [[4]](diffhunk://#diff-aff4517bad730102ba3508c80c02e5e263c9259c58ec2a7dcc609772645d1021L87-R167) [[5]](diffhunk://#diff-aff4517bad730102ba3508c80c02e5e263c9259c58ec2a7dcc609772645d1021L104-R198) [[6]](diffhunk://#diff-aff4517bad730102ba3508c80c02e5e263c9259c58ec2a7dcc609772645d1021L134)
* Updated the `set_horizon_lock` interface and all related method calls to accept the new automatic lock parameters, and ensured these are serialized/deserialized with project settings. [[1]](diffhunk://#diff-1fd48ab302efbb91fe84507671007262db18094467e4ad707d036f60ff22e0eaL81-R84) [[2]](diffhunk://#diff-1fd48ab302efbb91fe84507671007262db18094467e4ad707d036f60ff22e0eaL1199-R1202) [[3]](diffhunk://#diff-8028c332ff0012861de59ca33de727d754ca3eb2efee49776fed4fa08cc24b8eL1027-R1028) [[4]](diffhunk://#diff-8028c332ff0012861de59ca33de727d754ca3eb2efee49776fed4fa08cc24b8eL1584-R1588)

**New Methods for Turn Analysis:**

* Added methods to the controller for calculating turn speed (`get_turn_speed`), current x angle (`get_x_angle`), and generating automatic lock keyframes (`generate_automatic_lock_keyframes`). These support the new automatic lock feature and allow external access to turn/angle data. [[1]](diffhunk://#diff-1fd48ab302efbb91fe84507671007262db18094467e4ad707d036f60ff22e0eaL81-R84) [[2]](diffhunk://#diff-1fd48ab302efbb91fe84507671007262db18094467e4ad707d036f60ff22e0eaR1512-R1578)

**Code Safety and Cleanliness:**

* Improved safety of FFI calls in `get_error` by wrapping all CoreFoundation calls in `unsafe` blocks, and minor refactoring for clarity.
* Minor cleanups in calibration code, such as removing unnecessary mutability and unused variables. [[1]](diffhunk://#diff-990b006d49ffd7138330b37448f424227b6c2e0aa6545119b48dc4b4dce78106L180-R180) [[2]](diffhunk://#diff-990b006d49ffd7138330b37448f424227b6c2e0aa6545119b48dc4b4dce78106L217-R218)

These changes collectively make the horizon lock more adaptive to real-world camera motion, providing smoother stabilization during turns, and expose useful telemetry for further tuning or UI integration.

Tested in Windows and MacOS