### PR TITLE
feat: optical-flow-only video stabilization (no gyro)

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -121,6 +121,8 @@ pub struct Controller {
     request_recompute: qt_signal!(),
 
     stab_enabled: qt_property!(bool; WRITE set_stab_enabled),
+    optical_flow_stabilization: qt_property!(bool; WRITE set_optical_flow_stabilization),
+    start_optical_flow_analysis: qt_method!(fn(&mut self)),
     show_detected_features: qt_property!(bool; WRITE set_show_detected_features),
     show_optical_flow: qt_property!(bool; WRITE set_show_optical_flow),
     fov: qt_property!(f64; WRITE set_fov),
@@ -527,6 +529,117 @@ impl Controller {
                                 frame_no += 1;
                             }
                             abs_frame_no += 1;
+                            Ok(())
+                        });
+                        if let Err(e) = proc.start_decoder_only(ranges, cancel_flag.clone()) {
+                            err(("An error occured: %1".to_string(), e.to_string()));
+                        }
+                        sync.finished_feeding_frames();
+                    }
+                    Err(error) => {
+                        err(("An error occured: %1".to_string(), error.to_string()));
+                    }
+                };
+            });
+        } else {
+            err(("An error occured: %1".to_string(), "Invalid parameters".to_string()));
+        }
+    }
+
+    fn start_optical_flow_analysis(&mut self) {
+        rendering::clear_log();
+
+        self.sync_in_progress = true;
+        self.sync_in_progress_changed();
+
+        let sync_params = synchronization::SyncParams {
+            every_nth_frame: 1,
+            of_method: self.stabilizer.params.read().of_method as usize,
+            ..Default::default()
+        };
+
+        let progress = util::qt_queued_callback_mut(QPointer::from(self as &Self), |this, (percent, ready, total): (f64, usize, usize)| {
+            this.sync_in_progress = ready < total || percent < 1.0;
+            this.sync_in_progress_changed();
+            this.chart_data_changed();
+            this.sync_progress(percent, ready, total);
+        });
+        let finished = util::qt_queued_callback_mut(QPointer::from(self as &Self), move |this, _offsets: Vec<(f64, f64, f64)>| {
+            this.sync_in_progress = false;
+            this.sync_in_progress_changed();
+            this.chart_data_changed();
+            this.request_recompute();
+        });
+        let err = util::qt_queued_callback_mut(QPointer::from(self as &Self), |this, (msg, mut arg): (String, String)| {
+            arg.push_str("\n\n");
+            arg.push_str(&rendering::get_log());
+            this.error(QString::from(msg), QString::from(arg), QString::default());
+            this.sync_in_progress = false;
+            this.sync_in_progress_changed();
+            this.request_recompute();
+        });
+        self.sync_progress(0.0, 0, 0);
+
+        self.cancel_flag.store(false, SeqCst);
+
+        // Use 0.5 as a dummy timestamp fraction to cover the entire video (overridden in autosync for this mode)
+        let timestamps_fract = vec![0.5f64];
+
+        if let Ok(mut sync) = AutosyncProcess::from_manager(&self.stabilizer, &timestamps_fract, sync_params, "optical_flow_stabilization".into(), self.cancel_flag.clone()) {
+            sync.on_progress(move |percent, ready, total| {
+                progress((percent, ready, total));
+            });
+            sync.on_finished(move |arg| {
+                match arg {
+                    Either::Left(offsets) => finished(offsets),
+                    _ => ()
+                };
+            });
+
+            let ranges = sync.get_ranges();
+            let cancel_flag = self.cancel_flag.clone();
+
+            let input_file = self.stabilizer.input_file.read().clone();
+            let proc_height = self.processing_resolution;
+            let gpu_decoding = self.stabilizer.gpu_decoding.load(SeqCst);
+            core::run_threaded(move || {
+                let mut frame_no = 0;
+
+                let mut decoder_options = ffmpeg_next::Dictionary::new();
+                if input_file.image_sequence_fps > 0.0 {
+                    let fps = rendering::fps_to_rational(input_file.image_sequence_fps);
+                    decoder_options.set("framerate", &format!("{}/{}", fps.numerator(), fps.denominator()));
+                }
+                if input_file.image_sequence_start > 0 {
+                    decoder_options.set("start_number", &format!("{}", input_file.image_sequence_start));
+                }
+                if proc_height > 0 {
+                    decoder_options.set("scale", &format!("{}x{}", (proc_height * 16) / 9, proc_height));
+                }
+
+                let sync = std::rc::Rc::new(sync);
+
+                match VideoProcessor::from_file(&input_file.url, gpu_decoding, 0, Some(decoder_options)) {
+                    Ok(mut proc) => {
+                        let err2 = err.clone();
+                        let sync2 = sync.clone();
+                        proc.on_frame(move |timestamp_us, input_frame, _output_frame, converter, _rate_control| {
+                            assert!(_output_frame.is_none());
+
+                            let h = if proc_height > 0 { proc_height as u32 } else { input_frame.height() };
+                            let ratio = input_frame.height() as f64 / h as f64;
+                            let sw = (input_frame.width() as f64 / ratio).round() as u32;
+                            let sh = (input_frame.height() as f64 / (input_frame.width() as f64 / sw as f64)).round() as u32;
+                            match converter.scale(input_frame, ffmpeg_next::format::Pixel::GRAY8, sw, sh) {
+                                Ok(small_frame) => {
+                                    let (width, height, stride, pixels) = (small_frame.plane_width(0), small_frame.plane_height(0), small_frame.stride(0), small_frame.data(0));
+                                    sync2.feed_frame(timestamp_us, frame_no, width, height, stride, pixels);
+                                },
+                                Err(e) => {
+                                    err2(("An error occured: %1".to_string(), e.to_string()))
+                                }
+                            }
+                            frame_no += 1;
                             Ok(())
                         });
                         if let Err(e) = proc.start_decoder_only(ranges, cancel_flag.clone()) {
@@ -1423,6 +1536,7 @@ impl Controller {
     wrap_simple_method!(override_video_fps,         v: f64, r: bool; recompute; update_offset_model);
     wrap_simple_method!(set_video_rotation,         v: f64; recompute; zooming_data_changed);
     wrap_simple_method!(set_stab_enabled,           v: bool);
+    wrap_simple_method!(set_optical_flow_stabilization, v: bool; recompute);
     wrap_simple_method!(set_show_detected_features, v: bool);
     wrap_simple_method!(set_show_optical_flow,      v: bool);
     wrap_simple_method!(set_digital_lens_name,      v: String; recompute);

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -837,6 +837,20 @@ impl StabilizationManager {
     pub fn set_show_detected_features(&self, v: bool) { self.params.write().show_detected_features = v; }
     pub fn set_show_optical_flow     (&self, v: bool) { self.params.write().show_optical_flow      = v; }
     pub fn set_stab_enabled          (&self, v: bool) { self.params.write().stab_enabled           = v; }
+    pub fn set_optical_flow_stabilization(&self, v: bool) { self.params.write().optical_flow_stabilization = v; }
+
+    /// Copy optical-flow-estimated gyro data from PoseEstimator into GyroSource as the primary motion data.
+    /// This enables stabilization purely from optical flow, without requiring external gyro/IMU data.
+    pub fn apply_optical_flow_as_gyro(&self) {
+        let estimated_gyro = self.pose_estimator.estimated_gyro.read();
+        if !estimated_gyro.is_empty() {
+            let imu_data: Vec<_> = estimated_gyro.values().cloned().collect();
+            drop(estimated_gyro);
+            let mut gyro = self.gyro.write();
+            gyro.file_metadata.set_raw_imu(imu_data);
+            gyro.apply_transforms();
+        }
+    }
     pub fn set_frame_readout_time    (&self, v: f64)  { self.params.write().frame_readout_time     = v; }
     pub fn set_frame_readout_direction(&self, v: impl Into<ReadoutDirection>) { self.params.write().frame_readout_direction = v.into(); }
     pub fn set_adaptive_zoom         (&self, v: f64)  { self.params.write().adaptive_zoom_window   = v; self.invalidate_zooming(); }

--- a/src/core/stabilization/compute_params.rs
+++ b/src/core/stabilization/compute_params.rs
@@ -57,6 +57,8 @@ pub struct ComputeParams {
 
     pub zooming_debug_points: bool,
 
+    pub optical_flow_stabilization: bool,
+
     pub distortion_model: DistortionModel,
     pub digital_lens: Option<DistortionModel>,
     pub digital_lens_params: Option<Vec<f64>>
@@ -113,6 +115,8 @@ impl ComputeParams {
             video_speed_affects_smoothing: params.video_speed_affects_smoothing,
             video_speed_affects_zooming: params.video_speed_affects_zooming,
             video_speed_affects_zooming_limit: params.video_speed_affects_zooming_limit,
+
+            optical_flow_stabilization: params.optical_flow_stabilization,
 
             distortion_model,
             digital_lens,

--- a/src/core/stabilization_params.rs
+++ b/src/core/stabilization_params.rs
@@ -117,6 +117,8 @@ pub struct StabilizationParams {
     pub of_method: u32,
     pub current_device: i32,
 
+    pub optical_flow_stabilization: bool,
+
     pub zooming_debug_points: std::collections::BTreeMap<i64, Vec<(f64, f64)>>
 }
 impl Default for StabilizationParams {
@@ -168,6 +170,8 @@ impl Default for StabilizationParams {
             of_method: 2,
 
             current_device: 0,
+
+            optical_flow_stabilization: false,
 
             fps: 0.0,
             fps_scale: None,
@@ -290,6 +294,7 @@ impl StabilizationParams {
             background_margin_feather: self.background_margin_feather,
             of_method:                 self.of_method,
             current_device:            self.current_device,
+            optical_flow_stabilization: self.optical_flow_stabilization,
             adaptive_zoom_method:      self.adaptive_zoom_method,
             fov_overview:              self.fov_overview,
             show_safe_area:            self.show_safe_area,

--- a/src/core/synchronization/autosync.rs
+++ b/src/core/synchronization/autosync.rs
@@ -72,6 +72,12 @@ impl AutosyncProcess {
             ranges_us.push((0, (org_duration_ms * 1000.0).round() as i64));
         }
 
+        if mode == "optical_flow_stabilization" {
+            // Analyze entire video for optical-flow-only stabilization
+            ranges_us.clear();
+            ranges_us.push((0, (org_duration_ms * 1000.0).round() as i64));
+        }
+
         let scaled_ranges_us = ranges_us.iter().map(|(f, t)| (
             (*f as f64 / fps_scale.unwrap_or(1.0)) as i64,
             (*t as f64 / fps_scale.unwrap_or(1.0)) as i64)
@@ -235,6 +241,25 @@ impl AutosyncProcess {
                 cb(0.6 + (progress * 0.4), d, t);
             }
         };
+
+        if self.mode == "optical_flow_stabilization" {
+            // For optical-flow-only stabilization, copy OF-derived gyro data into GyroSource
+            let compute_params = self.compute_params.write();
+            let mut gyro = compute_params.gyro.write();
+            gyro.file_metadata.set_raw_imu(self.estimator.estimated_gyro.read().values().cloned().collect::<Vec<_>>());
+            gyro.apply_transforms();
+            drop(gyro);
+            drop(compute_params);
+
+            if let Some(cb) = &self.finished_cb {
+                cb(Either::Left(Vec::new())); // Signal completion with empty offsets
+            }
+            if let Some(cb) = &self.progress_cb {
+                let len = self.total_detected_frames.load(SeqCst);
+                cb(1.0, len, len);
+            }
+            return;
+        }
 
         if let Some(cb) = &self.finished_cb {
             if self.mode == "estimate_rolling_shutter" {

--- a/src/ui/menu/Stabilization.qml
+++ b/src/ui/menu/Stabilization.qml
@@ -281,6 +281,28 @@ MenuItem {
         QT_TRANSLATE_NOOP("Stabilization", "Roll angle");
     }
 
+    CheckBoxWithContent {
+        id: opticalFlowCb;
+        text: qsTr("Optical flow stabilization (no gyro)");
+        cb.onCheckedChanged: {
+            controller.optical_flow_stabilization = cb.checked;
+        }
+
+        Button {
+            text: qsTr("Analyze optical flow");
+            iconName: "sync";
+            enabled: !controller.sync_in_progress;
+            onClicked: controller.start_optical_flow_analysis();
+        }
+
+        BasicText {
+            width: parent.width;
+            wrapMode: Text.WordWrap;
+            textFormat: Text.StyledText;
+            text: qsTr("Stabilize video using only optical flow analysis, without gyroscope data. Load a video and click Analyze to compute motion from pixel tracking.");
+        }
+    }
+
     ComboBox {
         id: smoothingMethod;
         model: smoothingAlgorithms;


### PR DESCRIPTION
## Summary

Implements optical-flow-only stabilization mode as requested in #45. This enables video stabilization **without requiring gyroscope or IMU data** — the camera motion is estimated purely from optical flow (pixel tracking between consecutive frames).

### How it works

1. User enables "Optical flow stabilization (no gyro)" checkbox in the Stabilization panel
2. Clicks "Analyze optical flow" to process the entire video
3. All frames are decoded and fed through the existing optical flow pipeline (AKAZE/PyrLK/DIS)
4. Pose estimation computes rotation matrices from point correspondences
5. The derived motion data (`estimated_gyro`) is loaded into `GyroSource` as raw IMU data
6. The standard smoothing pipeline (Default, Plain 3D, Fixed camera) handles the rest

### Changes

- **`StabilizationParams` / `ComputeParams`**: Added `optical_flow_stabilization` flag
- **`StabilizationManager`**: Added `apply_optical_flow_as_gyro()` to copy OF-derived gyro into GyroSource
- **`AutosyncProcess`**: New `"optical_flow_stabilization"` mode — analyzes entire video, loads OF data as primary motion source
- **`Controller`**: Exposed `optical_flow_stabilization` property and `start_optical_flow_analysis()` method
- **`Stabilization.qml`**: Added checkbox + "Analyze optical flow" button with description text

### Design decisions

- Reuses the existing optical flow infrastructure (no new algorithms needed)
- Reuses the existing `AutosyncProcess` pipeline with a new mode string — minimal new code
- After OF analysis, data flows through the same smoothing/zooming pipeline as gyro data
- The `every_nth_frame` is set to 1 for maximum quality (every frame analyzed)

Closes #45

## Test plan

- [ ] Load a video without gyro data, enable optical flow stabilization, click Analyze
- [ ] Verify progress indicator works during analysis
- [ ] Verify stabilization is applied after analysis completes
- [ ] Verify smoothing methods work with OF-derived data
- [ ] Verify cancel button works during analysis
- [ ] Verify existing gyro-based workflow is unaffected when checkbox is off

🤖 Generated with [Claude Code](https://claude.com/claude-code)