### PR TITLE
Fix partial lens correction intrinsics

### DIFF
--- a/src/core/stabilization/cpu_undistort.rs
+++ b/src/core/stabilization/cpu_undistort.rs
@@ -633,9 +633,9 @@ impl Stabilization {
 
 pub fn undistort_points_with_rolling_shutter(distorted: &[(f32, f32)], timestamp_ms: f64, frame: Option<usize>, params: &ComputeParams, lens_correction_amount: f64, use_fovs: bool) -> Vec<(f32, f32)> {
     if distorted.is_empty() { return Vec::new(); }
-    let (camera_matrix, distortion_coeffs, _p, rotations, is, mesh) = FrameTransform::at_timestamp_for_points(params, distorted, timestamp_ms, frame, use_fovs);
+    let (camera_matrix, distortion_coeffs, output_camera_matrix, rotations, is, mesh) = FrameTransform::at_timestamp_for_points(params, distorted, timestamp_ms, frame, use_fovs);
 
-    undistort_points(distorted, camera_matrix, &distortion_coeffs, rotations[0], Some(Matrix3::identity()), Some(rotations), params, lens_correction_amount, timestamp_ms, is, mesh)
+    undistort_points(distorted, camera_matrix, &distortion_coeffs, rotations[0], Some(Matrix3::identity()), Some(output_camera_matrix), Some(rotations), params, lens_correction_amount, timestamp_ms, is, mesh)
 }
 pub fn undistort_points_for_optical_flow(distorted: &[(f32, f32)], timestamp_us: i64, params: &ComputeParams, points_dims: (u32, u32)) -> Vec<(f32, f32)> {
     let img_dim_ratio = points_dims.0 as f64 / params.width.max(1) as f64;//FrameTransform::get_ratio(params);
@@ -644,10 +644,10 @@ pub fn undistort_points_for_optical_flow(distorted: &[(f32, f32)], timestamp_us:
 
     let scaled_k = camera_matrix * img_dim_ratio;
 
-    undistort_points(distorted, scaled_k, &distortion_coeffs, Matrix3::identity(), None, None, params, 1.0, timestamp_us as f64 / 1000.0, None, None)
+    undistort_points(distorted, scaled_k, &distortion_coeffs, Matrix3::identity(), None, None, None, params, 1.0, timestamp_us as f64 / 1000.0, None, None)
 }
 // Ported from OpenCV: https://github.com/opencv/opencv/blob/4.x/modules/calib3d/src/fisheye.cpp#L321
-pub fn undistort_points(distorted: &[(f32, f32)], camera_matrix: Matrix3<f64>, distortion_coeffs: &[f64; 12], rotation: Matrix3<f64>, p: Option<Matrix3<f64>>, rot_per_point: Option<Vec<Matrix3<f64>>>, params: &ComputeParams, lens_correction_amount: f64, timestamp_ms: f64, shift_per_point: Option<Vec<(f32, f32, f32, f32, f32)>>, mesh: Option<Vec<f64>>) -> Vec<(f32, f32)> {
+pub fn undistort_points(distorted: &[(f32, f32)], camera_matrix: Matrix3<f64>, distortion_coeffs: &[f64; 12], rotation: Matrix3<f64>, p: Option<Matrix3<f64>>, output_camera_matrix: Option<Matrix3<f64>>, rot_per_point: Option<Vec<Matrix3<f64>>>, params: &ComputeParams, lens_correction_amount: f64, timestamp_ms: f64, shift_per_point: Option<Vec<(f32, f32, f32, f32, f32)>>, mesh: Option<Vec<f64>>) -> Vec<(f32, f32)> {
     let f = (camera_matrix[(0, 0)] as f32, camera_matrix[(1, 1)] as f32);
     let c = (camera_matrix[(0, 2)] as f32, camera_matrix[(1, 2)] as f32);
 
@@ -757,12 +757,26 @@ pub fn undistort_points(distorted: &[(f32, f32)], camera_matrix: Matrix3<f64>, d
             pt = (pr[0] / pr[2], pr[1] / pr[2]);
 
             if lens_correction_amount < 1.0 {
-                let mut out_c = (params.output_width as f32 / 2.0, params.output_height as f32 / 2.0);
-                if params.lens.input_horizontal_stretch > 0.001 { out_c.0 /= params.lens.input_horizontal_stretch as f32; }
-                if params.lens.input_vertical_stretch   > 0.001 { out_c.1 /= params.lens.input_vertical_stretch as f32; }
+                let factor = (1.0 - lens_correction_amount as f32).max(0.001);
+                let lens_amount = lens_correction_amount as f32;
+                let intrinsics_blend = 1.0 - (1.0 - lens_amount).powi(2);
+                let output_k = output_camera_matrix.unwrap_or_else(|| {
+                    let mut fallback = Matrix3::identity();
+                    fallback[(0, 0)] = f.0 as f64;
+                    fallback[(1, 1)] = f.1 as f64;
+                    fallback[(0, 2)] = params.output_width as f64 / 2.0;
+                    fallback[(1, 2)] = params.output_height as f64 / 2.0;
+                    fallback
+                });
+                let out_c = (output_k[(0, 2)] as f32, output_k[(1, 2)] as f32);
+                let candidate_out_f = ((output_k[(0, 0)] as f32) / factor, (output_k[(1, 1)] as f32) / factor);
+                let out_f = (
+                    f.0 + (candidate_out_f.0 - f.0) * intrinsics_blend,
+                    f.1 + (candidate_out_f.1 - f.1) * intrinsics_blend,
+                );
 
                 let mut new_pt = pt;
-                new_pt = ((new_pt.0 - out_c.0) / f.0, (new_pt.1 - out_c.1) / f.1);
+                new_pt = ((new_pt.0 - out_c.0) / out_f.0, (new_pt.1 - out_c.1) / out_f.1);
                 let mut _w = 1.0;
                 if kernel_params.light_refraction_coefficient != 1.0 && kernel_params.light_refraction_coefficient > 0.0 {
                     let r = (new_pt.0.powi(2) + new_pt.1.powi(2)).sqrt() / _w;
@@ -773,7 +787,7 @@ pub fn undistort_points(distorted: &[(f32, f32)], camera_matrix: Matrix3<f64>, d
                     }
                 }
                 new_pt = params.distortion_model.distort_point(new_pt.0, new_pt.1, _w, &kernel_params); // TODO: z?
-                new_pt = ((new_pt.0 * f.0) + out_c.0, (new_pt.1 * f.1) + out_c.1);
+                new_pt = ((new_pt.0 * out_f.0) + out_c.0, (new_pt.1 * out_f.1) + out_c.1);
 
                 if let Some(digital) = &params.digital_lens {
                     new_pt = digital.distort_point(new_pt.0, new_pt.1, 1.0, &kernel_params);

--- a/src/core/stmap.rs
+++ b/src/core/stmap.rs
@@ -56,7 +56,7 @@ pub fn generate_stmaps(stab: &StabilizationManager, per_frame: bool) -> impl Ite
 
         let bbox = fov_iterative::FovIterative::new(&compute_params, org_output_size).points_around_rect(width as f32, height as f32, 31, 31);
         let (camera_matrix, distortion_coeffs, _p, rotations, is, mesh) = FrameTransform::at_timestamp_for_points(&compute_params, &bbox, timestamp, Some(frame), false);
-        let undistorted_bbox = undistort_points(&bbox, camera_matrix, &distortion_coeffs, rotations[0], None, Some(rotations), &compute_params, 1.0, timestamp, is, mesh);
+        let undistorted_bbox = undistort_points(&bbox, camera_matrix, &distortion_coeffs, rotations[0], None, None, Some(rotations), &compute_params, 1.0, timestamp, is, mesh);
 
         let mut min_x = 0.0;
         let mut min_y = 0.0;
@@ -114,7 +114,7 @@ pub fn generate_stmaps(stab: &StabilizationManager, per_frame: bool) -> impl Ite
         let dist = parallel_exr(width, height, |x, y| {
             let distorted = [(x as f32, y as f32)];
             let (camera_matrix, distortion_coeffs, _p, rotations, is, mesh) = FrameTransform::at_timestamp_for_points(&compute_params, &distorted, timestamp, Some(frame), true);
-            undistort_points(&distorted, camera_matrix, &distortion_coeffs, rotations[0], None, Some(rotations), &compute_params, 1.0, timestamp, is, mesh).first().copied()
+            undistort_points(&distorted, camera_matrix, &distortion_coeffs, rotations[0], None, None, Some(rotations), &compute_params, 1.0, timestamp, is, mesh).first().copied()
         });
 
         (filename_base.clone(), frame, dist, undist)

--- a/src/core/synchronization/estimate_pose/almeida.rs
+++ b/src/core/synchronization/estimate_pose/almeida.rs
@@ -62,7 +62,7 @@ impl Camera {
 
         let rot = na::Matrix3::<f32>::from(rotation.fixed_view::<3, 3>(0, 0));
 
-        let pt = undistort_points(&[(coords[0] * vw, coords[1] * vh)], camera_matrix, &distortion_coeffs, na::convert(rot), Some(camera_matrix), None, &self.compute_params, 1.0, timestamp_ms, None, None)[0];
+        let pt = undistort_points(&[(coords[0] * vw, coords[1] * vh)], camera_matrix, &distortion_coeffs, na::convert(rot), Some(camera_matrix), None, None, &self.compute_params, 1.0, timestamp_ms, None, None)[0];
 
         na::Point2::new(pt.0 / vw, pt.1 / vh) - coords
     }


### PR DESCRIPTION
/claim #384

## Summary
- pass the per-frame `output_camera_matrix` into `undistort_points()` for partial lens-correction reprojection
- blend toward the intermediate output intrinsics for `0% < Lens correction < 100%` instead of reusing the fully corrected intrinsics across the whole range
- update the `stmap` and Almeida pose-estimation call sites for the new `undistort_points()` signature

## Testing
- `cargo test --lib` (run in `src/core`)
- `cargo build --release --bin gyroflow`
- verified in the real app with maintainer repro steps using the Gyroflow test file:
  - `Stabilization overview` enabled
  - `No smoothing`
  - move `Lens correction` between `100%` and `50%`
  - `Zero-copy OpenCL` preview pipeline
- also rechecked `Zero-copy Qt RHI`; this final patch does not modify `src/qt_gpu/undistort.frag`, so `qsb` regeneration was not needed for this revision

## Demo
Preview:

![Issue 384 demo preview](https://raw.githubusercontent.com/javery556/gyroflow/codex/issue-384-demo-assets/docs/algora/issue-384-demo-preview.png)

MP4:

[issue-384-demo.mp4](https://github.com/javery556/gyroflow/raw/codex/issue-384-demo-assets/docs/algora/issue-384-demo.mp4)

This is a window-only recording of the real Gyroflow app on `Zero-copy OpenCL` with `Stabilization overview` and `No smoothing`, moving `Lens correction` from `100%` to `50%` and back.
