### PR TITLE
Add "Disable Gyroflow's stretch" to preset export dialog

### DIFF
--- a/src/ui/SettingsSelector.qml
+++ b/src/ui/SettingsSelector.qml
@@ -23,7 +23,10 @@ Modal {
             "Rotation":   ["rotation"],
             "Frame rate": ["fps_scale", "vfr_fps"],
         },
-        "Lens profile": ["calibration_data", "light_refraction_coefficient"],
+        "Lens profile": {
+            "Lens profile":                ["calibration_data", "light_refraction_coefficient"],
+            "Disable Gyroflow's stretch":  ["plugin_disable_stretch"],
+        },
         "Motion data|gyro_source": {
             "Low pass filter":    ["lpf"],
             "Median filter":      ["mf"],
@@ -67,7 +70,7 @@ Modal {
         }
     }];
 
-    property var defaultOff: ["trim_ranges_ms", "offsets", "video_infofps_scale", "video_inforotation", "synchronizationdo_autosync"];
+    property var defaultOff: ["trim_ranges_ms", "offsets", "video_infofps_scale", "video_inforotation", "synchronizationdo_autosync", "plugin_disable_stretch"];
 
     text: type == "preset"? qsTr("Select settings you want to include in the preset")
         : type == "apply"? qsTr("Select settings you want to apply to all items in the render queue")
@@ -97,6 +100,7 @@ Modal {
             QT_TR_NOOP("Rotation");
             QT_TR_NOOP("Frame rate");
         QT_TR_NOOP("Lens profile");
+            QT_TR_NOOP("Disable Gyroflow's stretch");
         QT_TR_NOOP("Motion data");
             QT_TR_NOOP("Low pass filter");
             QT_TR_NOOP("Median filter");
@@ -316,6 +320,10 @@ Modal {
     function getFilteredObject(source: var, desc: var): var {
         let finalData = { version: 2 };
         copyObj(source, desc, finalData);
+        // Handle plugin-specific flags not present in gyroflow data
+        if (desc["plugin_disable_stretch"]) {
+            finalData["plugin_disable_stretch"] = true;
+        }
         // Cleanup empty objects
         for (const key in finalData) {
             if (typeof finalData[key] === "object" && !Array.isArray(finalData[key]) && Object.keys(finalData[key]).length == 0) {


### PR DESCRIPTION
## Summary

Adds a "Disable Gyroflow's stretch" checkbox to the preset export settings dialog, under the **Lens profile** section. When checked, writes `"plugin_disable_stretch": true` to the exported `.gyroflow` preset file.

## Companion PR

**gyroflow/gyroflow-plugins#51** — the plugin-side change that reads this flag and auto-enables "Disable Gyroflow's stretch" when loading a preset/lens profile containing it.

## Motivation

When using anamorphic lenses in DaVinci Resolve (or any NLE that handles desqueeze via Pixel Aspect Ratio), users must manually check "Disable Gyroflow's stretch" on every clip in the OFX plugin. This setting couldn't be saved in presets because it's a plugin-level parameter with no representation in the gyroflow project format.

With both PRs merged, the workflow becomes:
1. Set up stabilization in Gyroflow app
2. Export preset → check "Disable Gyroflow's stretch" under Lens profile
3. Load preset in OFX plugin → DisableStretch auto-enables
4. No manual checkbox clicking per clip

## Changes

`src/ui/SettingsSelector.qml`:
- Convert "Lens profile" from single-checkbox to section with sub-items
- Add "Disable Gyroflow's stretch" checkbox (unchecked by default)
- Add translation string
- Inject `plugin_disable_stretch: true` in `getFilteredObject()` since it's a plugin-specific flag not present in the gyroflow export data

🤖 Generated with [Claude Code](https://claude.com/claude-code)