### PR TITLE
Improve vertical footage workflow

### DIFF
--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -378,11 +378,22 @@ impl StabilizationManager {
         if width > 0 && height > 0 {
             let params = self.params.upgradable_read();
 
-            let r = (params.video_rotation as f64).abs();
-            let (ow, oh) = if r == 90.0 || r == 270.0 {
-                (params.size.1, params.size.0)
+            let (ow, oh) = if params.frame_rotation.abs() > 0.01 {
+                // NLE has pre-rotated the frame — use frame_rotation to determine effective content dims
+                let fr = ((params.frame_rotation % 360.0) + 360.0) % 360.0;
+                if (fr - 90.0).abs() < 0.01 || (fr - 270.0).abs() < 0.01 {
+                    (params.size.1, params.size.0) // Content is portrait (rotated from landscape source)
+                } else {
+                    params.size
+                }
             } else {
-                params.size
+                // Plugin handles rotation — use video_rotation to determine output orientation (original behavior)
+                let r = ((params.video_rotation % 360.0) + 360.0) % 360.0;
+                if (r - 90.0).abs() < 0.01 || (r - 270.0).abs() < 0.01 {
+                    (params.size.1, params.size.0)
+                } else {
+                    params.size
+                }
             };
 
             let wp = width as f64;
@@ -936,6 +947,7 @@ impl StabilizationManager {
     }
 
     pub fn set_video_rotation(&self, v: f64) { self.params.write().video_rotation = v; self.invalidate_smoothing(); }
+    pub fn set_frame_rotation(&self, v: f64) { self.params.write().frame_rotation = v; self.invalidate_smoothing(); }
 
     pub fn trim_ranges(&self) -> Vec<(f64, f64)> { self.params.read().trim_ranges.clone() }
     pub fn set_trim_ranges(&self, v: Vec<(f64, f64)>) {
@@ -1297,6 +1309,7 @@ impl StabilizationManager {
                 "width":       params.size.0,
                 "height":      params.size.1,
                 "rotation":    params.video_rotation,
+                "frame_rotation": params.frame_rotation,
                 "num_frames":  params.frame_count,
                 "fps":         params.fps,
                 "duration_ms": params.duration_ms,
@@ -1489,8 +1502,9 @@ impl StabilizationManager {
                     }
                 }
                 output_size = Some(params.size);
-                if let Some(v) = vid_info.get("rotation")   .and_then(|x| x.as_f64()) { params.video_rotation = v; }
-                if let Some(v) = vid_info.get("num_frames") .and_then(|x| x.as_u64()) { params.frame_count    = v as usize; }
+                if let Some(v) = vid_info.get("rotation")       .and_then(|x| x.as_f64()) { params.video_rotation = v; }
+                if let Some(v) = vid_info.get("frame_rotation").and_then(|x| x.as_f64()) { params.frame_rotation = v; }
+                if let Some(v) = vid_info.get("num_frames")    .and_then(|x| x.as_u64()) { params.frame_count    = v as usize; }
                 if let Some(v) = vid_info.get("fps")        .and_then(|x| x.as_f64()) { params.fps            = v; }
                 if let Some(v) = vid_info.get("duration_ms").and_then(|x| x.as_f64()) { params.duration_ms    = v; }
                 if let Some(v) = vid_info.get("fps_scale") { params.fps_scale = v.as_f64(); }

--- a/src/core/stabilization_params.rs
+++ b/src/core/stabilization_params.rs
@@ -98,6 +98,7 @@ pub struct StabilizationParams {
     pub trim_ranges: Vec<(f64, f64)>,
 
     pub video_rotation: f64,
+    pub frame_rotation: f64,
 
     pub lens_correction_amount: f64,
     pub light_refraction_coefficient: f64,
@@ -150,6 +151,7 @@ impl Default for StabilizationParams {
             output_size: (0, 0),
 
             video_rotation: 0.0,
+            frame_rotation: 0.0,
 
             max_zoom: Some(130.0),
             max_zoom_iterations: 5,


### PR DESCRIPTION
## Summary

- Adds a `frame_rotation` field to `StabilizationParams` that tells the stabilization engine the host/NLE has already rotated the input frame
- When `frame_rotation` is 90°/270°, `set_output_size()` uses portrait reference dimensions (swapped width/height) — matching the host's portrait buffer so scale=1.0 with no cropping
- When `frame_rotation` is 0, original `video_rotation`-based dimension swap applies (backward compatible)
- Gyro alignment (`image_rotation` in frame_transform.rs) remains driven by `video_rotation` — unchanged

## Problem

Vertical footage in DaVinci Resolve requires a manual workaround to use with the Gyroflow OFX plugin: users must clear the clip's rotation attribute (undoing the NLE's pre-rotation), then set `video_rotation` in Gyroflow to compensate. This is cumbersome, unintuitive, and is not ideal having sideways preview thumbnails in the timeline.

The root cause: when `video_rotation=270°` is set, the core swaps output dimensions, but the plugin has no way to tell the core "the host already rotated this frame, don't swap dimensions." Keeping the NLE's native orientation produced incorrect stabilization because the dimension swap logic couldn't be bypassed independently of gyro alignment.

## Solution

The new `frame_rotation` field decouples two previously coupled behaviors in `set_output_size()`:
- **When `frame_rotation != 0`** (NLE pre-rotated): use `frame_rotation` to determine effective content dimensions. If 90°/270°, reference dims are portrait (size.1, size.0), matching the portrait buffer the host provides → scale=1.0, no cropping.
- **When `frame_rotation == 0`** (plugin handles rotation): use `video_rotation` for dimension swap (original behavior).

The transform pipeline, camera matrix, gyro alignment, and rolling shutter correction are all unchanged — they continue operating in landscape sensor coordinates. The shader's `input_rotation` handles the final UV rotation to the portrait buffer.

## Media

| Before | After |
|------|--------|
| ![before](https://github.com/user-attachments/assets/5d2d8ca6-fb04-4436-a844-24ba375977ab) | ![after](https://github.com/user-attachments/assets/a977379a-5fba-4667-a906-66c8a2078c73) |
| ![Drag and Drop](https://github.com/user-attachments/assets/b47c03c5-35b6-4386-b71f-363fa1283030) | ![Drag and Drop](https://github.com/user-attachments/assets/9a84efbb-96c5-4047-972c-0aebd9e68909) |

## Files changed

| File | Change |
|------|--------|
| `src/core/stabilization_params.rs` | Added `frame_rotation: f64` field with default 0.0 |
| `src/core/lib.rs` | Added `set_frame_rotation()` API, modified `set_output_size()` dimension logic, added JSON serialization/deserialization |

## Companion PR

The gyroflow-plugins repo has corresponding changes to auto-detect NLE rotation and set `frame_rotation`. See companion PR in gyroflow-plugins.

## Test plan

- [x] Horizontal footage with `frame_rotation=0` behaves identically to before
- [x] `video_rotation=270, frame_rotation=0` still swaps output dimensions (backward compat)
- [x] `video_rotation=270, frame_rotation=270` keeps output dims matching host portrait buffer
- [x] DaVinci Resolve vertical footage: correct stabilization without clearing clip attributes
- [x] Saved projects load correctly without requiring manual reload

Created with assistance from Claude Code.

/claim gyroflow/gyroflow-plugins#73