### PR TITLE
Add camera database (camera_database.json) for #742

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ gyroflow.log
 *.provisionprofile
 *.pfx
 resources/camera_presets
+resources/camera_database/_build/
 *.exe
 .qmlls.ini

--- a/resources/camera_database/build.py
+++ b/resources/camera_database/build.py
@@ -1,0 +1,497 @@
+#!/usr/bin/env python3
+"""
+Build resources/camera_database/camera_database.json from two upstream sources:
+
+  1. gyroflow's lens_profiles repo (https://github.com/gyroflow/lens_profiles)
+     - we read the per-camera JSON files in the repo and pull out
+       camera_brand / camera_model / crop_factor
+
+  2. LensFun's camera database (https://github.com/lensfun/lensfun)
+     - we read the per-mount XML files under data/db/ and pull out
+       maker / model / mount / cropfactor
+
+Both inputs are cloned into a sibling _build/ directory the first time
+the script runs. Pass --refresh to force a fresh clone.
+
+Output schema (one entry per unique brand|model, case-insensitive):
+{
+  "version": 1,
+  "sources": ["gyroflow_lens_profiles", "lensfun"],
+  "cameras": [
+    {
+      "brand": "Sony",
+      "model": "ILCE-7M4",
+      "mount": "Sony E",                # empty if unknown
+      "crop_factor": 1.0,               # null if unknown
+      "sensor_size_mm": [35.6, 23.8],   # null if unknown; from crop factor (3:2)
+      "sources": ["gyroflow", "lensfun"]
+    },
+    ...
+  ]
+}
+
+Usage:
+    python3 resources/camera_database/build.py [--refresh]
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+DATA_DIR = Path(__file__).parent
+OUT_FILE = DATA_DIR / "camera_database.json"
+BUILD_DIR = DATA_DIR / "_build"
+GYROFLOW_REPO = "https://github.com/gyroflow/lens_profiles.git"
+LENSFUN_REPO = "https://github.com/lensfun/lensfun.git"
+
+# --- Brand normalization aliases ---
+BRAND_ALIASES = {
+    "GOPRO": "GoPro",
+    "DJI": "DJI",
+    "RED": "RED",
+    "ARRI": "ARRI",
+    "Z CAM": "Z CAM",
+    "ZCAM": "Z CAM",
+    "BLACKMAGIC": "Blackmagic",
+    "BLACKMAGICDESIGN": "Blackmagic",
+    "BLACKMAGIC DESIGN": "Blackmagic",
+    "SJCAM": "SJCAM",
+    "SONY": "Sony",
+    "CANON": "Canon",
+    "NIKON": "Nikon",
+    "NIKON CORPORATION": "Nikon",
+    "PANASONIC": "Panasonic",
+    "FUJIFILM": "Fujifilm",
+    "FUJI": "Fujifilm",
+    "FUFIFILM": "Fujifilm",
+    "OLYMPUS": "Olympus",
+    "OLYMPUS CORPORATION": "Olympus",
+    "OLYMPUS IMAGING CORP.": "Olympus",
+    "OLYMPUS OPTICAL CO.,LTD": "Olympus",
+    "OM SYSTEM": "OM System",
+    "OM-SYSTEM": "OM System",
+    "OMSYSTEM": "OM System",
+    "OM DIGITAL SOLUTIONS": "OM System",
+    "SIGMA": "Sigma",
+    "TAMRON": "Tamron",
+    "TOKINA": "Tokina",
+    "SAMYANG": "Samyang",
+    "ZEISS": "Zeiss",
+    "LEICA": "Leica",
+    "LEICA CAMERA AG": "Leica",
+    "LEICA CAMERA AG.": "Leica",
+    "PENTAX": "Pentax",
+    "PENTAX CORPORATION": "Pentax",
+    "KODAK": "Kodak",
+    "EASTMAN KODAK COMPANY": "Kodak",
+    "RICOH": "Ricoh",
+    "RICOH IMAGING COMPANY, LTD.": "Ricoh",
+    "SAMSUNG": "Samsung",
+    "SAMSUNG TECHWIN": "Samsung",
+    "SAMSUNG TECHWIN CO.": "Samsung",
+    "RUNCAM": "RunCam",
+    "INSTA360": "Insta360",
+    "KINEFINITY": "Kinefinity",
+    "FREEFLY": "Freefly",
+    "FOXEER": "Foxeer",
+    "CADDX": "Caddx",
+    "WALKSNAIL": "Walksnail",
+    "HAWKEYE": "Hawkeye",
+    "MOBIUS": "Mobius",
+    "MORECAM": "Morecam",
+    "THIEYE": "ThiEYE",
+    "AKASO": "AKASO",
+    "EKEN": "Eken",
+    "XTU": "XTU",
+    "XIAOMI": "Xiaomi",
+    "POCO": "Xiaomi",  # POCO is Xiaomi sub-brand, but keep for now
+    "REDMI": "Xiaomi",
+    "APEMAN": "apeman",
+    "KONICA-MINOLTA": "Konica Minolta",
+    "KONICA MINOLTA": "Konica Minolta",
+    "KONICA MINOLTA CAMERA, INC.": "Konica Minolta",
+    "MINOLTA CO., LTD.": "Minolta",
+    "HASSELBLAD": "Hasselblad",
+    "CASIO": "Casio",
+    "CASIO COMPUTER CO.,LTD": "Casio",
+    "CASIO COMPUTER CO.,LTD.": "Casio",
+    "SCHNEIDER-KREUZNACH": "Schneider Kreuznach",
+    "VIVITAR": "Vivitar",
+    "SOLIGOR": "Soligor",
+    "CONTAX": "Contax",
+    "PHASE ONE": "Phase One",
+    "MAMIYA": "Mamiya",
+    "ASAHI OPTICAL CO.,LTD": "Pentax",
+    "ROLLEI": "Rollei",
+    "ROLLEIFLEX": "Rollei",
+    "APPLE": "Apple",
+    "GOOGLE": "Google",
+    "HUAWEI": "Huawei",
+    "HONOR": "Honor",
+    "ONEPLUS": "OnePlus",
+    "OPPO": "Oppo",
+    "VIVO": "Vivo",
+    "REALME": "Realme",
+    "MOTOROLA": "Motorola",
+    "NOKIA": "Nokia",
+    "MICROSOFT": "Microsoft",
+    "LG": "LG",
+    "LGE": "LG",
+    "LG MOBILE": "LG",
+    "LG V30": "LG",
+    "MEIZU": "Meizu",
+    "ZTE": "ZTE",
+    "NUBIA": "Nubia",
+    "TECNO": "Tecno",
+    "INFINIX": "Infinix",
+    "UMIDIGI": "Umidigi",
+    "ULEFONE": "Ulefone",
+    "ASUS": "ASUS",
+    "BLACKBERRY": "BlackBerry",
+    "FAIRPHONE": "Fairphone",
+    "JVC": "JVC",
+    "PHILIPS": "Philips",
+    "GARMIN": "Garmin",
+    "RASPBERRY PI": "Raspberry Pi",
+    "SHARP": "Sharp",
+    "MI": "Xiaomi",
+    "GENERIC": "Generic",
+    "ITALIA INDEPENDENT": "Italia Independent",
+    "DIGITAL BOLEX": "Digital Bolex",
+    "FEIYU TECH": "Feiyu Tech",
+    "FEIYU-TECH": "Feiyu Tech",
+    "GITUP": "GitUp",
+    "AEE DV": "AEE",
+    "BETAFPV": "BetaFPV",
+    "WALKSNAIL AVATAR V2": "Walksnail",
+    "WALKSNAIL AVATAR V2 PRO": "Walksnail",
+    "WOLFGANG": "Wolfang",
+    "WOLFANG": "Wolfang",
+    "HOLYSTONE": "Holy Stone",
+    "NICEBOY": "Niceboy",
+    "LAMAX": "Lamax",
+    "GOXTREME": "Goxtreme",
+    "GOPLUS CAMPRO": "GoPlus CamPro",
+    "MY GEKO GEAR": "My GEKO Gear",
+    "YI TECHNOLOGY": "YI Technology",
+    "BLAUPUNKT": "Blaupunkt",
+    "COOAU": "Cooau",
+    "DDPAI": "DDPAI",
+    "EVOLIO": "Evolio",
+    "EZVIZ": "Ezviz",
+    "GADNIC": "Gadnic",
+    "MAGINON": "Maginon",
+    "ROLLEI (禄来)": "Rollei",
+    "RYZE": "Ryze",
+    "SARGO": "Sargo",
+    "SENA": "Sena",
+    "SENCOR": "Sencor",
+    "SIMULUS": "Simulus",
+    "SOOYI": "Sooyi",
+    "SURFOLA": "Surfola",
+    "TRACER": "Tracer",
+    "VAQUITA": "Vaquita",
+    "VISUO": "Visuo",
+    "ACTIVEON": "ActiveON",
+    "AIKUCAM": "Aikucam",
+    "ANDOER": "Andoer",
+    "AOLBEA": "Aolbea",
+    "APEXCAM": "Apexcam",
+    "ARDUCAM": "Arducam",
+    "AUSEK": "Ausek",
+    "AXNEN": "Axnen",
+    "AKSOGO": "Aksogo",
+    "BIWOND": "Biwond",
+    "BLACKVUE": "BlackVue",
+    "BLACKSHARK": "Black Shark",
+    "CAMPARK": "CamPark",
+    "CHRONOS": "Chronos",
+    "COTUO": "Cotuo",
+    "CROSSTOUR": "Crosstour",
+    "CYCLIQ": "Cycliq",
+    "DECATHLON": "Decathlon",
+    "DENVER": "Denver",
+    "DIGMA": "Digma",
+    "DOGCAM": "DogCam",
+    "DRIFT": "Drift",
+    "EACHINE": "Eachine",
+    "FIMI": "FIMI",
+    "FIREFLY": "Firefly",
+    "FORCITE": "Forcite",
+    "FOREVER": "Forever",
+    "GENERAL MOBILE": "General Mobile",
+    "GHOSTSTOP": "GhostStop",
+    "HAPPYMODEL": "HappyModel",
+    "HDZERO": "HDZero",
+    "HP": "HP",
+    "ICONNTECHS": "IconnTechs",
+    "IZI": "IZI",
+    "INSTA TITAN": "Insta Titan",
+    "KMZ": "KMZ",
+    "MATECAM": "Matecam",
+    "MOBULA": "Mobula",
+    "MOMA": "MOMA",
+    "MONSTER": "Monster",
+    "NWO JAPAN": "NWO Japan",
+    "NECKER": "Necker",
+    "NICEBOY": "Niceboy",
+    "NOTHING": "Nothing",
+    "NOVATEK": "Novatek",
+    "ODRVM": "ODRVM",
+    "OMNIVISION": "OmniVision",
+    "ORION": "Orion",
+    "OVERMAX": "Overmax",
+    "POLAROID": "Polaroid",
+    "RACECAM": "RaceCam",
+    "SBOX": "SBOX",
+    "SEIKO EPSON CORP.": "Seiko Epson",
+    "SIOEYE": "Sioeye",
+    "SKYDIO": "Skydio",
+    "SOMIKON": "Somikon",
+    "SOOCOO": "SOOCOO",
+    "TOMTOM": "TomTom",
+    "TOMATE": "Tomate",
+    "ULEFONE": "Ulefone",
+    "VOLLA": "Volla",
+    "WOLFANG": "Wolfang",
+    "X-TRY": "X-TRY",
+    "XDV": "XDV",
+    "YICAM": "YiCam",
+    "YOLANSIN": "Yolansin",
+    "ZOOM": "Zoom",
+    "FUJITSU": "Fujitsu",
+    "ULEFONE": "Ulefone",
+}
+
+# Strings that look like model names rather than brand names,
+# rejected to avoid noise. These are typically user-typed mistakes
+# in the existing lens profile collection.
+BAD_BRANDS = {
+    "iqoo z3", "iqoo 9", "iqoo", "honor 80", "nova7", "h7s",
+    "jjrc x5", "kf102", "mate40pro", "sargo11", "sj6 legend",
+    "techno spark", "cyanchen", "duoke", "cleep",
+    "infinix hot 30", "insta titan", "supremo", "visi",
+    "china_actioncam", "iflight", "redmi",
+}
+BAD_BRAND_PATTERNS = re.compile(r"^[a-z]+\d+$", re.IGNORECASE)  # like "sargo11"
+
+
+def normalize_brand(s: str) -> str:
+    s = (s or "").strip()
+    if not s:
+        return ""
+    upper = s.upper()
+    if upper in BRAND_ALIASES:
+        return BRAND_ALIASES[upper]
+    if s.lower() in BAD_BRANDS:
+        return ""
+    return s
+
+
+def normalize_model(s: str) -> str:
+    s = (s or "").strip()
+    s = re.sub(r"\s+", " ", s)
+    return s
+
+
+# Approximate sensor sizes by crop factor — used when only crop is known.
+# Diagonal of 35mm full frame = 43.27mm. Standard 3:2 ratio assumed.
+def sensor_from_crop(crop_factor: float) -> list | None:
+    if not crop_factor or crop_factor <= 0:
+        return None
+    diag_ff = 43.266615305567875  # sqrt(36^2 + 24^2)
+    diag = diag_ff / crop_factor
+    # Most stills cameras 3:2; many video cameras 16:9. We can't know the ratio
+    # for sure from crop factor alone, so we record diagonal-based 3:2 as a hint.
+    h = diag / ((3.0 / 2.0) ** 2 + 1) ** 0.5
+    w = h * 3.0 / 2.0
+    return [round(w, 2), round(h, 2)]
+
+
+def parse_gyroflow_db(repo_root: Path) -> tuple[list[dict], int]:
+    cameras = {}
+    count = 0
+    for jf in repo_root.rglob("*.json"):
+        if jf.name.startswith("_"):
+            continue
+        try:
+            payload = json.loads(jf.read_text(encoding="utf-8", errors="replace"))
+        except json.JSONDecodeError:
+            continue
+        # Some files contain compatible_settings array of profiles
+        candidates = [payload]
+        cs = payload.get("compatible_settings")
+        if isinstance(cs, list):
+            candidates.extend(c for c in cs if isinstance(c, dict))
+        for p in candidates:
+            brand = normalize_brand(p.get("camera_brand", ""))
+            model = normalize_model(p.get("camera_model", ""))
+            if not brand or not model:
+                continue
+            count += 1
+            crop = p.get("crop_factor")
+            try:
+                crop = float(crop) if crop is not None else None
+                if crop and crop <= 0:
+                    crop = None
+            except (TypeError, ValueError):
+                crop = None
+            key = (brand.lower(), model.lower())
+            cur = cameras.setdefault(
+                key,
+                {
+                    "brand": brand,
+                    "model": model,
+                    "mount": "",
+                    "crop_factor": None,
+                    "sensor_size_mm": None,
+                    "sources": ["gyroflow"],
+                },
+            )
+            if crop and not cur["crop_factor"]:
+                cur["crop_factor"] = crop
+    print(f"  scanned {count} profiles in gyroflow", file=sys.stderr)
+    return list(cameras.values()), count
+
+
+def parse_lensfun(data_dir: Path) -> list[dict]:
+    cameras = {}
+    for xml_file in sorted(data_dir.glob("*.xml")):
+        if xml_file.stat().st_size < 50:
+            continue
+        try:
+            tree = ET.parse(xml_file)
+        except ET.ParseError as e:
+            print(f"warn: parse error {xml_file.name}: {e}", file=sys.stderr)
+            continue
+        root = tree.getroot()
+        for cam in root.findall("camera"):
+            maker_el = cam.find("maker")
+            model_el = cam.find("model")
+            mount_el = cam.find("mount")
+            crop_el = cam.find("cropfactor")
+            if maker_el is None or model_el is None:
+                continue
+            brand = normalize_brand(maker_el.text or "")
+            model = normalize_model(model_el.text or "")
+            if not brand or not model:
+                continue
+            mount = (mount_el.text or "").strip() if mount_el is not None else ""
+            try:
+                crop = float(crop_el.text) if (crop_el is not None and crop_el.text) else None
+            except ValueError:
+                crop = None
+            key = (brand.lower(), model.lower())
+            cur = cameras.setdefault(
+                key,
+                {
+                    "brand": brand,
+                    "model": model,
+                    "mount": mount,
+                    "crop_factor": crop,
+                    "sensor_size_mm": None,
+                    "sources": ["lensfun"],
+                },
+            )
+            if mount and not cur["mount"]:
+                cur["mount"] = mount
+            if crop and not cur["crop_factor"]:
+                cur["crop_factor"] = crop
+    return list(cameras.values())
+
+
+def merge(gyro: list[dict], lensfun: list[dict]) -> list[dict]:
+    merged = {}
+    for c in gyro:
+        key = (c["brand"].lower(), c["model"].lower())
+        merged[key] = dict(c)
+    for c in lensfun:
+        key = (c["brand"].lower(), c["model"].lower())
+        if key in merged:
+            cur = merged[key]
+            if not cur["mount"] and c["mount"]:
+                cur["mount"] = c["mount"]
+            if not cur["crop_factor"] and c["crop_factor"]:
+                cur["crop_factor"] = c["crop_factor"]
+            srcs = set(cur.get("sources", [])) | set(c.get("sources", []))
+            cur["sources"] = sorted(srcs)
+        else:
+            merged[key] = dict(c)
+    out = list(merged.values())
+    for c in out:
+        if c["sensor_size_mm"] is None and c["crop_factor"]:
+            c["sensor_size_mm"] = sensor_from_crop(c["crop_factor"])
+    out.sort(key=lambda x: (x["brand"].lower(), x["model"].lower()))
+    return out
+
+
+def shallow_clone(url: str, dest: Path, refresh: bool) -> None:
+    if dest.exists() and refresh:
+        shutil.rmtree(dest)
+    if dest.exists():
+        return
+    subprocess.run(
+        ["git", "clone", "--depth", "1", url, str(dest)],
+        check=True,
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--refresh",
+        action="store_true",
+        help="re-clone the upstream repos before building",
+    )
+    args = parser.parse_args()
+
+    BUILD_DIR.mkdir(exist_ok=True)
+    gyroflow_root = BUILD_DIR / "lens_profiles"
+    lensfun_root = BUILD_DIR / "lensfun"
+
+    print(f"cloning {GYROFLOW_REPO}", file=sys.stderr)
+    shallow_clone(GYROFLOW_REPO, gyroflow_root, args.refresh)
+    print(f"cloning {LENSFUN_REPO}", file=sys.stderr)
+    shallow_clone(LENSFUN_REPO, lensfun_root, args.refresh)
+
+    print("scanning gyroflow profiles tree", file=sys.stderr)
+    gyro_cams, gyro_count = parse_gyroflow_db(gyroflow_root)
+    print(f"  gyroflow: {len(gyro_cams)} unique cameras from {gyro_count} profiles", file=sys.stderr)
+
+    print("scanning lensfun xml", file=sys.stderr)
+    lensfun_cams = parse_lensfun(lensfun_root / "data" / "db")
+    print(f"  lensfun: {len(lensfun_cams)} unique cameras", file=sys.stderr)
+
+    merged = merge(gyro_cams, lensfun_cams)
+    print(f"  merged total: {len(merged)} unique cameras", file=sys.stderr)
+
+    out = {
+        "version": 1,
+        "sources": [
+            "gyroflow_lens_profiles",
+            "lensfun",
+        ],
+        "cameras": merged,
+    }
+    OUT_FILE.write_text(json.dumps(out, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    print(f"wrote {OUT_FILE} ({OUT_FILE.stat().st_size} bytes)", file=sys.stderr)
+
+    # Stats
+    from_gyro = sum(1 for c in merged if "gyroflow" in c["sources"])
+    from_lf = sum(1 for c in merged if "lensfun" in c["sources"])
+    both = sum(1 for c in merged if len(c["sources"]) == 2)
+    with_mount = sum(1 for c in merged if c["mount"])
+    with_crop = sum(1 for c in merged if c["crop_factor"])
+    brands = sorted({c["brand"] for c in merged})
+    print(f"stats: gyro={from_gyro} lensfun={from_lf} both={both} mount={with_mount} crop={with_crop}", file=sys.stderr)
+    print(f"brands ({len(brands)}): {', '.join(brands)}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/resources/camera_database/camera_database.json
+++ b/resources/camera_database/camera_database.json
@@ -1,0 +1,29750 @@
+{
+  "version": 1,
+  "sources": [
+    "gyroflow_lens_profiles",
+    "lensfun"
+  ],
+  "cameras": [
+    {
+      "brand": "ActiveON",
+      "model": "CX",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "AEE DV",
+      "mount": "aeeDV",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "Lyfe Titan",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "Magicam s60",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "S50 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "S90R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Aikucam",
+      "model": "NANO1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "B8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 4 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 6 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 7 Le",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "EK7000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "EK7000pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Keychain",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "KeyChain_1920x1080",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "snapX",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "V50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "V50 Elite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "v50 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "V50 X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "V50x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Aksogo",
+      "model": "SnapX",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Andoer",
+      "model": "AN7000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Aolbea",
+      "model": "Body camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "A100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "A100 Trawo",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "A77",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "A80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "A87",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apexcam",
+      "model": "M80 Air",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPad Pro 11-inch (2020)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 11",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 11 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 11 Pro Max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12 Mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12 Pro Max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 3x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 Pro (v1.1)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 Pro Max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14 Pro max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14 Pro Mox",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14pm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 Pro 24mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 PRO GA",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 Pro Max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 26mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 6s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 7 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 8 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone Pro max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE (2nd generation)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE (3rd gen)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE 2019",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone se3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone XR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone XS",
+      "mount": "iPhoneXS",
+      "crop_factor": 6.118,
+      "sensor_size_mm": [
+        5.88,
+        3.92
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone XS (tele)",
+      "mount": "iPhoneXStele",
+      "crop_factor": 8.667,
+      "sensor_size_mm": [
+        4.15,
+        2.77
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone xs 2x zoom",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone Xs Max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Arducam",
+      "model": "12.3MP 1/2.3 Inch IMX477 HQ Camera Module",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "35",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "Alexa 35",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "Alexa LF",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "Alexa mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ASUS",
+      "model": "ROG Phone 7 Ultimate",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ASUS",
+      "model": "Zenfone6 ZS630KL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ASUS",
+      "model": "Zenphone 9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ausek",
+      "model": "AT-Q40C",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Axnen",
+      "model": "A10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "BetaFPV",
+      "model": "HD_X65HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "BetaFPV",
+      "model": "Nano HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Biwond",
+      "model": "EX3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Black Shark",
+      "model": "4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "BlackBerry",
+      "model": "BB2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "BlackBerry",
+      "model": "Key2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Cinema Camera 6K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Cinema Pocket Camera 6K G2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Micro Cinema Camera",
+      "mount": "",
+      "crop_factor": 2.88,
+      "sensor_size_mm": [
+        12.5,
+        8.33
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Micro Studio Camera 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Micro Studio Camera 4K G2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocker Cinema Camera 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket (OG)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera (2013 first model)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 2013",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 4k",
+      "mount": "",
+      "crop_factor": 0.75,
+      "sensor_size_mm": [
+        48.0,
+        32.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 4K V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 6K",
+      "mount": "",
+      "crop_factor": 1.55,
+      "sensor_size_mm": [
+        23.23,
+        15.48
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 6K G2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 6k Pro",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera C4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera OG",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera Original",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera SHIMA",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket OG",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Ursa Mini 12k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Ursa Mini 4.6K PL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Ursa Mini Pro 12k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "URSA Mini Pro 4.6k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "BlackVue",
+      "model": "DR900x Plus",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blaupunkt",
+      "model": "bp 6410",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Ant",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Avatar HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Avatar Moonlight",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "AVATAR-HD PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Baby Turtle",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "BabyTurtle",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "CADDX Nebula Pro Nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "DJI Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Loris",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Loris 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Lorris",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nano Walksnail",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Pro Micro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Pro nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "nebula pro vista kit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "ORCA",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Orca 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Orca 4K 25fps LDC",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Peanut",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Polar",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Polar Nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Polar Starlight",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Ratel",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Ratel V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "tarsier",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Tarsier 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Tarsier V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "ThumbPro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Turtle",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Turtle v1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Turtle V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "turtle_v2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Vista",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Walnut",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Walnut cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "CamPark",
+      "model": "X30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "CamPark",
+      "model": "X40",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "100D Magic Lantern",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1100D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1300D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1DX",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1DX Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200 d2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200D",
+      "mount": "",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200D / SL2",
+      "mount": "",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200d Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "250D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "35mm film: full frame",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "4000D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "550D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D mark 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D Mark 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D Mark III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D Mark IV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "600D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "60D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "650D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "6D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "6D Mark 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "6D mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "700D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "700D / T5I",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "700D T5i X7i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "70d",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "750D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "77d",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "7D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "800D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "80D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "90D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C100 MKII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C300 Mk 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C70",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 30",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 40",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 400",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 430",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 50",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 500",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 55",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 70",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 700",
+      "mount": "canonSD500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 750",
+      "mount": "canonSD500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 80 IS",
+      "mount": "canonIxus80IS",
+      "crop_factor": 6.02,
+      "sensor_size_mm": [
+        5.98,
+        3.99
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS 95 IS",
+      "mount": "canonIxus80IS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS i",
+      "mount": "canonIxusI",
+      "crop_factor": 6.144,
+      "sensor_size_mm": [
+        5.86,
+        3.91
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS II",
+      "mount": "canonIxusII",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon DIGITAL IXUS v2",
+      "mount": "canonIxusII",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 1000D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 100D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 10D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.587,
+      "sensor_size_mm": [
+        22.68,
+        15.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 1100D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 1200D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 1300D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 2000D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 200D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 200D II",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 20D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 250D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 300D DIGITAL",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.587,
+      "sensor_size_mm": [
+        22.68,
+        15.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 30D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 350D DIGITAL",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 4000D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 400D DIGITAL",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 40D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 450D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 500D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 50D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 550D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 5D",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 5D Mark II",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 5D Mark III",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 5D Mark IV",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 5DS",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 5DS R",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 600D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 60D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 650D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 6D",
+      "mount": "Canon EF",
+      "crop_factor": 1.005,
+      "sensor_size_mm": [
+        35.82,
+        23.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 6D Mark II",
+      "mount": "Canon EF",
+      "crop_factor": 1.005,
+      "sensor_size_mm": [
+        35.82,
+        23.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 700D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 70D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 750D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 760D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 77D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 7D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 7D Mark II",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.605,
+      "sensor_size_mm": [
+        22.43,
+        14.95
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 8000D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 800D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 80D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 850D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 9000D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS 90D",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS D30",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.587,
+      "sensor_size_mm": [
+        22.68,
+        15.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS D60",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.587,
+      "sensor_size_mm": [
+        22.68,
+        15.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS DIGITAL REBEL",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.587,
+      "sensor_size_mm": [
+        22.68,
+        15.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS DIGITAL REBEL XS",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS DIGITAL REBEL XSi",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS DIGITAL REBEL XT",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS DIGITAL REBEL XTi",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Hi",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss Digital",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.587,
+      "sensor_size_mm": [
+        22.68,
+        15.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss Digital F",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss Digital N",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss Digital X",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss Digital X2",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.622,
+      "sensor_size_mm": [
+        22.19,
+        14.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS KISS M",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X10i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X3",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X4",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X5",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X50",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X6i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X7",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X70",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X7i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X8i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X9",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X90",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Kiss X9i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M10",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M100",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M2",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M200",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M3",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M5",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M50",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M50m2",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M6",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS M6 Mark II",
+      "mount": "Canon EF-M",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R1",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R10",
+      "mount": "Canon RF",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R100",
+      "mount": "Canon RF",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R3",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R5",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R5 C",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R50",
+      "mount": "Canon RF",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R50 V",
+      "mount": "Canon RF",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R5m2",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R6",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R6 Mark III",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R6m2",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R7",
+      "mount": "Canon RF",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS R8",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL SL1",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL SL2",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL SL3",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Rebel T100",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T1i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T2i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T3",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T3i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T4i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T5",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T5i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Rebel T6",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.62,
+      "sensor_size_mm": [
+        22.22,
+        14.81
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Rebel T6i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Rebel T6s",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Rebel T7",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS REBEL T7i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS Rebel T8i",
+      "mount": "Canon EF-S",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS RP",
+      "mount": "Canon RF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1D",
+      "mount": "Canon EF",
+      "crop_factor": 1.255,
+      "sensor_size_mm": [
+        28.69,
+        19.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1D Mark II",
+      "mount": "Canon EF",
+      "crop_factor": 1.255,
+      "sensor_size_mm": [
+        28.69,
+        19.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1D Mark II N",
+      "mount": "Canon EF",
+      "crop_factor": 1.255,
+      "sensor_size_mm": [
+        28.69,
+        19.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1D Mark III",
+      "mount": "Canon EF",
+      "crop_factor": 1.282,
+      "sensor_size_mm": [
+        28.08,
+        18.72
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1D Mark IV",
+      "mount": "Canon EF",
+      "crop_factor": 1.29,
+      "sensor_size_mm": [
+        27.91,
+        18.6
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1D X",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1D X Mark II",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1Ds",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1Ds Mark II",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon EOS-1Ds Mark III",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXUS 125 HS",
+      "mount": "canonIxus125HS",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXUS 220 HS",
+      "mount": "canonIxus220HS",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY 220F",
+      "mount": "canonIxy220F",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 200a",
+      "mount": "canonIxusII",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 30",
+      "mount": "canonIxusII",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 40",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 400",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 450",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 50",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 500",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon IXY DIGITAL 55",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A10",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A1200",
+      "mount": "canonA1200",
+      "crop_factor": 5.61,
+      "sensor_size_mm": [
+        6.42,
+        4.28
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A20",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A30",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A40",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A4000 IS",
+      "mount": "canonA4000IS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A490",
+      "mount": "canonA495",
+      "crop_factor": 5.39,
+      "sensor_size_mm": [
+        6.68,
+        4.45
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A495",
+      "mount": "canonA495",
+      "crop_factor": 5.39,
+      "sensor_size_mm": [
+        6.68,
+        4.45
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A510",
+      "mount": "canonA510",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A520",
+      "mount": "canonA510",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A60",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A610",
+      "mount": "canonA610",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A620",
+      "mount": "canonA610",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A640",
+      "mount": "canonA640",
+      "crop_factor": 4.79,
+      "sensor_size_mm": [
+        7.52,
+        5.01
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A650 IS",
+      "mount": "canonA650IS",
+      "crop_factor": 4.67712,
+      "sensor_size_mm": [
+        7.7,
+        5.13
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A70",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A720 IS",
+      "mount": "canonA720IS",
+      "crop_factor": 6.03,
+      "sensor_size_mm": [
+        5.97,
+        3.98
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A75",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A80",
+      "mount": "canonA80",
+      "crop_factor": 4.85,
+      "sensor_size_mm": [
+        7.42,
+        4.95
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A85",
+      "mount": "canonA70",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot A95",
+      "mount": "canonA80",
+      "crop_factor": 4.85,
+      "sensor_size_mm": [
+        7.42,
+        4.95
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot ELPH 110 HS",
+      "mount": "canonIxus125HS",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G1",
+      "mount": "canonG1",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G1 X",
+      "mount": "canonG1X",
+      "crop_factor": 1.85,
+      "sensor_size_mm": [
+        19.46,
+        12.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G1 X Mark II",
+      "mount": "canonG1X2",
+      "crop_factor": 1.93,
+      "sensor_size_mm": [
+        18.65,
+        12.44
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G1 X Mark III",
+      "mount": "canonG1X3",
+      "crop_factor": 1.613,
+      "sensor_size_mm": [
+        22.32,
+        14.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G10",
+      "mount": "canonG10",
+      "crop_factor": 4.605,
+      "sensor_size_mm": [
+        7.82,
+        5.21
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G11",
+      "mount": "canonG11",
+      "crop_factor": 4.554,
+      "sensor_size_mm": [
+        7.91,
+        5.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G12",
+      "mount": "canonG12",
+      "crop_factor": 4.63,
+      "sensor_size_mm": [
+        7.78,
+        5.18
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G15",
+      "mount": "canonG15",
+      "crop_factor": 4.65,
+      "sensor_size_mm": [
+        7.74,
+        5.16
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G16",
+      "mount": "canonG16",
+      "crop_factor": 4.67,
+      "sensor_size_mm": [
+        7.71,
+        5.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G2",
+      "mount": "canonG2",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G3",
+      "mount": "canonG3",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G3 X",
+      "mount": "canonG3X",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G5",
+      "mount": "canonG3",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G5 X",
+      "mount": "canonG7X",
+      "crop_factor": 2.72,
+      "sensor_size_mm": [
+        13.24,
+        8.82
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G5 X 16:9",
+      "mount": "canonG7X",
+      "crop_factor": 2.85,
+      "sensor_size_mm": [
+        12.63,
+        8.42
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G5 X 4:3",
+      "mount": "canonG7X",
+      "crop_factor": 2.94,
+      "sensor_size_mm": [
+        12.24,
+        8.16
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G5 X Mark II",
+      "mount": "canonG5X2",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G6",
+      "mount": "canonG3",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7",
+      "mount": "canonG7",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7 X",
+      "mount": "canonG7X",
+      "crop_factor": 2.72,
+      "sensor_size_mm": [
+        13.24,
+        8.82
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7 X 16:9",
+      "mount": "canonG7X",
+      "crop_factor": 2.85,
+      "sensor_size_mm": [
+        12.63,
+        8.42
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7 X 4:3",
+      "mount": "canonG7X",
+      "crop_factor": 2.94,
+      "sensor_size_mm": [
+        12.24,
+        8.16
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7 X Mark II",
+      "mount": "canonG7X",
+      "crop_factor": 2.72,
+      "sensor_size_mm": [
+        13.24,
+        8.82
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7 X Mark II 16:9",
+      "mount": "canonG7X",
+      "crop_factor": 2.85,
+      "sensor_size_mm": [
+        12.63,
+        8.42
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7 X Mark II 4:3",
+      "mount": "canonG7X",
+      "crop_factor": 2.94,
+      "sensor_size_mm": [
+        12.24,
+        8.16
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G7 X Mark III",
+      "mount": "canonG7X",
+      "crop_factor": 2.72,
+      "sensor_size_mm": [
+        13.24,
+        8.82
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G9",
+      "mount": "canonG9",
+      "crop_factor": 4.605,
+      "sensor_size_mm": [
+        7.82,
+        5.21
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G9 X",
+      "mount": "canonG9X",
+      "crop_factor": 2.72,
+      "sensor_size_mm": [
+        13.24,
+        8.82
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot G9 X Mark II",
+      "mount": "canonG9X",
+      "crop_factor": 2.72,
+      "sensor_size_mm": [
+        13.24,
+        8.82
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot Pro1",
+      "mount": "canonPro1",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot Pro70",
+      "mount": "canonPro70",
+      "crop_factor": 5.47,
+      "sensor_size_mm": [
+        6.58,
+        4.39
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot Pro90 IS",
+      "mount": "canonPro90",
+      "crop_factor": 5.28,
+      "sensor_size_mm": [
+        6.82,
+        4.55
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S1 IS",
+      "mount": "canonS1",
+      "crop_factor": 6.56,
+      "sensor_size_mm": [
+        5.49,
+        3.66
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S100",
+      "mount": "canonS100",
+      "crop_factor": 4.62,
+      "sensor_size_mm": [
+        7.79,
+        5.19
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S110",
+      "mount": "canonS110",
+      "crop_factor": 4.62,
+      "sensor_size_mm": [
+        7.79,
+        5.19
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S120",
+      "mount": "canonS120",
+      "crop_factor": 4.62,
+      "sensor_size_mm": [
+        7.79,
+        5.19
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S2 IS",
+      "mount": "canonS2",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S200",
+      "mount": "canonIxusII",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S30",
+      "mount": "canonS30",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S40",
+      "mount": "canonS30",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S400",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S410",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S45",
+      "mount": "canonS30",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S5 IS",
+      "mount": "canonS5",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S50",
+      "mount": "canonS30",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S500",
+      "mount": "canonIxus400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S60",
+      "mount": "canonS70",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S70",
+      "mount": "canonS70",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S80",
+      "mount": "canonS70",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S90",
+      "mount": "canonS90",
+      "crop_factor": 4.67,
+      "sensor_size_mm": [
+        7.71,
+        5.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot S95",
+      "mount": "canonS95",
+      "crop_factor": 4.67,
+      "sensor_size_mm": [
+        7.71,
+        5.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD10",
+      "mount": "canonIxusI",
+      "crop_factor": 6.144,
+      "sensor_size_mm": [
+        5.86,
+        3.91
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD100",
+      "mount": "canonIxusII",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD110",
+      "mount": "canonIxusII",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD1100 IS",
+      "mount": "canonIxus80IS",
+      "crop_factor": 6.02,
+      "sensor_size_mm": [
+        5.98,
+        3.99
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD200",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD300",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD400",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD450",
+      "mount": "canonSD200",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD500",
+      "mount": "canonSD500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD550",
+      "mount": "canonSD500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SD950 IS",
+      "mount": "canonSD950",
+      "crop_factor": 4.7,
+      "sensor_size_mm": [
+        7.66,
+        5.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX1 IS",
+      "mount": "canonSX1",
+      "crop_factor": 5.5,
+      "sensor_size_mm": [
+        6.55,
+        4.36
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX10 IS",
+      "mount": "canonSX10IS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX130 IS",
+      "mount": "canonSX150IS",
+      "crop_factor": 5.62,
+      "sensor_size_mm": [
+        6.41,
+        4.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX150 IS",
+      "mount": "canonSX150IS",
+      "crop_factor": 5.62,
+      "sensor_size_mm": [
+        6.41,
+        4.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX160 IS",
+      "mount": "canonSX160IS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX220 HS",
+      "mount": "canonSX220HS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX230 HS",
+      "mount": "canonSX230HS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX240 HS",
+      "mount": "canonSX260HS",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX260 HS",
+      "mount": "canonSX260HS",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX30 IS",
+      "mount": "canonSX30IS",
+      "crop_factor": 5.581,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX50 HS",
+      "mount": "canonSX50HS",
+      "crop_factor": 5.61,
+      "sensor_size_mm": [
+        6.42,
+        4.28
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX510 HS",
+      "mount": "canonSX510HS",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX60 HS",
+      "mount": "canonSX60HS",
+      "crop_factor": 5.61,
+      "sensor_size_mm": [
+        6.42,
+        4.28
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX700 HS",
+      "mount": "canonSX710HS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon PowerShot SX710 HS",
+      "mount": "canonSX710HS",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "d700",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 1 DX MK3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 100d",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 1100D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 2000D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 200D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 250D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 4000D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 50D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 550D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 5D Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 5d mark iv",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 5DIII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6 Mark 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 600D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 60D",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D mk2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6DII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 700D",
+      "mount": "",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Eos 70d",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 750D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 77D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 7D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 800D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 80D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 80D18-135 f/3.5-5.6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 850D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 90D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS C100mkii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS C200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS C70",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS D2000",
+      "mount": "Canon EF",
+      "crop_factor": 1.593,
+      "sensor_size_mm": [
+        22.6,
+        15.07
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M",
+      "mount": "",
+      "crop_factor": 1.14,
+      "sensor_size_mm": [
+        31.58,
+        21.05
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS m crop mood",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M MLV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M50 Mark 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M50 Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "eos m50 mii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M6 Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M6II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R5",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R5c",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS r6 mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R62",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R7",
+      "mount": "",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel T100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS REBEL T5i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel T6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel T6i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel t8i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS RP",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS T6S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOSD 1 DX MK3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "G7X Mark 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "G7X Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "G9X M2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "IXY Digital 600",
+      "mount": "canonSD500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "IXY Digital 700",
+      "mount": "canonSD500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Legria G20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "m100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M50 Mark 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "m50 mark 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M50 mark I",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "m50 mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M6 ii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M6 Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Mark2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R5 C",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R5c",
+      "mount": "",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 m2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 Mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 MarkII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 Mii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 Mk II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 mk2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "r6 mkii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R62",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6ii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Rebel EOS SL3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Rebel EOS T6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Rebel sl2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "rebel t7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "RP",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Sl2/200D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "SL3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "SX740hs",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "T4i/650D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "t6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "t6 d1300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "T6i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "t7i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "T8i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Vixia HF200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "XA50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-FH20",
+      "mount": "casioEX-FH20",
+      "crop_factor": 5.68,
+      "sensor_size_mm": [
+        6.34,
+        4.23
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-P600",
+      "mount": "casioP600",
+      "crop_factor": 4.65,
+      "sensor_size_mm": [
+        7.74,
+        5.16
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-P700",
+      "mount": "casioP600",
+      "crop_factor": 4.65,
+      "sensor_size_mm": [
+        7.74,
+        5.16
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-Z3",
+      "mount": "casioZ4",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-Z30",
+      "mount": "casioZ4",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-Z4",
+      "mount": "casioZ4",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-Z40",
+      "mount": "casioZ4",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-Z55",
+      "mount": "casioZ4",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "EX-Z750",
+      "mount": "casioZ750",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "QV-3000EX",
+      "mount": "casioQV3500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "QV-3500EX",
+      "mount": "casioQV3500",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Casio",
+      "model": "QV-4000",
+      "mount": "canonG2",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Chronos",
+      "model": "CR14-1.0",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Contax",
+      "model": "35mm film: full frame",
+      "mount": "Contax/Yashica",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Cooau",
+      "model": "CU SPC02",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Cooau",
+      "model": "SPC06",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Cotuo",
+      "model": "Q6TR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Crosstour",
+      "model": "4K wifi",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Crosstour",
+      "model": "CT 9000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Crosstour",
+      "model": "CT7000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Cycliq",
+      "model": "Fly12 sport",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DDPAI",
+      "model": "mini3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DDPAI",
+      "model": "Mini5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Decathlon",
+      "model": "G-eye-900",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Denver",
+      "model": "ACK-8062W",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Digital Bolex",
+      "model": "D16",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Digma",
+      "model": "850",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "4D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Action",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Action 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Action 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air 2S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air Unit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "AIR2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air2s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "caddx vista dji",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "DJI FPV Drone",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "DJI MINI SE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FC3411",
+      "mount": "djiFC3411",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FC3582",
+      "mount": "djiFC3582",
+      "crop_factor": 3.6,
+      "sensor_size_mm": [
+        10.0,
+        6.67
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FC6310",
+      "mount": "djiFC6310",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FC6310R",
+      "mount": "djiFC6310R",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FPV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FPV Air Unit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FPV skyliner",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Goggles2 From Avata",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 2 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 2 Zoom",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mavic 2pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 C1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 C2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 Classic",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 Pro Hasselblad 4/3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Air 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "MAVIC AIR 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Air 2s 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Air FC2103",
+      "mount": "djiMavicAirFC2103",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic mini 2 se 2.7 k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Pro 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Pro 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Pro FC220",
+      "mount": "djiMavicProFC220",
+      "crop_factor": 5.64,
+      "sensor_size_mm": [
+        6.38,
+        4.26
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic3 PRO 3x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic3Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mini 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini 2 4K 30 fps",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini 2 se",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mini 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "MINI 3 PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini 4 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mini Pro 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mini2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "O4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "O4 Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Action",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Action 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Action 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Pocket",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Pocket 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "OsmoPocket3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 3 Advanced",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 3 Pro FC300X",
+      "mount": "dijPhantom3ProFC300X",
+      "crop_factor": 5.5,
+      "sensor_size_mm": [
+        6.55,
+        4.36
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 4 Pro V1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 4 prov2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom Vision FC200",
+      "mount": "dijPhantomVisionFC200",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Pocket 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "vista",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "X7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "ZEMMUSE X7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "ZENMUSE X7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DogCam",
+      "model": "Bullet R+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Drift",
+      "model": "Ghost XL Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Drift",
+      "model": "xl pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eachine",
+      "model": "Lizard105S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eachine",
+      "model": "TX06 700tvl",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eken",
+      "model": "H9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eken",
+      "model": "H9R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eken",
+      "model": "HR9S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Evolio",
+      "model": "iSmart 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ezviz",
+      "model": "S2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fairphone",
+      "model": "5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Feiyu Tech",
+      "model": "Pocket 2s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Feiyu Tech",
+      "model": "Pocket3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "FIMI",
+      "model": "Fimi x8 2022 v2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "FIMI",
+      "model": "plam 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "FIMI",
+      "model": "x8 mini v2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Firefly",
+      "model": "Firefly 8SE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Firefly",
+      "model": "Hawkey Naked 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Firefly",
+      "model": "Xlite2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Forcite",
+      "model": "MK1S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Forever",
+      "model": "SC-410",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Box",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "BOX 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Box2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Digisight Nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Digisight V3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "HS1177",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Legend 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Legend 2+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Legend1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "mix",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Mix V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "PREDATOR MICRO V5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Razer Pico",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Razor Pico",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Freefly",
+      "model": "Wave",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "100S 0.7X",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "100S减焦",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix 3800",
+      "mount": "fuji2800",
+      "crop_factor": 6.3333333,
+      "sensor_size_mm": [
+        5.68,
+        3.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix A370",
+      "mount": "fujiA370",
+      "crop_factor": 6.03,
+      "sensor_size_mm": [
+        5.97,
+        3.98
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix E550",
+      "mount": "fuji810",
+      "crop_factor": 4.5,
+      "sensor_size_mm": [
+        8.0,
+        5.33
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix F10",
+      "mount": "fujiF11",
+      "crop_factor": 4.5,
+      "sensor_size_mm": [
+        8.0,
+        5.33
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix F11",
+      "mount": "fujiF11",
+      "crop_factor": 4.5,
+      "sensor_size_mm": [
+        8.0,
+        5.33
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix F200EXR",
+      "mount": "fujiF200exr",
+      "crop_factor": 4.341,
+      "sensor_size_mm": [
+        8.29,
+        5.53
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix F601 ZOOM",
+      "mount": "fuji601",
+      "crop_factor": 4.487,
+      "sensor_size_mm": [
+        8.02,
+        5.35
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix F710",
+      "mount": "fuji810",
+      "crop_factor": 4.5,
+      "sensor_size_mm": [
+        8.0,
+        5.33
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix F770EXR",
+      "mount": "fujif770exr",
+      "crop_factor": 5.43,
+      "sensor_size_mm": [
+        6.63,
+        4.42
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix F810",
+      "mount": "fuji810",
+      "crop_factor": 4.5,
+      "sensor_size_mm": [
+        8.0,
+        5.33
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix HS20EXR",
+      "mount": "fujihs20exr",
+      "crop_factor": 5.71,
+      "sensor_size_mm": [
+        6.3,
+        4.2
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix HS30EXR",
+      "mount": "fujihs20exr",
+      "crop_factor": 5.71,
+      "sensor_size_mm": [
+        6.3,
+        4.2
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S20Pro",
+      "mount": "fuji602",
+      "crop_factor": 4.487,
+      "sensor_size_mm": [
+        8.02,
+        5.35
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S3000",
+      "mount": "fuji2800",
+      "crop_factor": 6.3333333,
+      "sensor_size_mm": [
+        5.68,
+        3.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S304",
+      "mount": "fuji2800",
+      "crop_factor": 6.3333333,
+      "sensor_size_mm": [
+        5.68,
+        3.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S3Pro",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S5100",
+      "mount": "fujiS5500",
+      "crop_factor": 6.491,
+      "sensor_size_mm": [
+        5.55,
+        3.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S5500",
+      "mount": "fujiS5500",
+      "crop_factor": 6.491,
+      "sensor_size_mm": [
+        5.55,
+        3.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S5600",
+      "mount": "fujiS5600",
+      "crop_factor": 6.03,
+      "sensor_size_mm": [
+        5.97,
+        3.98
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S5Pro",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.56,
+      "sensor_size_mm": [
+        23.08,
+        15.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S602 ZOOM",
+      "mount": "fuji602",
+      "crop_factor": 4.487,
+      "sensor_size_mm": [
+        8.02,
+        5.35
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S7000",
+      "mount": "fuji602",
+      "crop_factor": 4.487,
+      "sensor_size_mm": [
+        8.02,
+        5.35
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S9000",
+      "mount": "fujiS9000",
+      "crop_factor": 4.48,
+      "sensor_size_mm": [
+        8.04,
+        5.36
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S9500",
+      "mount": "fujiS9000",
+      "crop_factor": 4.48,
+      "sensor_size_mm": [
+        8.04,
+        5.36
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix S9600",
+      "mount": "fujiS9000",
+      "crop_factor": 4.48,
+      "sensor_size_mm": [
+        8.04,
+        5.36
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix X100",
+      "mount": "fujix100",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePix2800ZOOM",
+      "mount": "fuji2800",
+      "crop_factor": 6.3333333,
+      "sensor_size_mm": [
+        5.68,
+        3.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePixS1Pro",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.543,
+      "sensor_size_mm": [
+        23.33,
+        15.55
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "FinePixS2Pro",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.543,
+      "sensor_size_mm": [
+        23.33,
+        15.55
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX 100",
+      "mount": "Fujifilm G",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX 50R",
+      "mount": "Fujifilm G",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX 50S",
+      "mount": "Fujifilm G",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX100 II",
+      "mount": "Fujifilm G",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX100ii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX100RF",
+      "mount": "fujiGFX100RF",
+      "crop_factor": 0.8,
+      "sensor_size_mm": [
+        45.0,
+        30.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX100S",
+      "mount": "Fujifilm G",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX100S II",
+      "mount": "Fujifilm G",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX50S II",
+      "mount": "Fujifilm G",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "H2S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "HS25EXR Pinefix",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "IS Pro",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.56,
+      "sensor_size_mm": [
+        23.08,
+        15.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-A1",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-A10",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-A2",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-A3",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-A5",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-A7",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E1",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E2",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E2S",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E3",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E4",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E5",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-H1",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.528,
+      "sensor_size_mm": [
+        23.56,
+        15.71
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-H2",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.528,
+      "sensor_size_mm": [
+        23.56,
+        15.71
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-H2S",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.528,
+      "sensor_size_mm": [
+        23.56,
+        15.71
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-M1",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-M5",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "x-pro 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-Pro1",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-Pro2",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.528,
+      "sensor_size_mm": [
+        23.56,
+        15.71
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-Pro3",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-S/X-T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-S1",
+      "mount": "fujiXS1",
+      "crop_factor": 3.93,
+      "sensor_size_mm": [
+        9.16,
+        6.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "x-S10",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-S10_T3_T30_T4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-S20",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.6,
+      "sensor_size_mm": [
+        22.5,
+        15.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T/X-S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T1",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T10",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T100",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "x-T15",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T2",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T20",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T200",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.529,
+      "sensor_size_mm": [
+        23.54,
+        15.7
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T3",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T30",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T30 II",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T30 III",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T4",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T5",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.14,
+      "sensor_size_mm": [
+        31.58,
+        21.05
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T50",
+      "mount": "Fujifilm X",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X10",
+      "mount": "fujix10",
+      "crop_factor": 3.93,
+      "sensor_size_mm": [
+        9.16,
+        6.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100F",
+      "mount": "fujix100",
+      "crop_factor": 1.528,
+      "sensor_size_mm": [
+        23.56,
+        15.71
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100S",
+      "mount": "fujix100",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100T",
+      "mount": "fujix100",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100V",
+      "mount": "fujix100v2",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100V 4K 30P",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100VI",
+      "mount": "fujix100v2",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X20",
+      "mount": "fujix10",
+      "crop_factor": 3.93,
+      "sensor_size_mm": [
+        9.16,
+        6.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X30",
+      "mount": "fujix10",
+      "crop_factor": 3.93,
+      "sensor_size_mm": [
+        9.16,
+        6.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X70",
+      "mount": "fujix70",
+      "crop_factor": 1.5375,
+      "sensor_size_mm": [
+        23.41,
+        15.61
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "xe4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XF10",
+      "mount": "fujixf10",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XH-2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XH-2S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "xh2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XH2s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XQ1",
+      "mount": "fujiXQ1",
+      "crop_factor": 3.91,
+      "sensor_size_mm": [
+        9.21,
+        6.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XS-10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XS-20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XS10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "Xs20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-30 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "xt3",
+      "mount": "",
+      "crop_factor": 1.77,
+      "sensor_size_mm": [
+        20.34,
+        13.56
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "xt4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujitsu",
+      "model": "F-52A",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujitsu",
+      "model": "f52a",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Gadnic",
+      "model": "Extreme 13",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Garmin",
+      "model": "Virb Ultra 30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Garmin",
+      "model": "Virb Ultra30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Garmin",
+      "model": "Virb XE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "General Mobile",
+      "model": "GM22 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "General Mobile",
+      "model": "GM22Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 0.8 (Medium Format)",
+      "mount": "Generic",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 1.0 (Full Frame)",
+      "mount": "Generic",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 1.1",
+      "mount": "Generic",
+      "crop_factor": 1.1,
+      "sensor_size_mm": [
+        32.73,
+        21.82
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 1.3 (APS-H)",
+      "mount": "Generic",
+      "crop_factor": 1.267,
+      "sensor_size_mm": [
+        28.41,
+        18.94
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 1.5 (APS-C)",
+      "mount": "Generic",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 1.6 (APS-C)",
+      "mount": "Generic",
+      "crop_factor": 1.611,
+      "sensor_size_mm": [
+        22.35,
+        14.9
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 1.7",
+      "mount": "Generic",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Generic",
+      "model": "Crop-factor 2.0 (Four-Thirds)",
+      "mount": "Generic",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GhostStop",
+      "model": "Phasm Cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GitUp",
+      "model": "Git2",
+      "mount": "git2",
+      "crop_factor": 5.57,
+      "sensor_size_mm": [
+        6.46,
+        4.31
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GitUp",
+      "model": "Git2P",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 3 XL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4 XL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4a",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4a 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4XL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 6 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 6a",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7 25mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "pixel 7 main",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7 Pro 12MP Ultrawide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7A",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 8 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPlus CamPro",
+      "model": "4K Sports Ultra HD DV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HD2",
+      "mount": "goProHero",
+      "crop_factor": 6.4,
+      "sensor_size_mm": [
+        5.62,
+        3.75
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO (2014)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO 2018",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO 3+ black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO 3+black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO 4 Session",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO Session",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO10 Black",
+      "mount": "goProHero10bl",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO11 Black",
+      "mount": "goProHero11bl",
+      "crop_factor": 5.54,
+      "sensor_size_mm": [
+        6.5,
+        4.33
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO11 Black Mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO12 Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO13 Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO2014",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO3 Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO3 Silver",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO3+ Black",
+      "mount": "goProHero3+",
+      "crop_factor": 5.42,
+      "sensor_size_mm": [
+        6.64,
+        4.43
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO3+ Silver",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Hero3+Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Hero4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO4 Black",
+      "mount": "goProHero4black",
+      "crop_factor": 5.0,
+      "sensor_size_mm": [
+        7.2,
+        4.8
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO4 Session",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO4 Silver",
+      "mount": "goProHero4",
+      "crop_factor": 7.66,
+      "sensor_size_mm": [
+        4.7,
+        3.13
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO5 Black",
+      "mount": "goProHero4black",
+      "crop_factor": 5.0,
+      "sensor_size_mm": [
+        7.2,
+        4.8
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO5 Black (FW-hacked Hero 2018)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO5 Session",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Hero5(2018)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO6 Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7 Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7 Silver",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7 White",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO8 Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO9 Black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO_2024",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Session",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Session 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Session4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Goxtreme",
+      "model": "enduro black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Goxtreme",
+      "model": "Vision+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HappyModel",
+      "model": "Mobula7 HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "CFV 100C/907X",
+      "mount": "Hasselblad X",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "CFV II 50C/907X",
+      "mount": "Hasselblad X",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "EQV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "Hasselblad 500 mech.",
+      "mount": "Hasselblad 500",
+      "crop_factor": 0.66,
+      "sensor_size_mm": [
+        54.55,
+        36.36
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "Hasselblad H3D",
+      "mount": "Hasselblad H",
+      "crop_factor": 0.72,
+      "sensor_size_mm": [
+        50.0,
+        33.33
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "L1D-20c",
+      "mount": "l1d20c",
+      "crop_factor": 2.8,
+      "sensor_size_mm": [
+        12.86,
+        8.57
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "L2D-20c",
+      "mount": "l2d20c",
+      "crop_factor": 1.953,
+      "sensor_size_mm": [
+        18.43,
+        12.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "X1D II 50C",
+      "mount": "Hasselblad X",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "X2D 100C",
+      "mount": "Hasselblad X",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "X2D II 100C",
+      "mount": "Hasselblad X",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "2k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "4k split",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly 6S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly 8SE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Micro 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly naked II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Q6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "firefly Split",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Split 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Split Mini 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Split v4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Whoop Split",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly X Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly X Lite II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "FireFlyV4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "FireflyXLite II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Hawkeye",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked/Split",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Split 4k mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Split Cam 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "SplitCam4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "SplitV5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Thumb",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "THUMB 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Thumb 鹰眼拇指相机",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Thumb2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "卡录V4.0",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "裸狗V4.0",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "鹰眼4K卡录",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "鹰眼二代2K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "鹰眼裸狗",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HDZero",
+      "model": "HDZero_Nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Holy Stone",
+      "model": "HolyStone 360s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Holy Stone",
+      "model": "HS510",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "20 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "70 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "8x Sony",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "90",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "9i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "ANP-AN00",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "DLI-L22",
+      "mount": "dlil22",
+      "crop_factor": 8.235,
+      "sensor_size_mm": [
+        4.37,
+        2.91
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "M5P",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "X7b Rear Main Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "荣耀90gt",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HP",
+      "model": "AC 100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HP",
+      "model": "ac100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "10s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "40p",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "CLT-L29",
+      "mount": "cltl29",
+      "crop_factor": 4.55,
+      "sensor_size_mm": [
+        7.91,
+        5.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mate 10Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate 40pro+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate 50 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate 50pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mate 60 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate50 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate50pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mate60 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "MATEPAD11",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "MateX2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "meta 50 pro 1x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "meta40pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mets40pro华为",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Nova 2i RNE-L22",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "nova 7i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Nova7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P20 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P30 PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P30pro main_f1.6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p40",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P40 1.0",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p40 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p40 sx",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P50PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p60 pro main",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p60 pro sony main lens",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60pro 4K24mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P8 Lite 2017",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "VOG-L29",
+      "mount": "vogl29",
+      "crop_factor": 4.86,
+      "sensor_size_mm": [
+        7.41,
+        4.94
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "WAS-LX1A",
+      "mount": "waslx1a",
+      "crop_factor": 6.88,
+      "sensor_size_mm": [
+        5.23,
+        3.49
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "IconnTechs",
+      "model": "4K Ultra HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Infinix",
+      "model": "Open Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta Titan",
+      "model": "Insta Titan",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "Ace",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "Ace Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "EVO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "Go",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "GO 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "GO 3S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "One R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "ONE RS",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "One RS 1-Inch 360 Edition",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "ONE X2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "OneR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "OneR 1inch",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "OneRS",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "SMO 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "X4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "IZI",
+      "model": "ONE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "JVC",
+      "model": "GY-HM180U",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "Mavo 8k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "Mavo Edge",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "MAVO LF",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "MAVO-LF",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "TERRA 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "terra4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "KMZ",
+      "model": "Zenit 122",
+      "mount": "M42",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "KMZ",
+      "model": "Zenit 122K",
+      "mount": "Pentax K",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "KMZ",
+      "model": "Zenit 212K",
+      "mount": "Pentax K",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "KMZ",
+      "model": "Zenit 312K",
+      "mount": "Pentax K",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "KMZ",
+      "model": "Zenit 412LS",
+      "mount": "M42",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "KMZ",
+      "model": "Zenit KM",
+      "mount": "Pentax K",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "DCS Pro 14N",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "DCS Pro 14nx",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "DCS Pro SLR/c",
+      "mount": "Canon EF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "DCS Pro SLR/n",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "DCS520",
+      "mount": "Canon EF",
+      "crop_factor": 1.593,
+      "sensor_size_mm": [
+        22.6,
+        15.07
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "Kodak CX6330 Zoom Digital Camera",
+      "mount": "kodakCX6330",
+      "crop_factor": 6.593,
+      "sensor_size_mm": [
+        5.46,
+        3.64
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "Kodak CX7525 Zoom Digital Camera",
+      "mount": "kodakCX6330",
+      "crop_factor": 6.07,
+      "sensor_size_mm": [
+        5.93,
+        3.95
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "Kodak DC120 ZOOM Digital Camera",
+      "mount": "kodakDC120",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Kodak",
+      "model": "Kodak Digital Science DC50 Zoom Camera",
+      "mount": "kodakDC50",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE A2",
+      "mount": "kmD7",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE A200",
+      "mount": "kmD7",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE G400",
+      "mount": "kmG400",
+      "crop_factor": 6.144,
+      "sensor_size_mm": [
+        5.86,
+        3.91
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE Z10",
+      "mount": "kmZ10",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE Z2",
+      "mount": "kmZ2",
+      "crop_factor": 6.03,
+      "sensor_size_mm": [
+        5.97,
+        3.98
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE Z20",
+      "mount": "kmZ10",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE Z3",
+      "mount": "kmZ3",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE Z5",
+      "mount": "kmZ3",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "DiMAGE Z6",
+      "mount": "kmZ3",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "Dynax 5D",
+      "mount": "Minolta AF",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "Dynax 7D",
+      "mount": "Minolta AF",
+      "crop_factor": 1.522,
+      "sensor_size_mm": [
+        23.65,
+        15.77
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "Maxxum 5D",
+      "mount": "Minolta AF",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "Maxxum 7D",
+      "mount": "Minolta AF",
+      "crop_factor": 1.522,
+      "sensor_size_mm": [
+        23.65,
+        15.77
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Konica Minolta",
+      "model": "Revio KD-420Z",
+      "mount": "kmG400",
+      "crop_factor": 6.144,
+      "sensor_size_mm": [
+        5.86,
+        3.91
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Lamax",
+      "model": "X8 Electra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lamax",
+      "model": "X9.1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lamax",
+      "model": "X9.2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "C-Lux",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "D-Lux 3",
+      "mount": "panasonicLX3",
+      "crop_factor": 4.33,
+      "sensor_size_mm": [
+        8.31,
+        5.54
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "D-Lux 4",
+      "mount": "panasonicLX4",
+      "crop_factor": 4.33,
+      "sensor_size_mm": [
+        8.31,
+        5.54
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "D-Lux2",
+      "mount": "panasonicLX1",
+      "crop_factor": 4.45,
+      "sensor_size_mm": [
+        8.09,
+        5.39
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Digilux 2",
+      "mount": "leicaDigilux2",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Digilux 3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica CL",
+      "mount": "Leica L",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M (Typ 240)",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M EV1",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M Monochrom (Typ 246)",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M10",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M10 Monochrom",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M10-D",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M10-P",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M10-R",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M11",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M11 Monochrom",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M11-D",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica M11-P",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica Q (Typ 116)",
+      "mount": "leicaQTyp116",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica Q2",
+      "mount": "leicaQ2",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica Q2 Mono",
+      "mount": "leicaQ2",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica Q3",
+      "mount": "leicaQ2",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "LEICA Q3 43",
+      "mount": "leicaQ343",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica Q3 Mono",
+      "mount": "leicaQ2",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica SL (Typ 601)",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica SL2",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica SL2-S",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica SL3",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica SL3-S",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica T (Typ 701)",
+      "mount": "Leica L",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica TL",
+      "mount": "Leica L",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica TL2",
+      "mount": "Leica L",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Leica X Vario (Typ 107)",
+      "mount": "leicaXVario107",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "M8 Digital Camera",
+      "mount": "Leica M",
+      "crop_factor": 1.33,
+      "sensor_size_mm": [
+        27.07,
+        18.05
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "M9 Digital Camera",
+      "mount": "Leica M",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Q3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "SL2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "sl2-s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lenovo",
+      "model": "K6 Note",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lenovo",
+      "model": "Mirage VR405",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "G8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "LG G7 ThinQ",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "LG-H815",
+      "mount": "lgH815",
+      "crop_factor": 6.34,
+      "sensor_size_mm": [
+        5.68,
+        3.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "Motion cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "V35",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "V40",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "V50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "v50 27mm f1.5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "v60",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Maginon",
+      "model": "AC-500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mamiya",
+      "model": "Mamiya 645",
+      "mount": "Mamiya 645",
+      "crop_factor": 0.577,
+      "sensor_size_mm": [
+        62.39,
+        41.59
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Mamiya",
+      "model": "Mamiya ZD",
+      "mount": "Mamiya 645",
+      "crop_factor": 0.721,
+      "sensor_size_mm": [
+        49.93,
+        33.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Matecam",
+      "model": "4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Meizu",
+      "model": "Note9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Microsoft",
+      "model": "Lumia 950",
+      "mount": "lumia950",
+      "crop_factor": 6.02,
+      "sensor_size_mm": [
+        5.98,
+        3.99
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Microsoft",
+      "model": "Lumia 950 XL",
+      "mount": "lumia950",
+      "crop_factor": 6.02,
+      "sensor_size_mm": [
+        5.98,
+        3.99
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE 7",
+      "mount": "kmD7",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE 7Hi",
+      "mount": "kmD7",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE 7i",
+      "mount": "kmD7",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE A1",
+      "mount": "kmD7",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE X",
+      "mount": "kmXt",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE Xi",
+      "mount": "kmXt",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE Xt",
+      "mount": "kmXt",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Minolta",
+      "model": "DiMAGE Z1",
+      "mount": "kmZ1",
+      "crop_factor": 6.545,
+      "sensor_size_mm": [
+        5.5,
+        3.67
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "1S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "ActionCam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "ActionCamera v2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "Maxi 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "Mini V1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "Mobius 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobula",
+      "model": "7HD 1S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "MOMA",
+      "model": "探境",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Monster",
+      "model": "Monster FQ777 F8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Morecam",
+      "model": "M9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 20 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 2023",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 40 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge S Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge+",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "G100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "g13",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "G41",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "G7 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G Power",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G200 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G60s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G72",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G8 Power Omnivision OV16E10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto One Fusion+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "moto X30 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "RAZR 2023",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "My GEKO Gear",
+      "model": "ORBIT 960",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Necker",
+      "model": "v5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Niceboy",
+      "model": "VEGA",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Niceboy",
+      "model": "VEGA 6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Niceboy",
+      "model": "vega x play",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "1-J2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "170",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "24-120",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "35mm film: full frame",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "62",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "7200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "810",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix A",
+      "mount": "nikonA",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix b500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P1000",
+      "mount": "nikonP1000",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P1100",
+      "mount": "nikonP1000",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P330",
+      "mount": "nikonP330",
+      "crop_factor": 4.706,
+      "sensor_size_mm": [
+        7.65,
+        5.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P340",
+      "mount": "nikonP330",
+      "crop_factor": 4.706,
+      "sensor_size_mm": [
+        7.65,
+        5.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P60",
+      "mount": "nikonP60",
+      "crop_factor": 5.62,
+      "sensor_size_mm": [
+        6.41,
+        4.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P6000",
+      "mount": "nikonP6000",
+      "crop_factor": 4.6,
+      "sensor_size_mm": [
+        7.83,
+        5.22
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P7000",
+      "mount": "nikonP7000",
+      "crop_factor": 4.69,
+      "sensor_size_mm": [
+        7.68,
+        5.12
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P7800",
+      "mount": "nikonP7800",
+      "crop_factor": 4.67,
+      "sensor_size_mm": [
+        7.71,
+        5.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "COOLPIX P900",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P950",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix S3300",
+      "mount": "nikonS3300",
+      "crop_factor": 5.65,
+      "sensor_size_mm": [
+        6.37,
+        4.25
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "CoolPix W300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D 3300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D-750",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3400",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "d3500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "d5300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5600",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D610",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D7000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D7100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D7200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D750",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "d7500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D780",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D800",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "d810",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D850",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E4200",
+      "mount": "nikon7900",
+      "crop_factor": 4.86,
+      "sensor_size_mm": [
+        7.41,
+        4.94
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E4500",
+      "mount": "nikon4500",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E4800",
+      "mount": "nikon4800",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E5000",
+      "mount": "nikon5000",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E5200",
+      "mount": "nikon7900",
+      "crop_factor": 4.86,
+      "sensor_size_mm": [
+        7.41,
+        4.94
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E5400",
+      "mount": "nikon5400",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E5700",
+      "mount": "nikon5700",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E5900",
+      "mount": "nikon7900",
+      "crop_factor": 4.86,
+      "sensor_size_mm": [
+        7.41,
+        4.94
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E7600",
+      "mount": "nikon7900",
+      "crop_factor": 4.86,
+      "sensor_size_mm": [
+        7.41,
+        4.94
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E7900",
+      "mount": "nikon7900",
+      "crop_factor": 4.86,
+      "sensor_size_mm": [
+        7.41,
+        4.94
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E8400",
+      "mount": "nikon8400",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E8700",
+      "mount": "nikon5700",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E8800",
+      "mount": "nikon8800",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E950",
+      "mount": "nikon950",
+      "crop_factor": 5.408,
+      "sensor_size_mm": [
+        6.66,
+        4.44
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E990",
+      "mount": "nikon990",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "E995",
+      "mount": "nikon995",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "j",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Keymission 120",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "KeyMission 170",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 AW1",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 J1",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 J2",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 J3",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 J4",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 J5",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 S1",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 S2",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 V1",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 V2",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 1 V3",
+      "mount": "Nikon CX",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 5100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D1",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D100",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D1H",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D1X",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D200",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D2H",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.546,
+      "sensor_size_mm": [
+        23.29,
+        15.52
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D2Hs",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.546,
+      "sensor_size_mm": [
+        23.29,
+        15.52
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D2X",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.522,
+      "sensor_size_mm": [
+        23.65,
+        15.77
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D2Xs",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.522,
+      "sensor_size_mm": [
+        23.65,
+        15.77
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D300",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3000",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D300S",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3100",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.558,
+      "sensor_size_mm": [
+        23.11,
+        15.4
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3200",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.554,
+      "sensor_size_mm": [
+        23.17,
+        15.44
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3300",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3400",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3500",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3S",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D3X",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D4",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D40",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D40X",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D4s",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D5",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.003,
+      "sensor_size_mm": [
+        35.89,
+        23.93
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D50",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D500",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D5000",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D5100",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D5200",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D5300",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D5500",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D5600",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D6",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D60",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D600",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D610",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D70",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D700",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D7000",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D70s",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D7100",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D7200",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D750",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D7500",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D780",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D80",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D800",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D800E",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D810",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D850",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon D90",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Df",
+      "mount": "Nikon F AF",
+      "crop_factor": 1.001,
+      "sensor_size_mm": [
+        35.96,
+        23.98
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 30",
+      "mount": "Nikon Z",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 5",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 50",
+      "mount": "Nikon Z",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 6",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 6_2",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 7",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 7_2",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 8",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z 9",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z f",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z fc",
+      "mount": "Nikon Z",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "NIKON Z5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z50_2",
+      "mount": "Nikon Z",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z5_2",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "NIKON Z6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon Z6_3",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon ZR",
+      "mount": "Nikon Z",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "p950",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z 50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z 6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z 6 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z 6II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z 8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z fc",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z30",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z30 DX",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z6 I",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z6 II",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z62",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z6ii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z7i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z7II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "ZF",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "zf c",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "ZFC",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nokia",
+      "model": "1020",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nokia",
+      "model": "7 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nokia",
+      "model": "Lumia 1020",
+      "mount": "lumia1020",
+      "crop_factor": 3.93,
+      "sensor_size_mm": [
+        9.16,
+        6.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nokia",
+      "model": "Lumia 1520",
+      "mount": "lumia1520",
+      "crop_factor": 6.26,
+      "sensor_size_mm": [
+        5.75,
+        3.83
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Nothing",
+      "model": "Phone",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nothing",
+      "model": "Phone 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Novatek",
+      "model": "96675",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nubia",
+      "model": "NX721J",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "NWO Japan",
+      "model": "Generation Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ODRVM",
+      "model": "1080P Wifi",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ODRVM",
+      "model": "Action Cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C2040Z",
+      "mount": "olympus2040",
+      "crop_factor": 4.93,
+      "sensor_size_mm": [
+        7.3,
+        4.87
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C3040Z",
+      "mount": "olympus2040",
+      "crop_factor": 4.93,
+      "sensor_size_mm": [
+        7.3,
+        4.87
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C4040Z",
+      "mount": "olympus2040",
+      "crop_factor": 4.93,
+      "sensor_size_mm": [
+        7.3,
+        4.87
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C4100Z,C4000Z",
+      "mount": "olympus4000",
+      "crop_factor": 4.92,
+      "sensor_size_mm": [
+        7.32,
+        4.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C5050Z",
+      "mount": "olympus2040",
+      "crop_factor": 4.93,
+      "sensor_size_mm": [
+        7.3,
+        4.87
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C5060WZ",
+      "mount": "olympus5060",
+      "crop_factor": 4.93,
+      "sensor_size_mm": [
+        7.3,
+        4.87
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C700UZ",
+      "mount": "olympus700",
+      "crop_factor": 6.52,
+      "sensor_size_mm": [
+        5.52,
+        3.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C7070WZ",
+      "mount": "olympus5060",
+      "crop_factor": 4.93,
+      "sensor_size_mm": [
+        7.3,
+        4.87
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C70Z,C7000Z",
+      "mount": "olympus7000",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C730UZ",
+      "mount": "olympus700",
+      "crop_factor": 6.52,
+      "sensor_size_mm": [
+        5.52,
+        3.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C750UZ",
+      "mount": "olympus750",
+      "crop_factor": 6.03,
+      "sensor_size_mm": [
+        5.97,
+        3.98
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C8080WZ",
+      "mount": "olympus8080",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "C860L,D360L",
+      "mount": "olympusC860",
+      "crop_factor": 6.563,
+      "sensor_size_mm": [
+        5.49,
+        3.66
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-1",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-10",
+      "mount": "olympusE10",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-20,E-20N,E-20P",
+      "mount": "olympusE10",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-3",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-30",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-300",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-330",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-400",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-410",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-420",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-450",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-5",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-500",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-510",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-520",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-600",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-620",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M1 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M10",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M10 Mark III",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M10MarkII",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M10MarkIIIS",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M10MarkIV",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M1MarkII",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M1MarkIII",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M5MarkII",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M5MarkIII",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-P1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-P2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-P3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-P5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-P7",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL1s",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL6",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL7",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL8",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PL9",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PM1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-PM2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "M10 MARK IV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "mju-II",
+      "mount": "olympusEpic",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-D 10 MARK III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-D E-M10 Mark III",
+      "mount": "",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-D EM 10 MARK IIIS",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-D Mark 3s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OMD 10 mark III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OMD EM-10 Mk. III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OMD mark II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "PEN-F",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "SP350",
+      "mount": "olympusSP350",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "SP500UZ",
+      "mount": "olympusSP500",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "SP560UZ",
+      "mount": "olympusSP560",
+      "crop_factor": 5.8,
+      "sensor_size_mm": [
+        6.21,
+        4.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "Stylus 1s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "Stylus Epic",
+      "mount": "olympusEpic",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "Stylus1",
+      "mount": "olympusStylus1",
+      "crop_factor": 4.67,
+      "sensor_size_mm": [
+        7.71,
+        5.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "Stylus1,1s",
+      "mount": "olympusStylus1",
+      "crop_factor": 4.67,
+      "sensor_size_mm": [
+        7.71,
+        5.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "TG-1",
+      "mount": "olympusToughTG4",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "TG-2",
+      "mount": "olympusToughTG4",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "TG-3",
+      "mount": "olympusToughTG4",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "TG-4",
+      "mount": "olympusToughTG4",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "TG-5",
+      "mount": "olympusToughTG5",
+      "crop_factor": 5.62,
+      "sensor_size_mm": [
+        6.41,
+        4.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "TG-6",
+      "mount": "olympusToughTG4",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "u-miniD,Stylus V",
+      "mount": "olympusStylusV",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "X-2,C-50Z",
+      "mount": "olympusC50",
+      "crop_factor": 4.9,
+      "sensor_size_mm": [
+        7.35,
+        4.9
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "XZ-1",
+      "mount": "olympusxz1",
+      "crop_factor": 4.68,
+      "sensor_size_mm": [
+        7.69,
+        5.13
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "XZ-2",
+      "mount": "olympusxz1",
+      "crop_factor": 4.68,
+      "sensor_size_mm": [
+        7.69,
+        5.13
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "OM System",
+      "model": "OM-1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "OM System",
+      "model": "OM-1MarkII",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "OM System",
+      "model": "OM-3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "OM System",
+      "model": "OM-5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "OM System",
+      "model": "OM-5MarkII",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "OmniVision",
+      "model": "ov16a1q_i_aac",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "11",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "11 CPH2451",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "12r",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "5T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "6T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "7 PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "7T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "8 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "8T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9 pro Film mode",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "ace3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "HD1913",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "IZI",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord 2 5G FHD OpenCamera Sensors",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord 2T",
+      "mount": "",
+      "crop_factor": 0.6,
+      "sensor_size_mm": [
+        60.0,
+        40.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord CE2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord N10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "OnePlus 5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "OnePlus 8 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Oneplus 9 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Open",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "A15",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "A16",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "A74 4G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Find X 6 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Find X2 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Find X5 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "findx6 主摄",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "IQOO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "K9X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "PHY110",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "reno 10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Reno 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Reno 4 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Reno 6 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "reno5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "X6 pro 24mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "X7U",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Orion",
+      "model": "819L",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Overmax",
+      "model": "X-Bee drone 9.5 fold",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "AG-DVX200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BGH-1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BGH1",
+      "mount": "",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BGH6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BS1H",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-BGH1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-FZ10002",
+      "mount": "panasonicFZ1000",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G100",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G100D",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G110",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G9",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G90",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G91",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G95",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G95D",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G97",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G99",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G99D",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-G9M2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GH5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GH5M2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GH5S",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GH6",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GH7",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GX7MK3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GX800",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GX880",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-GX9",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-LX100M2",
+      "mount": "panasonicDMCLX100",
+      "crop_factor": 2.21,
+      "sensor_size_mm": [
+        16.29,
+        10.86
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S1",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S1H",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S1M2",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S1M2ES",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S1R",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S1RM2",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S5",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S5D",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S5M2",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S5M2X",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S9",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ200",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ200D",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ202",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ220",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ90",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ91",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ96",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-TZ99",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-ZS200",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-ZS200D",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-ZS220",
+      "mount": "panasonicZS200",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-ZS70",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC GH4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FX150",
+      "mount": "panasonicFX150",
+      "crop_factor": 4.7,
+      "sensor_size_mm": [
+        7.66,
+        5.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FX2",
+      "mount": "panasonicFX7",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FX7",
+      "mount": "panasonicFX7",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FX8",
+      "mount": "panasonicFX7",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FX9",
+      "mount": "panasonicFX7",
+      "crop_factor": 6.05,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ10",
+      "mount": "panasonicFZ10",
+      "crop_factor": 5.84,
+      "sensor_size_mm": [
+        6.16,
+        4.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ100",
+      "mount": "panasonicDMCFZ45",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ100 (3:2)",
+      "mount": "panasonicDMCFZ45",
+      "crop_factor": 5.81,
+      "sensor_size_mm": [
+        6.2,
+        4.13
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ1000",
+      "mount": "panasonicFZ1000",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ150",
+      "mount": "panasonicFZ150",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ18",
+      "mount": "panasonicDMCFZ18",
+      "crop_factor": 6.1,
+      "sensor_size_mm": [
+        5.9,
+        3.93
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ20",
+      "mount": "panasonicFZ10",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ200",
+      "mount": "panasonicDMCFZ200",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ2000",
+      "mount": "panasonicFZ2000",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ2500",
+      "mount": "panasonicFZ2000",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ28",
+      "mount": "panasonicFZ28",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ3",
+      "mount": "panasonicFZ3",
+      "crop_factor": 7.6,
+      "sensor_size_mm": [
+        4.74,
+        3.16
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ30",
+      "mount": "panasonicFZ30",
+      "crop_factor": 4.73,
+      "sensor_size_mm": [
+        7.61,
+        5.07
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ300",
+      "mount": "panasonicDMCFZ200",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ330",
+      "mount": "panasonicDMCFZ200",
+      "crop_factor": 5.56,
+      "sensor_size_mm": [
+        6.47,
+        4.32
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ35",
+      "mount": "panasonicDMCFZ35",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ40",
+      "mount": "panasonicDMCFZ45",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ40 (3:2)",
+      "mount": "panasonicDMCFZ45",
+      "crop_factor": 5.81,
+      "sensor_size_mm": [
+        6.2,
+        4.13
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ45",
+      "mount": "panasonicDMCFZ45",
+      "crop_factor": 5.6,
+      "sensor_size_mm": [
+        6.43,
+        4.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ45 (3:2)",
+      "mount": "panasonicDMCFZ45",
+      "crop_factor": 5.81,
+      "sensor_size_mm": [
+        6.2,
+        4.13
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ5",
+      "mount": "panasonicFZ5",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ50",
+      "mount": "panasonicDMCFZ50",
+      "crop_factor": 4.84,
+      "sensor_size_mm": [
+        7.44,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-FZ8",
+      "mount": "panasonicDMCFZ8",
+      "crop_factor": 6.02,
+      "sensor_size_mm": [
+        5.98,
+        3.99
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G10",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G6",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G7",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G70",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G8",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G80",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G81",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G85",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GF1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GF2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GF3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GF5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GF6",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GF7",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GF8",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GH1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GH2",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GH3",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GH4",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GM1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GM5",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GX1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GX7",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GX8",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GX80",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-GX85",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-L1",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-L10",
+      "mount": "4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LC1",
+      "mount": "leicaDigilux2",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LF1",
+      "mount": "panasonicLF1",
+      "crop_factor": 4.67,
+      "sensor_size_mm": [
+        7.71,
+        5.14
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX1",
+      "mount": "panasonicLX1",
+      "crop_factor": 4.45,
+      "sensor_size_mm": [
+        8.09,
+        5.39
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX10",
+      "mount": "panasonicLX10",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX100",
+      "mount": "panasonicDMCLX100",
+      "crop_factor": 2.21,
+      "sensor_size_mm": [
+        16.29,
+        10.86
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX15",
+      "mount": "panasonicLX10",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX2",
+      "mount": "panasonicDMCLX2",
+      "crop_factor": 4.44,
+      "sensor_size_mm": [
+        8.11,
+        5.41
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX3",
+      "mount": "panasonicLX3",
+      "crop_factor": 4.7,
+      "sensor_size_mm": [
+        7.66,
+        5.11
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX5",
+      "mount": "panasonicLX5",
+      "crop_factor": 4.71,
+      "sensor_size_mm": [
+        7.64,
+        5.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LX7",
+      "mount": "panasonicLX7",
+      "crop_factor": 5.1,
+      "sensor_size_mm": [
+        7.06,
+        4.71
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LZ1",
+      "mount": "panasonicLZ2",
+      "crop_factor": 6.06,
+      "sensor_size_mm": [
+        5.94,
+        3.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-LZ2",
+      "mount": "panasonicLZ2",
+      "crop_factor": 6.06,
+      "sensor_size_mm": [
+        5.94,
+        3.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ100",
+      "mount": "panasonicTZ100",
+      "crop_factor": 2.75,
+      "sensor_size_mm": [
+        13.09,
+        8.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ101",
+      "mount": "panasonicTZ100",
+      "crop_factor": 2.75,
+      "sensor_size_mm": [
+        13.09,
+        8.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ110",
+      "mount": "panasonicTZ100",
+      "crop_factor": 2.75,
+      "sensor_size_mm": [
+        13.09,
+        8.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ60",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ61",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ70",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ71",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ80",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-TZ81",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-ZS100",
+      "mount": "panasonicTZ100",
+      "crop_factor": 2.75,
+      "sensor_size_mm": [
+        13.09,
+        8.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-ZS110",
+      "mount": "panasonicTZ100",
+      "crop_factor": 2.75,
+      "sensor_size_mm": [
+        13.09,
+        8.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-ZS40",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-ZS50",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-ZS60",
+      "mount": "panasonicTZ70",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "EVA1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "FZ10002",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "FZ2000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "FZ2500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "fz82",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G 100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G70",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G85",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "g9",
+      "mount": "",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G92",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G95D",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GF15",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH-2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5 m2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5M2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GHˆ",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GX80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GX85",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GX9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-1500X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-V785",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-VX980",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-VX981K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-X1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-X1500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HX A1H",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "lumix 300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LUMIX DC-S5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix DMC-G7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix G7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix G85",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix G9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH4R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5ii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GX5S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GX80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix gx9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix LX100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S1H",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LUMIX S5 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5 Mark 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LUMIX S52X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5M2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "lx100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LX15",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LX5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "nv_gs280_mindv",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S1H",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "s5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5 M 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S52",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "s52x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5IIX",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5M2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "s5m2x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S9",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "35mm film: full frame",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "6x7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "K-3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "K-5 IIS",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "K3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax *ist D",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax *ist DL",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax *ist DL2",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax *ist DS",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax *ist DS2",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax 645D",
+      "mount": "Pentax 645AF2",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-01",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.522,
+      "sensor_size_mm": [
+        23.65,
+        15.77
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-30",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.526,
+      "sensor_size_mm": [
+        23.59,
+        15.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-5",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.526,
+      "sensor_size_mm": [
+        23.59,
+        15.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-5 II",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.526,
+      "sensor_size_mm": [
+        23.59,
+        15.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-5 II s",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.526,
+      "sensor_size_mm": [
+        23.59,
+        15.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-50",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.526,
+      "sensor_size_mm": [
+        23.59,
+        15.73
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-500",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-7",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.538,
+      "sensor_size_mm": [
+        23.41,
+        15.6
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-m",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-r",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K-x",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K100D",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K100D Super",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K10D",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K110D",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K2000",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K200D",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax K20D",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.538,
+      "sensor_size_mm": [
+        23.41,
+        15.6
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 230GS",
+      "mount": "pentax230",
+      "crop_factor": 6.563,
+      "sensor_size_mm": [
+        5.49,
+        3.66
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 330GS",
+      "mount": "pentax230",
+      "crop_factor": 6.563,
+      "sensor_size_mm": [
+        5.49,
+        3.66
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 33L",
+      "mount": "pentax230",
+      "crop_factor": 6.563,
+      "sensor_size_mm": [
+        5.49,
+        3.66
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 33LF",
+      "mount": "pentax230",
+      "crop_factor": 6.563,
+      "sensor_size_mm": [
+        5.49,
+        3.66
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 430",
+      "mount": "pentax430",
+      "crop_factor": 4.85,
+      "sensor_size_mm": [
+        7.42,
+        4.95
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 43WR",
+      "mount": "pentax43WR",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 450",
+      "mount": "pentax750",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 550",
+      "mount": "pentax750",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 555",
+      "mount": "pentax750",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Optio 750Z",
+      "mount": "pentax750",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Q",
+      "mount": "Pentax Q",
+      "crop_factor": 5.53,
+      "sensor_size_mm": [
+        6.51,
+        4.34
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Q-S1",
+      "mount": "Pentax Q",
+      "crop_factor": 4.6,
+      "sensor_size_mm": [
+        7.83,
+        5.22
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Q10",
+      "mount": "Pentax Q",
+      "crop_factor": 5.53,
+      "sensor_size_mm": [
+        6.51,
+        4.34
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "Pentax Q7",
+      "mount": "Pentax Q",
+      "crop_factor": 4.6,
+      "sensor_size_mm": [
+        7.83,
+        5.22
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Phase One",
+      "model": "IQ140",
+      "mount": "Mamiya 645",
+      "crop_factor": 0.789,
+      "sensor_size_mm": [
+        45.63,
+        30.42
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Phase One",
+      "model": "IQ180",
+      "mount": "Mamiya 645",
+      "crop_factor": 0.644,
+      "sensor_size_mm": [
+        55.9,
+        37.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Phase One",
+      "model": "P 25",
+      "mount": "Mamiya 645",
+      "crop_factor": 0.577,
+      "sensor_size_mm": [
+        62.39,
+        41.59
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Philips",
+      "model": "adr810",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Polaroid",
+      "model": "cube",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RaceCam",
+      "model": "R1 Micro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Raspberry Pi",
+      "model": "Camera Module 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Raspberry Pi",
+      "model": "HQ Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "3 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "6 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "7 (RMX2151)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "7 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "8pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "9 pro plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "C2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "C67",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "GT MASTER",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "GT Neo3 Realme",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "RMX2151",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "X3 Zoom",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "8k vv",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "DRAGON X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "DSMC2 GEMINI 5K S35",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "EPIC",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "EPIC DRAGON",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "EPIC-X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Gemini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Gemini 5K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Helium 8K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "komodo",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "KOMODO 6K",
+      "mount": "",
+      "crop_factor": 1.14,
+      "sensor_size_mm": [
+        31.58,
+        21.05
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "KOMODO X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "KOMODO-X 6K S35",
+      "mount": "",
+      "crop_factor": 1.33,
+      "sensor_size_mm": [
+        27.07,
+        18.05
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Raptor",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Raven",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "SCARLET-W 5K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "SCARLET-X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-Raptor",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-RAPTOR 8K S35",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-RAPTOR 8K VV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-Raptor [X] 8K VV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-RAPTOR VV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V_Raptor",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Caplio GX",
+      "mount": "ricohGX",
+      "crop_factor": 4.9,
+      "sensor_size_mm": [
+        7.35,
+        4.9
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Caplio GX8",
+      "mount": "ricohGX",
+      "crop_factor": 4.9,
+      "sensor_size_mm": [
+        7.35,
+        4.9
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Caplio RR30",
+      "mount": "ricohRR30",
+      "crop_factor": 6.4,
+      "sensor_size_mm": [
+        5.62,
+        3.75
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "GR",
+      "mount": "ricohGR",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "GR Digital",
+      "mount": "ricohGRdigital",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "GR II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax 645Z",
+      "mount": "Pentax 645AF2",
+      "crop_factor": 0.79,
+      "sensor_size_mm": [
+        45.57,
+        30.38
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-1",
+      "mount": "Pentax KAF4",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-1 Mark II",
+      "mount": "Pentax KAF4",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-3",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-3 II",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-3 Mark III",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.546,
+      "sensor_size_mm": [
+        23.29,
+        15.52
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-3 Mark III Monochrome",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.546,
+      "sensor_size_mm": [
+        23.29,
+        15.52
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-70",
+      "mount": "Pentax KAF4",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-S1",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax K-S2",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax KF",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Pentax KP",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Ricoh GR III",
+      "mount": "ricohGRIII",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Ricoh GR III HDF",
+      "mount": "ricohGRIII",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Ricoh GR IIIx",
+      "mount": "ricohGRIIIx",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Ricoh GR IIIx HDF",
+      "mount": "ricohGRIIIx",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "Ricoh GR IV",
+      "mount": "ricohGRIV",
+      "crop_factor": 1.53,
+      "sensor_size_mm": [
+        23.53,
+        15.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "2.8E",
+      "mount": "Rollei 6x6",
+      "crop_factor": 0.51,
+      "sensor_size_mm": [
+        70.59,
+        47.06
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "530",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "9s Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "AC 625",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "ac500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "Actioncam 7S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "2 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "3S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "5 black",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "5 Orange",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HDZERO Micro V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HDZero Nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HuangFeng",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HYBRID",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Hybrid 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "IF Gocam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Iflight Gocam PMGR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Link Phoenix HD Kit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Link Wasp",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "LR-RUNCAM43",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Micro V2 HDZero",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "MIPI",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Nano 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Nano2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Nano3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Phinex",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Phoenix",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Phoenix 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "phoenix jb",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Protek25",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Protek25 2.7K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RC5-OR (v1.1)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RunCam 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RunCam 4K Protek25 3840x2160 29.97fps",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RunCam 6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Runcam Split 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Spilt",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 3 Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split 3 lite caddx turtle 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 3 Micro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 3 Nano HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split hd 2.7k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split HD 43",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split lite 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split Mini 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split Mini 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split Nano 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "SPLIT-HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split3 lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "thumb pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb Pro W",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb ProW",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "ThumbPro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "ThumbPW",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Tramp pro 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Wasp",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ryze",
+      "model": "Tello",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "23",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A 20 E",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A03s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A13",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A14 ISOCELL JN1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A22",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A30s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A34",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A41",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A5 2017",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A51",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A52 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "a53 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "a70",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A71",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A73",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A9 pro(2016)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A9Pro (2016)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "EK-GN120",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "EX2F",
+      "mount": "samsungEx2f",
+      "crop_factor": 4.6,
+      "sensor_size_mm": [
+        7.83,
+        5.22
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Fold 3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Fold 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A51 Ultra Wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A52",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A52s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A71",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A72",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy F62",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy M20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy m31",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy note 10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note 10+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note 20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note 9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note S20 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note10+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S10e",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S20 FE 4G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy s20 fe 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S20fe",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy s20u",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S21",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S21 FE 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy s21 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S22",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S22 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S22 Ultra - Main (108 MP)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S23",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S23 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S23 x1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S24",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S24 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S24 Ultra 14mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Ultra 23S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Gear 360 (2017)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Gear360",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Gran angular",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "gw1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "GX-1L",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "GX-1S",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "GX20",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.538,
+      "sensor_size_mm": [
+        23.41,
+        15.6
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "ISOCELL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "J7 NXT",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "M30s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "m52",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10 Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10H",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 9 1080p",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX 500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX mini",
+      "mount": "Samsung NX mini",
+      "crop_factor": 2.727,
+      "sensor_size_mm": [
+        13.2,
+        8.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX-30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX1",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX10",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX100",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX1000",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX11",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX1100",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX20",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX200",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX2000",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX210",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX30",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "nx300",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX3000",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX300M",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX5",
+      "mount": "Samsung NX",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX500",
+      "mount": "Samsung NX",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S10 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S10+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S10e",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S20 fe",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S20+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S20FE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S21 FE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S21 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22 Base",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22 ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22 Wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "s22+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22u",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23 FE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23+",
+      "mount": "",
+      "crop_factor": 0.6,
+      "sensor_size_mm": [
+        60.0,
+        40.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23U",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23ultra 23mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S24",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S24 Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S24 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S24_Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S25 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S5K4H7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S5KGM1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "s5kgm2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S6 edge plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S8+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "s9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S9+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Samsung A51 Ultra Wide 9:16",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "SAMSUNG GX10",
+      "mount": "Pentax KAF2",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "SM-G935F",
+      "mount": "samsungS7",
+      "crop_factor": 6.19,
+      "sensor_size_mm": [
+        5.82,
+        3.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "SM-G9500",
+      "mount": "samsungS8",
+      "crop_factor": 6.19,
+      "sensor_size_mm": [
+        5.82,
+        3.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "SM-G950F",
+      "mount": "samsungS8",
+      "crop_factor": 6.19,
+      "sensor_size_mm": [
+        5.82,
+        3.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "SM-G991B",
+      "mount": "samsungS21uw",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "SM-N950U",
+      "mount": "samsungS8wide",
+      "crop_factor": 6.047,
+      "sensor_size_mm": [
+        5.95,
+        3.97
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "WB2000",
+      "mount": "samsungWB2000",
+      "crop_factor": 5.69,
+      "sensor_size_mm": [
+        6.33,
+        4.22
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "WB800F",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Xcover 5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Z Flip 4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sargo",
+      "model": "A9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sargo",
+      "model": "G10+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SBOX",
+      "model": "actioncam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Seiko Epson",
+      "model": "R-D1",
+      "mount": "Leica M",
+      "crop_factor": 1.525,
+      "sensor_size_mm": [
+        23.61,
+        15.74
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sena",
+      "model": "50C",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sencor",
+      "model": "4K20WR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sharp",
+      "model": "aquos r6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sharp",
+      "model": "SH-R80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "fp",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "fp L",
+      "mount": "",
+      "crop_factor": 1.24,
+      "sensor_size_mm": [
+        29.03,
+        19.35
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "FPL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "sd Quattro",
+      "mount": "Sigma SA",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "sd Quattro H",
+      "mount": "Sigma SA",
+      "crop_factor": 1.346,
+      "sensor_size_mm": [
+        26.75,
+        17.83
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma BF",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP1",
+      "mount": "sigmaDP1",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP1 Merrill",
+      "mount": "sigmaDP1M",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP1S",
+      "mount": "sigmaDP1",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP1X",
+      "mount": "sigmaDP1",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP2",
+      "mount": "sigmaDP2",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP2 Merrill",
+      "mount": "sigmaDP2M",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP2S",
+      "mount": "sigmaDP2",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP2X",
+      "mount": "sigmaDP2",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma DP3 Merrill",
+      "mount": "sigmaDP3M",
+      "crop_factor": 1.531,
+      "sensor_size_mm": [
+        23.51,
+        15.68
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma fp",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma fp L",
+      "mount": "Leica L",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma SD1",
+      "mount": "Sigma SA",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma SD1 Merrill",
+      "mount": "Sigma SA",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma SD10",
+      "mount": "Sigma SA",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma SD14",
+      "mount": "Sigma SA",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma SD15",
+      "mount": "Sigma SA",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "Sigma SD9",
+      "mount": "Sigma SA",
+      "crop_factor": 1.739,
+      "sensor_size_mm": [
+        20.7,
+        13.8
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "SIGMA_FPL",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Simulus",
+      "model": "GH-265",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sioeye",
+      "model": "Blink",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sioeye",
+      "model": "v3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sioeye",
+      "model": "v4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "11",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "200pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "4000 AIR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "4000air",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "4000W",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "8 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "8Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "C",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "c100+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "c100+ Horizontal",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "c100+ Vertical",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "C200",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "c200pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "c300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "Legend 6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "M10+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "M20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ 7 STAR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ 8 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ10 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "sj10pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ20",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ4000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ4000 Air",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ5000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ5000X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "sj6 legend",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "sj6legend",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ6PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ8 PLUS",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ8 PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCAM",
+      "model": "SJ8PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Skydio",
+      "model": "2+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Somikon",
+      "model": "action cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "5100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "6300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "7CII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "A37",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a5000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a5100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a58 18-55 kit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6000",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6300",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6400",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6600",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6700",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "A7 IV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a77",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7C",
+      "mount": "",
+      "crop_factor": 1.2,
+      "sensor_size_mm": [
+        30.0,
+        20.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7CII",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7CR",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "A7II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7IV",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7R",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7RII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7RIII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rIIIA",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rIV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rIVa",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rV",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7sII",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7SIII",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "A99 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a9III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "blackshark4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Cybershot",
+      "mount": "sony707",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC WX 50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC WX50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-F828",
+      "mount": "sony828",
+      "crop_factor": 3.933,
+      "sensor_size_mm": [
+        9.15,
+        6.1
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-H1",
+      "mount": "sonyH1",
+      "crop_factor": 6.0,
+      "sensor_size_mm": [
+        6.0,
+        4.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-HX20V",
+      "mount": "sonyHX20V",
+      "crop_factor": 5.62,
+      "sensor_size_mm": [
+        6.41,
+        4.27
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-HX300",
+      "mount": "sonyHX300",
+      "crop_factor": 5.58,
+      "sensor_size_mm": [
+        6.45,
+        4.3
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-P100",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-P150",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-P200",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-P73",
+      "mount": "sonyS60",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-P93",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-R1",
+      "mount": "sonyR1",
+      "crop_factor": 1.68,
+      "sensor_size_mm": [
+        21.43,
+        14.29
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX0",
+      "mount": "sonyRX0M2",
+      "crop_factor": 2.7,
+      "sensor_size_mm": [
+        13.33,
+        8.89
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX0M2",
+      "mount": "sonyRX0M2",
+      "crop_factor": 2.7,
+      "sensor_size_mm": [
+        13.33,
+        8.89
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX10",
+      "mount": "sonyRX10",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100",
+      "mount": "sonyRX100",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M2",
+      "mount": "sonyRX100II",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M3",
+      "mount": "sonyRX100III",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M4",
+      "mount": "sonyRX100III",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M5",
+      "mount": "sonyRX100III",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M5A",
+      "mount": "sonyRX100III",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M6",
+      "mount": "sonyRX100VI",
+      "crop_factor": 2.66,
+      "sensor_size_mm": [
+        13.53,
+        9.02
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M7",
+      "mount": "sonyRX100VI",
+      "crop_factor": 2.66,
+      "sensor_size_mm": [
+        13.53,
+        9.02
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX100M7A",
+      "mount": "sonyRX100VI",
+      "crop_factor": 2.66,
+      "sensor_size_mm": [
+        13.53,
+        9.02
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX10M2",
+      "mount": "sonyRX10II",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX10M3",
+      "mount": "sonyRX10III",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX10M4",
+      "mount": "sonyRX10III",
+      "crop_factor": 2.73,
+      "sensor_size_mm": [
+        13.19,
+        8.79
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX1R",
+      "mount": "sonyRX1",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX1RM2",
+      "mount": "sonyRX1",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX1RM3",
+      "mount": "sonyRX1",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-S60",
+      "mount": "sonyS60",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-S80",
+      "mount": "sonyS60",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-S90",
+      "mount": "sonyS60",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-ST80",
+      "mount": "sonyS60",
+      "crop_factor": 6.5,
+      "sensor_size_mm": [
+        5.54,
+        3.69
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-T1",
+      "mount": "sonyT1",
+      "crop_factor": 5.65,
+      "sensor_size_mm": [
+        6.37,
+        4.25
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-V1",
+      "mount": "sonyV1",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-V3",
+      "mount": "sonyV1",
+      "crop_factor": 4.843,
+      "sensor_size_mm": [
+        7.43,
+        4.96
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-W1",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-W12",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-W15",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-W5",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-W7",
+      "mount": "sonyW1",
+      "crop_factor": 4.8,
+      "sensor_size_mm": [
+        7.5,
+        5.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A100",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A200",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A230",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A290",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A300",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A330",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A350",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A380",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.528,
+      "sensor_size_mm": [
+        23.56,
+        15.71
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A390",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A450",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A500",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A550",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A560",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A580",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A700",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A850",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSLR-A900",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR X1000V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX30",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX43",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX53",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX700",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-X1000V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-X3000",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "fs5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FS7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX3",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX30",
+      "mount": "",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX6V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR AS 15",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS100V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS15",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS200V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS30V Action Cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AZ1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-CX625",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-CX900E",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-mv1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HX200V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HX60",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HXR MC2500",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HXR-NX100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HXR-NX80",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCA-68",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCA-77M2",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCA-99M2",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-1",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-1M2",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-3000",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-5000",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-5100",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-6000",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-6100",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-6300",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-6400",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-6500",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-6600",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-6700",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7C",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7CM2",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7CR",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7M2",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7M3",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7M4",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7M5",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7R",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7RM2",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7RM3",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7RM3A",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7RM4",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7RM4A",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7RM5",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7S",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7SM2",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-7SM3",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-9",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-9M2",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILCE-9M3",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILME-FX2",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILME-FX3",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILME-FX30",
+      "mount": "Sony E",
+      "crop_factor": 1.546,
+      "sensor_size_mm": [
+        23.29,
+        15.52
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILME-FX6V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILX-LR1",
+      "mount": "",
+      "crop_factor": 1.24,
+      "sensor_size_mm": [
+        29.03,
+        19.35
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "M3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "mini dv",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX 5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Nex 5N",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Nex 6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-3",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-3N",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-5",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-5N",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-5R",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-5T",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-6",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-7",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-C3",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-F3",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "nex3n",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PMW-400",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "potensic",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Potensic Atom SE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PXW-FS7M2",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PXW-FX9V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PXW-Z280V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "R100III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0II-C-Mount-MOD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0II_C-Mount-MOD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0II_Custom-C-Mount-MOD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0M2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100IV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100M4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100M5A",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100VI",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10IV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10M2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10M4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RXO II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A33",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A35",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A37",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A55V",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A57",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A58",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A65V",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.523,
+      "sensor_size_mm": [
+        23.64,
+        15.76
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A77V",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A99",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.005,
+      "sensor_size_mm": [
+        35.82,
+        23.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SLT-A99V",
+      "mount": "Sony Alpha",
+      "crop_factor": 1.005,
+      "sensor_size_mm": [
+        35.82,
+        23.88
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SO-02K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Venice",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "XA75",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1 III",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1 iv",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1 V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "xperia 5 iii",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 iii Cinema pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 IV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 V",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia IV",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia PRO-I",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia V 2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia XA2 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia XZ1 Compact SO-02K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia Z3",
+      "mount": "sonyXperiaZ3",
+      "crop_factor": 7.87,
+      "sensor_size_mm": [
+        4.57,
+        3.05
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "XZ1 Compact",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-1",
+      "mount": "sonyZV1",
+      "crop_factor": 2.7,
+      "sensor_size_mm": [
+        13.33,
+        8.89
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-1F",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E1",
+      "mount": "Sony E",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10",
+      "mount": "Sony E",
+      "crop_factor": 1.5,
+      "sensor_size_mm": [
+        24.0,
+        16.0
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10 II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10II",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10M2",
+      "mount": "Sony E",
+      "crop_factor": 1.534,
+      "sensor_size_mm": [
+        23.47,
+        15.65
+      ],
+      "sources": [
+        "gyroflow",
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "黑鲨4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SOOCOO",
+      "model": "c100",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sooyi",
+      "model": "S3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Surfola",
+      "model": "530",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Tecno",
+      "model": "pova 5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ThiEYE",
+      "model": "dash cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ThiEYE",
+      "model": "t5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Tomate",
+      "model": "MT-1081",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "TomTom",
+      "model": "Bandit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Tracer",
+      "model": "SJ 4000LE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ulefone",
+      "model": "Armor 12g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ulefone",
+      "model": "Armor 7 Rear IMX586",
+      "mount": "",
+      "crop_factor": 5.41,
+      "sensor_size_mm": [
+        6.65,
+        4.44
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Umidigi",
+      "model": "F3 5G MP13",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vaquita",
+      "model": "Paralenz Gen 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Visuo",
+      "model": "Zen K1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivitar",
+      "model": "DVR923-KIT-BLK",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "A119 V3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "IQOO 9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "iQOO Z1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "IQOO3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "S15pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "V2145A",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "V23 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "V2309",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "v27e",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "Vivo x90 Pro+",
+      "mount": "",
+      "crop_factor": 3.0,
+      "sensor_size_mm": [
+        12.0,
+        8.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X100 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X100Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "x50 pro+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X50ProPlus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X70 Pro Plus",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "x90 Pro+",
+      "mount": "",
+      "crop_factor": 3.0,
+      "sensor_size_mm": [
+        12.0,
+        8.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "x90pro+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Volla",
+      "model": "Vollaphone X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "1s lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "1s little",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar HD Mini 1s Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Micro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Micro V1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar mini 1s kit nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Moonlight",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Moonlight kit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro HD",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro Wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar V2 Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "fpv cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "FPVcam V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "HD Pro kit",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Micro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "mini vtx",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Moonlight",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Moonlight 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Moonlight 4K 30fps",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Nano",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "ProV2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "V2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "walksnail cinlog35",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Wolfang",
+      "model": "GA300",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Wolfang",
+      "model": "GA320",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Wolfang",
+      "model": "ga400",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Wolfang",
+      "model": "GA420",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "X-TRY",
+      "model": "XTC 263",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XDV",
+      "model": "Action Sport Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10c",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10pro Ultra wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10T Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10u",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11 Lite 5G NE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11 ULTRA",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11 Ultra 4:3 RAW",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11Tpro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 SU",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12c",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12S Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12s ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12SU",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12T Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13 24mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13pro main",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13pro wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13T Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13U",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13U 23mm 小米",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13u广角",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14 3.2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14 Main",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14Pro main camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14u",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "22081212C",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "2210132G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "2304FPN6DG",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "24030PN60G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "cc9pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "f1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "f1 wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "F1 wide 2to1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "F3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "f3 stab off",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "f3 stab on",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "F4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "F4GT",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "fimi x8 mini",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "K30PRO1X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "k60",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "K60 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "K70",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "K70至尊",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "M2012K11AC",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "M2101K7BNY",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "M4Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "M5s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi 10t",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10T lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10T Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 lite 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 Lite 5G NE",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 Ultra 24mm",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi 11t",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11x",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "MI 11x / Poco F3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11X M2012K11AI",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 12 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 13",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 14",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 8 Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "MI 9 Lite",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 9 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "MI 9T Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 9T Pro / K20 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi A3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi Action 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi Action camera 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi MIX 1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi Note 10 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi10tpro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi14",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mijia 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mix 2s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mix3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mİ 10T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Nico",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 10 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 10s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "note 11 pro 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 12",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 12 Turbo",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 12T",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 13",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 13 Pro 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 8 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "note 9 pro max",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco F2 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco f3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "POCO F5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco X3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco X3 NFC",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco X3 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Pocophone NFC X3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 10s",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 11",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 9",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 9s pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Horizontal",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi K30pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi K50",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi K50 广角",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi k50i",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 10 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "REDMI NOTE 11 4G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11 pro 4G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11 Pro+ 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11Pro+ 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 11t pro +ultra wide",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 12 + 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 12 Pro (5G)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 12 pro + 5g",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 4X",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 4X Samsung S5K3L8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 7",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 8",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 8 PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 9 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 9 pro maxr",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 9Filmic pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 9S",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note12Tubro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Pro 10",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi S2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 红米K30pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "RN8 Ginkgo",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Ultra 14",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "X 3 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "x3 Pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "X5",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "x5 pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "X5 Pro 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "X6 5G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Xiaomi 13 Ultra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 1080p Action camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 22l",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 2K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 4K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 4k Action Camera",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 4K+",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi Action",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi action cam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi action caméra",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi action caméra 4k",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi Discovery",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yio",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "小蚁相机",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX2 CAM",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX3 CAM",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAXPRO CAM",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "Mini1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S2 PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S2PRO",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S3pro",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S3PRO CAM",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S5K",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S6 CAM",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X1",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X3",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X3 CAM",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "XTUMAX2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "XTUS5K (v1.2)",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "YI Technology",
+      "model": "M1",
+      "mount": "Micro 4/3 System",
+      "crop_factor": 2.0,
+      "sensor_size_mm": [
+        18.0,
+        12.0
+      ],
+      "sources": [
+        "lensfun"
+      ]
+    },
+    {
+      "brand": "YiCam",
+      "model": "Yicam",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Yolansin",
+      "model": "C16",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E1",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2 - M4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2 M4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "e2 S6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2 S6G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-F6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-M4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-S6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-S6G",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2c",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2F6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2M4",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2S6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "F6",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "laowa",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "S6",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Zoom",
+      "model": "Q2n",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "Axon",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "AXON40ULTRA",
+      "mount": "",
+      "crop_factor": null,
+      "sensor_size_mm": null,
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "Nubia z50 ultra",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "nubia z60 Ultra 35mm",
+      "mount": "",
+      "crop_factor": 1.0,
+      "sensor_size_mm": [
+        36.0,
+        24.0
+      ],
+      "sources": [
+        "gyroflow"
+      ]
+    }
+  ]
+}

--- a/src/core/camera_database.rs
+++ b/src/core/camera_database.rs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright © 2026 Gyroflow contributors
+
+//! Loader and lookup helpers for `camera_database.json`.
+//!
+//! The JSON file lives under `resources/camera_database/camera_database.json`
+//! and lists known camera brands / models with optional mount, crop factor and
+//! sensor size. It is built from the gyroflow lens profile collection and the
+//! LensFun database (see `resources/camera_database/build.py`).
+//!
+//! At runtime the file is loaded from disk next to the executable. If a newer
+//! copy has been downloaded into the user's data directory it takes precedence,
+//! mirroring the lens profile auto-update flow in `lens_profile_database`.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Camera {
+    pub brand: String,
+    pub model: String,
+    /// Lens mount label (free-form, may be empty when unknown).
+    pub mount: String,
+    /// 35mm crop factor. `None` when unknown.
+    pub crop_factor: Option<f64>,
+    /// `[width_mm, height_mm]` of the sensor. `None` when unknown.
+    /// Currently derived from `crop_factor` assuming a 3:2 still-camera sensor.
+    pub sensor_size_mm: Option<[f64; 2]>,
+    /// Which upstream sources the entry came from (e.g. `"gyroflow"`, `"lensfun"`).
+    #[serde(default)]
+    pub sources: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct CameraDatabaseFile {
+    pub version: u32,
+    #[serde(default)]
+    pub sources: Vec<String>,
+    pub cameras: Vec<Camera>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct CameraDatabase {
+    pub version: u32,
+    cameras: Vec<Camera>,
+}
+
+impl CameraDatabase {
+    /// Locate the `camera_database.json` shipped with the application.
+    ///
+    /// Mirrors `LensProfileDatabase::get_path()` candidate ordering so that
+    /// installed builds, source builds and the macOS bundle layout all work.
+    pub fn get_path() -> PathBuf {
+        let candidates = [
+            #[cfg(any(target_os = "macos", target_os = "ios"))]
+            PathBuf::from("../Resources/camera_database/camera_database.json"),
+            PathBuf::from("./resources/camera_database/camera_database.json"),
+            PathBuf::from("./camera_database/camera_database.json"),
+        ];
+        let exe = std::env::current_exe().unwrap_or_default();
+        let exe_parent = exe.parent();
+        for path in &candidates {
+            if let Ok(p) = std::fs::canonicalize(path) {
+                if p.exists() {
+                    return p;
+                }
+            }
+            if let Ok(p) = std::fs::canonicalize(
+                exe_parent.map(|x| x.join(path)).unwrap_or_default(),
+            ) {
+                if p.exists() {
+                    return p;
+                }
+            }
+        }
+        std::fs::canonicalize(&candidates[0]).unwrap_or_default()
+    }
+
+    /// User-writable override path (used by the auto-update flow).
+    pub fn user_path() -> PathBuf {
+        crate::settings::data_dir()
+            .join("camera_database")
+            .join("camera_database.json")
+    }
+
+    /// Load and parse the database. Tries the user-writable override first,
+    /// then falls back to the bundled copy.
+    pub fn load() -> Self {
+        for candidate in [Self::user_path(), Self::get_path()] {
+            if !candidate.exists() {
+                continue;
+            }
+            match std::fs::read(&candidate) {
+                Ok(bytes) => match Self::parse(&bytes) {
+                    Ok(db) => {
+                        log::info!(
+                            "Loaded camera database v{} ({} cameras) from {}",
+                            db.version,
+                            db.cameras.len(),
+                            candidate.display()
+                        );
+                        return db;
+                    }
+                    Err(e) => log::error!(
+                        "Error parsing camera database at {}: {e}",
+                        candidate.display()
+                    ),
+                },
+                Err(e) => log::error!(
+                    "Error reading camera database at {}: {e}",
+                    candidate.display()
+                ),
+            }
+        }
+        log::warn!("camera_database.json not found, using empty database");
+        Self::default()
+    }
+
+    pub fn parse(bytes: &[u8]) -> Result<Self, serde_json::Error> {
+        let file: CameraDatabaseFile = serde_json::from_slice(bytes)?;
+        let mut cameras = file.cameras;
+        cameras.sort_by(|a, b| {
+            a.brand
+                .to_ascii_lowercase()
+                .cmp(&b.brand.to_ascii_lowercase())
+                .then_with(|| {
+                    a.model
+                        .to_ascii_lowercase()
+                        .cmp(&b.model.to_ascii_lowercase())
+                })
+        });
+        Ok(Self {
+            version: file.version,
+            cameras,
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.cameras.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.cameras.is_empty()
+    }
+
+    pub fn cameras(&self) -> &[Camera] {
+        &self.cameras
+    }
+
+    /// Sorted list of unique brand names.
+    pub fn brands(&self) -> Vec<String> {
+        let mut set = std::collections::BTreeSet::new();
+        for c in &self.cameras {
+            if !c.brand.is_empty() {
+                set.insert(c.brand.clone());
+            }
+        }
+        set.into_iter().collect()
+    }
+
+    /// Sorted list of unique models for the given brand (case-insensitive match).
+    pub fn models_for_brand(&self, brand: &str) -> Vec<String> {
+        let key = brand.to_ascii_lowercase();
+        let mut set = std::collections::BTreeSet::new();
+        for c in &self.cameras {
+            if c.brand.to_ascii_lowercase() == key && !c.model.is_empty() {
+                set.insert(c.model.clone());
+            }
+        }
+        set.into_iter().collect()
+    }
+
+    /// Lookup a single camera by (brand, model). Case-insensitive.
+    pub fn find(&self, brand: &str, model: &str) -> Option<&Camera> {
+        let b = brand.to_ascii_lowercase();
+        let m = model.to_ascii_lowercase();
+        self.cameras.iter().find(|c| {
+            c.brand.to_ascii_lowercase() == b && c.model.to_ascii_lowercase() == m
+        })
+    }
+
+    /// Multi-word, case-insensitive substring search across brand+model.
+    /// Used to power UI selectors and combobox typeahead.
+    pub fn search(&self, query: &str, limit: usize) -> Vec<&Camera> {
+        let query = query.to_ascii_lowercase();
+        let words: Vec<&str> = query.split_whitespace().filter(|s| !s.is_empty()).collect();
+        if words.is_empty() {
+            return self.cameras.iter().take(limit).collect();
+        }
+        self.cameras
+            .iter()
+            .filter(|c| {
+                let haystack = format!(
+                    "{} {} {}",
+                    c.brand.to_ascii_lowercase(),
+                    c.model.to_ascii_lowercase(),
+                    c.mount.to_ascii_lowercase()
+                );
+                words.iter().all(|w| haystack.contains(w))
+            })
+            .take(limit)
+            .collect()
+    }
+
+    /// Cameras grouped by brand. Useful for UI population.
+    pub fn grouped_by_brand(&self) -> BTreeMap<String, Vec<&Camera>> {
+        let mut map: BTreeMap<String, Vec<&Camera>> = BTreeMap::new();
+        for c in &self.cameras {
+            map.entry(c.brand.clone()).or_default().push(c);
+        }
+        map
+    }
+
+    /// URL the application should fetch updated copies of `camera_database.json`
+    /// from. Mirrors the lens_profile auto-update endpoint.
+    pub const REMOTE_URL: &'static str =
+        "https://github.com/gyroflow/lens_profiles/releases/latest/download/camera_database.json";
+
+    /// Validate a payload (e.g. just downloaded from `REMOTE_URL`) and, if the
+    /// remote version is newer than the one we currently have loaded, write it
+    /// to the user-writable copy. Returns `true` on a successful update.
+    ///
+    /// This is split from any HTTP-fetching code so that core stays free of
+    /// network dependencies; the GUI controller drives the actual download.
+    pub fn store_update(payload: &[u8], current_version: u32) -> bool {
+        let parsed: CameraDatabaseFile = match serde_json::from_slice(payload) {
+            Ok(p) => p,
+            Err(e) => {
+                log::warn!("camera_database: remote payload not valid JSON: {e}");
+                return false;
+            }
+        };
+
+        if parsed.version <= current_version {
+            log::info!(
+                "camera_database: remote v{} not newer than local v{}, skipping",
+                parsed.version,
+                current_version
+            );
+            return false;
+        }
+
+        let dst = Self::user_path();
+        if let Some(parent) = dst.parent() {
+            if let Err(e) = std::fs::create_dir_all(parent) {
+                log::error!("camera_database: cannot create {}: {e}", parent.display());
+                return false;
+            }
+        }
+        if let Err(e) = std::fs::write(&dst, payload) {
+            log::error!("camera_database: cannot write {}: {e}", dst.display());
+            return false;
+        }
+
+        log::info!(
+            "camera_database: updated v{} -> v{} ({} bytes written to {})",
+            current_version,
+            parsed.version,
+            payload.len(),
+            dst.display()
+        );
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SAMPLE: &str = r#"{
+        "version": 1,
+        "sources": ["gyroflow_lens_profiles", "lensfun"],
+        "cameras": [
+            {"brand": "Sony", "model": "ILCE-7M4", "mount": "Sony E", "crop_factor": 1.0, "sensor_size_mm": [35.6, 23.8], "sources": ["lensfun"]},
+            {"brand": "Sony", "model": "FX3", "mount": "Sony E", "crop_factor": 1.0, "sensor_size_mm": null, "sources": ["gyroflow", "lensfun"]},
+            {"brand": "GoPro", "model": "HERO11 Black", "mount": "goProHero11bl", "crop_factor": 5.54, "sensor_size_mm": [6.5, 4.3], "sources": ["gyroflow"]},
+            {"brand": "Canon", "model": "EOS R5", "mount": "Canon RF", "crop_factor": 1.0, "sensor_size_mm": null, "sources": ["lensfun"]}
+        ]
+    }"#;
+
+    #[test]
+    fn parses_sample() {
+        let db = CameraDatabase::parse(SAMPLE.as_bytes()).expect("parse");
+        assert_eq!(db.version, 1);
+        assert_eq!(db.len(), 4);
+    }
+
+    #[test]
+    fn brands_are_sorted_and_unique() {
+        let db = CameraDatabase::parse(SAMPLE.as_bytes()).unwrap();
+        let brands = db.brands();
+        assert_eq!(brands, vec!["Canon", "GoPro", "Sony"]);
+    }
+
+    #[test]
+    fn models_for_brand_case_insensitive() {
+        let db = CameraDatabase::parse(SAMPLE.as_bytes()).unwrap();
+        let models = db.models_for_brand("sony");
+        assert_eq!(models, vec!["FX3", "ILCE-7M4"]);
+    }
+
+    #[test]
+    fn find_round_trips() {
+        let db = CameraDatabase::parse(SAMPLE.as_bytes()).unwrap();
+        let cam = db.find("GoPro", "HERO11 Black").expect("found");
+        assert_eq!(cam.mount, "goProHero11bl");
+        assert!((cam.crop_factor.unwrap() - 5.54).abs() < 1e-6);
+        assert!(db.find("nope", "nope").is_none());
+    }
+
+    #[test]
+    fn search_matches_multi_word_substrings() {
+        let db = CameraDatabase::parse(SAMPLE.as_bytes()).unwrap();
+        let hits = db.search("sony fx", 100);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].model, "FX3");
+
+        let hits = db.search("hero11", 100);
+        assert_eq!(hits.len(), 1);
+
+        let empty = db.search("nonexistent xyz", 100);
+        assert!(empty.is_empty());
+    }
+
+    #[test]
+    fn search_limit_is_respected() {
+        let db = CameraDatabase::parse(SAMPLE.as_bytes()).unwrap();
+        let hits = db.search("", 2);
+        assert_eq!(hits.len(), 2);
+    }
+
+    #[test]
+    fn grouped_by_brand_works() {
+        let db = CameraDatabase::parse(SAMPLE.as_bytes()).unwrap();
+        let grouped = db.grouped_by_brand();
+        assert_eq!(grouped.get("Sony").map(|v| v.len()), Some(2));
+        assert_eq!(grouped.get("GoPro").map(|v| v.len()), Some(1));
+    }
+
+    #[test]
+    fn store_update_rejects_older_versions() {
+        let payload = br#"{"version": 1, "cameras": []}"#;
+        assert!(
+            !CameraDatabase::store_update(payload, 5),
+            "remote older than local should not update"
+        );
+        assert!(
+            !CameraDatabase::store_update(payload, 1),
+            "equal version should not update"
+        );
+    }
+
+    #[test]
+    fn store_update_rejects_invalid_payload() {
+        let payload = b"not json";
+        assert!(!CameraDatabase::store_update(payload, 0));
+    }
+
+    #[test]
+    fn missing_optional_fields_default_to_none() {
+        let json = r#"{
+            "version": 1,
+            "cameras": [
+                {"brand": "X", "model": "Y"}
+            ]
+        }"#;
+        let db = CameraDatabase::parse(json.as_bytes()).unwrap();
+        assert_eq!(db.len(), 1);
+        let cam = &db.cameras()[0];
+        assert!(cam.crop_factor.is_none());
+        assert!(cam.sensor_size_mm.is_none());
+        assert_eq!(cam.mount, "");
+        assert!(cam.sources.is_empty());
+    }
+}

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -6,6 +6,7 @@ pub mod gyro_source;
 pub mod imu_integration;
 pub mod lens_profile;
 pub mod lens_profile_database;
+pub mod camera_database;
 #[cfg(feature = "opencv")]
 pub mod calibration;
 pub mod synchronization;


### PR DESCRIPTION
First pass at issue #742 (Refactor lens profile handling). Scope here is intentionally just the first checkbox - "create a list of known camera brands, models and lenses, store as json in resources, auto-updateable" - so this can land independently of the calibrator/UI work that follows.

## What's in here

- `resources/camera_database/camera_database.json` - normalized list of ~2.6k cameras across ~170 brands, merged from:
  - the per-camera JSON files in [gyroflow/lens_profiles](https://github.com/gyroflow/lens_profiles) (where most of the existing real-world data lives)
  - the [LensFun](https://github.com/lensfun/lensfun) `data/db/*.xml` database (mostly stills cameras with mount + crop factor metadata that gyroflow doesn't currently track)
- `resources/camera_database/build.py` - regenerator. Clones both upstream repos into `resources/camera_database/_build/` (gitignored) and rebuilds the JSON. `--refresh` to re-clone.
- `src/core/camera_database.rs` - small loader module: parse, brand list, models per brand, lookup by (brand, model), multi-word search, group-by-brand. Also a `store_update()` that validates a downloaded payload and writes it to `settings::data_dir()` if the version is newer, mirroring how `lens_profile_database` does its auto-update.

Schema:
```json
{
  "version": 1,
  "sources": ["gyroflow_lens_profiles", "lensfun"],
  "cameras": [
    {
      "brand": "Sony",
      "model": "ILCE-7M4",
      "mount": "Sony E",
      "crop_factor": 1.0,
      "sensor_size_mm": [35.6, 23.8],
      "sources": ["lensfun"]
    }
  ]
}
```

## What's deliberately not in here

- No calibrator UI changes
- No lens profile search UI changes
- No selector widgets in the main window

The other checkboxes in #742 (selectors, calibrator enforcement, video metadata pre-population, review process) all depend on having a clean canonical list to pick from, which is what this PR provides. Splitting that out keeps the diff reviewable and lets the data shape get nailed down before any UI is wired to it. Happy to follow up with the UI bits in separate PRs once the schema looks right.

## Notes on the data

Building the list highlighted the exact problem you mentioned in the issue thread - the existing `camera_brand` strings in lens profiles are very inconsistent. Same brand shows up as `Olympus` / `Olympus Corporation` / `Olympus Imaging Corp.` / `Olympus Optical Co.,Ltd`, `Casio` vs `Casio Computer Co.,Ltd.`, etc. The build script collapses these via an alias table (`BRAND_ALIASES` in `build.py`) and drops obvious noise entries like `iqoo z3` or `mate40pro` that are clearly model strings someone typed into the brand field. The alias table is the obvious thing to grow over time / accept patches against.

Stats from the current build:
- 2645 unique cameras (1664 from gyroflow, 1029 from lensfun, 48 in both)
- 169 unique brands
- 1029 entries have a known mount, 1081 have a known crop factor
- File size 574KB pretty-printed JSON

## Auto-update wiring

The loader is wired to look in `settings::data_dir()/camera_database/camera_database.json` first and fall back to the file shipped under `./resources/camera_database/` (and the macOS `../Resources/...` bundle layout). `CameraDatabase::REMOTE_URL` points at `https://github.com/gyroflow/lens_profiles/releases/latest/download/camera_database.json`, which is the same release path the lens profile cbor.gz already uses.

The actual HTTP fetch is intentionally not added in this PR because there's no UI surface yet to trigger it - I left a `store_update(payload, current_version)` entry point that the controller can call with a downloaded body, in the same shape as the existing `fetch_profiles_from_github` flow. Wiring that on top of the existing lens profile updater is a one-screen patch I'm happy to do as a follow-up once we agree on this base.

## How to regenerate

```
python3 resources/camera_database/build.py            # uses cached _build/ clones
python3 resources/camera_database/build.py --refresh  # re-clone first
```

## Tests

Unit tests are in `src/core/camera_database.rs` under `#[cfg(test)]` covering parse, brand list, model lookup, multi-word search, search limit, and the version-gating behaviour of `store_update()`. Run with `cargo test -p gyroflow-core camera_database`.

Open as draft because there's no demo video for a data/loader-only change - the visible bits land in follow-up PRs once the schema is signed off.

/claim #742