### PR TITLE
Add canonical camera and lens data store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ gyroflow.log
 *.mobileprovision
 *.provisionprofile
 *.pfx
-resources/camera_presets
+resources/camera_presets/*
+!resources/camera_presets/canonical_lenses.json
 *.exe
 .qmlls.ini

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1876,6 +1876,7 @@ impl Controller {
             this.all_profiles_loaded();
         });
         let db = self.stabilizer.lens_profile_db.clone();
+        let canonical_db = self.stabilizer.canonical_camera_db.clone();
         core::run_threaded(move || {
             if reload_from_disk {
                 let mut new_db = core::lens_profile_database::LensProfileDatabase::default();
@@ -1885,6 +1886,10 @@ impl Controller {
                 // new_db.process_adjusted_metadata();
 
                 db.write().set_from_db(new_db);
+
+                let mut new_canonical_db = core::canonical_camera_database::CanonicalCameraDatabase::default();
+                new_canonical_db.load_all();
+                canonical_db.write().set_from_db(new_canonical_db);
             }
 
             db.write().prepare_list_for_ui();
@@ -1931,6 +1936,7 @@ impl Controller {
         });
 
         let current_version = self.stabilizer.lens_profile_db.read().version;
+        let current_canonical_version = self.stabilizer.canonical_camera_db.read().version;
 
         let db_path = LensProfileDatabase::get_path().join("profiles.cbor.gz");
         if db_path.exists() || gyroflow_core::settings::data_dir().join("lens_profiles").exists() {
@@ -1941,9 +1947,18 @@ impl Controller {
                         if let Some(obj) = v.first() {
                             let obj = obj.as_object()?;
                             if let Ok(tag) = obj.get("tag_name")?.as_str()?.trim_start_matches("v").parse::<u32>() {
+                                let asset_url = |name: &str| -> Option<String> {
+                                    obj.get("assets")?
+                                        .as_array()?
+                                        .iter()
+                                        .find(|asset| asset.get("name").and_then(|v| v.as_str()) == Some(name))
+                                        .and_then(|asset| asset.get("browser_download_url")?.as_str())
+                                        .map(str::to_owned)
+                                };
+
                                 if tag > current_version {
                                     ::log::info!("Updating lens profile database from v{current_version} to v{tag}.");
-                                    if let Some(download_url) = obj["assets"][0]["browser_download_url"].as_str() {
+                                    if let Some(download_url) = asset_url("profiles.cbor.gz") {
                                         if let Ok(mut content) = ureq::get(download_url).call().map(|x| x.into_body().into_reader()) {
                                             let mut updated = false;
                                             if db_path.exists() {
@@ -1956,6 +1971,35 @@ impl Controller {
                                             }
                                             if !updated {
                                                 if let Ok(mut file) = std::fs::File::create(gyroflow_core::settings::data_dir().join("lens_profiles").join("profiles.cbor.gz")) {
+                                                    if std::io::copy(&mut content, &mut file).is_ok() {
+                                                        update(());
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+
+                                if tag > current_canonical_version {
+                                    ::log::info!("Updating canonical camera database from v{current_canonical_version} to v{tag}.");
+                                    if let Some(download_url) = asset_url(gyroflow_core::canonical_camera_database::CANONICAL_LENSES_FILENAME) {
+                                        let canonical_path = gyroflow_core::canonical_camera_database::CanonicalCameraDatabase::bundled_path();
+                                        let canonical_user_path = gyroflow_core::canonical_camera_database::CanonicalCameraDatabase::user_path();
+                                        if let Ok(mut content) = ureq::get(download_url).call().map(|x| x.into_body().into_reader()) {
+                                            let mut updated = false;
+                                            if canonical_path.exists() {
+                                                if let Ok(mut file) = std::fs::File::create(&canonical_path) {
+                                                    if std::io::copy(&mut content, &mut file).is_ok() {
+                                                        updated = true;
+                                                        update(());
+                                                    }
+                                                }
+                                            }
+                                            if !updated {
+                                                if let Some(parent) = canonical_user_path.parent() {
+                                                    let _ = std::fs::create_dir_all(parent);
+                                                }
+                                                if let Ok(mut file) = std::fs::File::create(canonical_user_path) {
                                                     if std::io::copy(&mut content, &mut file).is_ok() {
                                                         update(());
                                                     }

--- a/src/core/build.rs
+++ b/src/core/build.rs
@@ -4,13 +4,25 @@
 fn main() {
     // Download lens profiles if not already present
     let project_dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let db_path = format!("{project_dir}/../../resources/camera_presets/profiles.cbor.gz");
+    let resource_dir = format!("{project_dir}/../../resources/camera_presets");
+    let db_path = format!("{resource_dir}/profiles.cbor.gz");
     if !std::path::Path::new(&db_path).exists() {
-        std::fs::create_dir_all(&format!("{project_dir}/../../resources/camera_presets")).unwrap();
+        std::fs::create_dir_all(&resource_dir).unwrap();
         if let Ok(mut body) = ureq::get("https://github.com/gyroflow/lens_profiles/releases/latest/download/profiles.cbor.gz").call().map(|x| x.into_body().into_reader()) {
             match std::fs::File::create(&db_path) {
                 Ok(mut file) => { std::io::copy(&mut body, &mut file).unwrap(); },
                 Err(e) => { panic!("Failed to create {db_path}: {e:?}"); }
+            }
+        }
+    }
+
+    let canonical_path = format!("{resource_dir}/canonical_lenses.json");
+    if !std::path::Path::new(&canonical_path).exists() {
+        std::fs::create_dir_all(&resource_dir).unwrap();
+        if let Ok(mut body) = ureq::get("https://github.com/gyroflow/lens_profiles/releases/latest/download/canonical_lenses.json").call().map(|x| x.into_body().into_reader()) {
+            match std::fs::File::create(&canonical_path) {
+                Ok(mut file) => { std::io::copy(&mut body, &mut file).unwrap(); },
+                Err(e) => { panic!("Failed to create {canonical_path}: {e:?}"); }
             }
         }
     }

--- a/src/core/canonical_camera_database.rs
+++ b/src/core/canonical_camera_database.rs
@@ -1,0 +1,317 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2021-2022 Adrian <adrian.eddy at gmail>
+
+use std::path::PathBuf;
+
+pub const CANONICAL_LENSES_FILENAME: &str = "canonical_lenses.json";
+
+#[cfg(any(
+    target_os = "android",
+    target_os = "ios",
+    feature = "bundle-lens-profiles"
+))]
+static CANONICAL_LENSES_STATIC: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/../../resources/camera_presets/canonical_lenses.json"
+));
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalCameraDatabase {
+    pub schema_version: u32,
+    pub version: u32,
+    pub sources: Vec<CanonicalSource>,
+    pub mounts: Vec<CanonicalMount>,
+    pub brands: Vec<CanonicalBrand>,
+    pub setups: Vec<CanonicalSetup>,
+
+    #[serde(skip)]
+    pub loaded: bool,
+}
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalSource {
+    pub id: String,
+    pub name: String,
+    pub commit: String,
+    pub database_path: Option<String>,
+    pub file_count: Option<usize>,
+    pub profile_count: Option<usize>,
+    pub skipped_profile_count: Option<usize>,
+}
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalMount {
+    pub id: String,
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub compatible_mount_ids: Vec<String>,
+    pub sources: Vec<String>,
+}
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalBrand {
+    pub id: String,
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub sources: Vec<String>,
+    pub cameras: Vec<CanonicalCamera>,
+    pub lenses: Vec<CanonicalLens>,
+}
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalCamera {
+    pub id: String,
+    pub name: String,
+    pub aliases: Vec<String>,
+    pub sources: Vec<String>,
+    pub source_keys: Vec<String>,
+    pub mount_ids: Vec<String>,
+    pub crop_factor: Option<f64>,
+    pub sensor: Option<CanonicalSensor>,
+    pub profile_count: usize,
+    pub observed_lens_ids: Vec<String>,
+}
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalSensor {
+    pub name: String,
+    pub crop_factor: f64,
+}
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalLens {
+    pub id: String,
+    pub name: String,
+    pub maker: String,
+    pub aliases: Vec<String>,
+    pub sources: Vec<String>,
+    pub source_keys: Vec<String>,
+    pub mount_ids: Vec<String>,
+    pub crop_factor: Option<f64>,
+    pub lens_type: Option<String>,
+    pub profile_count: usize,
+}
+
+#[derive(Default, Clone, Debug, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CanonicalSetup {
+    pub camera_id: String,
+    pub lens_id: String,
+    pub sources: Vec<String>,
+    pub profile_count: usize,
+    pub profile_keys: Vec<String>,
+}
+
+impl CanonicalCameraDatabase {
+    pub fn get_path() -> PathBuf {
+        crate::lens_profile_database::LensProfileDatabase::get_path()
+    }
+
+    pub fn user_path() -> PathBuf {
+        crate::settings::data_dir()
+            .join("lens_profiles")
+            .join(CANONICAL_LENSES_FILENAME)
+    }
+
+    pub fn bundled_path() -> PathBuf {
+        Self::get_path().join(CANONICAL_LENSES_FILENAME)
+    }
+
+    pub fn load_all(&mut self) {
+        let _time = std::time::Instant::now();
+
+        let user_path = Self::user_path();
+        let loaded = if user_path.exists() {
+            ::log::info!(
+                "Loading canonical camera database from {}",
+                user_path.display()
+            );
+            self.load_from_file(&user_path).is_ok()
+        } else {
+            let bundled_path = Self::bundled_path();
+            if bundled_path.exists() {
+                ::log::info!(
+                    "Loading canonical camera database from {}",
+                    bundled_path.display()
+                );
+                self.load_from_file(&bundled_path).is_ok()
+            } else {
+                false
+            }
+        };
+
+        #[cfg(any(
+            target_os = "android",
+            target_os = "ios",
+            feature = "bundle-lens-profiles"
+        ))]
+        let loaded = if loaded {
+            true
+        } else {
+            self.load_from_str(CANONICAL_LENSES_STATIC).is_ok()
+        };
+
+        if loaded {
+            ::log::info!(
+                "Loaded canonical camera database: {} brands, {} mounts, {} setups in {:.3}ms",
+                self.brands.len(),
+                self.mounts.len(),
+                self.setups.len(),
+                _time.elapsed().as_micros() as f64 / 1000.0
+            );
+        } else {
+            ::log::warn!("Canonical camera database not found.");
+        }
+        self.loaded = loaded;
+    }
+
+    pub fn load_from_file(&mut self, path: &std::path::Path) -> std::io::Result<()> {
+        let data = std::fs::read_to_string(path)?;
+        self.load_from_str(&data)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+    }
+
+    pub fn load_from_str(&mut self, data: &str) -> Result<(), serde_json::Error> {
+        let mut parsed: Self = serde_json::from_str(data)?;
+        parsed.loaded = true;
+        *self = parsed;
+        Ok(())
+    }
+
+    pub fn set_from_db(&mut self, db: Self) {
+        *self = db;
+    }
+
+    pub fn find_brand(&self, id_or_name: &str) -> Option<&CanonicalBrand> {
+        let needle = id_or_name.to_ascii_lowercase();
+        self.brands.iter().find(|brand| {
+            brand.id == needle
+                || brand.name.eq_ignore_ascii_case(id_or_name)
+                || brand
+                    .aliases
+                    .iter()
+                    .any(|alias| alias.eq_ignore_ascii_case(id_or_name))
+        })
+    }
+
+    pub fn find_camera(&self, id_or_name: &str) -> Option<&CanonicalCamera> {
+        let needle = id_or_name.to_ascii_lowercase();
+        self.brands
+            .iter()
+            .flat_map(|brand| brand.cameras.iter())
+            .find(|camera| {
+                camera.id == needle
+                    || camera.name.eq_ignore_ascii_case(id_or_name)
+                    || camera
+                        .aliases
+                        .iter()
+                        .any(|alias| alias.eq_ignore_ascii_case(id_or_name))
+            })
+    }
+
+    pub fn find_lens(&self, id_or_name: &str) -> Option<&CanonicalLens> {
+        let needle = id_or_name.to_ascii_lowercase();
+        self.brands
+            .iter()
+            .flat_map(|brand| brand.lenses.iter())
+            .find(|lens| {
+                lens.id == needle
+                    || lens.name.eq_ignore_ascii_case(id_or_name)
+                    || lens
+                        .aliases
+                        .iter()
+                        .any(|alias| alias.eq_ignore_ascii_case(id_or_name))
+            })
+    }
+
+    pub fn setups_for_camera<'a>(
+        &'a self,
+        camera_id: &'a str,
+    ) -> impl Iterator<Item = &'a CanonicalSetup> + 'a {
+        self.setups
+            .iter()
+            .filter(move |setup| setup.camera_id == camera_id)
+    }
+
+    pub fn setups_for_lens<'a>(
+        &'a self,
+        lens_id: &'a str,
+    ) -> impl Iterator<Item = &'a CanonicalSetup> + 'a {
+        self.setups
+            .iter()
+            .filter(move |setup| setup.lens_id == lens_id)
+    }
+
+    pub fn camera_count(&self) -> usize {
+        self.brands.iter().map(|brand| brand.cameras.len()).sum()
+    }
+
+    pub fn lens_count(&self) -> usize {
+        self.brands.iter().map(|brand| brand.lenses.len()).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bundled_canonical_database_loads() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../resources/camera_presets/canonical_lenses.json");
+        let mut db = CanonicalCameraDatabase::default();
+        db.load_from_file(&path).unwrap();
+
+        assert_eq!(db.schema_version, 1);
+        assert!(db.find_brand("Sony").is_some());
+        assert!(db.find_brand("Canon").is_some());
+        assert!(db.find_brand("Nikon").is_some());
+        assert!(db.find_brand("Panasonic").is_some());
+        assert!(db.find_brand("DJI").is_some());
+        assert!(db.camera_count() > 0);
+        assert!(db.lens_count() > 0);
+        assert!(!db.mounts.is_empty());
+        assert!(!db.setups.is_empty());
+
+        for setup in &db.setups {
+            assert!(
+                db.find_camera(&setup.camera_id).is_some(),
+                "missing setup camera {}",
+                setup.camera_id
+            );
+            assert!(
+                db.find_lens(&setup.lens_id).is_some(),
+                "missing setup lens {}",
+                setup.lens_id
+            );
+        }
+    }
+
+    #[test]
+    fn canonical_database_lookup_helpers_find_profiles() {
+        let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../resources/camera_presets/canonical_lenses.json");
+        let mut db = CanonicalCameraDatabase::default();
+        db.load_from_file(&path).unwrap();
+
+        let sony = db.find_brand("Sony").unwrap();
+        let camera = sony
+            .cameras
+            .iter()
+            .find(|camera| !camera.observed_lens_ids.is_empty())
+            .unwrap();
+        assert!(db.find_camera(&camera.id).is_some());
+        assert!(db.setups_for_camera(&camera.id).count() > 0);
+
+        let lens_id = &camera.observed_lens_ids[0];
+        assert!(db.find_lens(lens_id).is_some());
+        assert!(db.setups_for_lens(lens_id).count() > 0);
+    }
+}

--- a/src/core/lens_profile_database.rs
+++ b/src/core/lens_profile_database.rs
@@ -74,6 +74,9 @@ impl LensProfileDatabase {
         let _time = std::time::Instant::now();
 
         let mut load = |data: DataSource, f_name: &str| {
+            if f_name.ends_with(crate::canonical_camera_database::CANONICAL_LENSES_FILENAME) {
+                return;
+            }
             if f_name.ends_with(".gyroflow") {
                 let mut profile = LensProfile::default();
                 profile.name = std::path::Path::new(f_name).file_stem().map(|x| x.to_string_lossy().to_string()).unwrap_or_default();

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -6,6 +6,7 @@ pub mod gyro_source;
 pub mod imu_integration;
 pub mod lens_profile;
 pub mod lens_profile_database;
+pub mod canonical_camera_database;
 #[cfg(feature = "opencv")]
 pub mod calibration;
 pub mod synchronization;
@@ -35,6 +36,7 @@ use gyro_source::{ GyroSource, Quat64, TimeQuat, TimeVec };
 use stabilization_params::{ ReadoutDirection, StabilizationParams };
 use lens_profile::LensProfile;
 use lens_profile_database::LensProfileDatabase;
+use canonical_camera_database::CanonicalCameraDatabase;
 use smoothing::Smoothing;
 use stabilization::{ Stabilization, KernelParamsFlags, ComputeParams };
 use camera_identifier::CameraIdentifier;
@@ -101,6 +103,7 @@ pub struct StabilizationManager {
 
     pub camera_id: Arc<RwLock<Option<CameraIdentifier>>>,
     pub lens_profile_db: Arc<RwLock<LensProfileDatabase>>,
+    pub canonical_camera_db: Arc<RwLock<CanonicalCameraDatabase>>,
 
     pub input_file: Arc<RwLock<InputFile>>,
 
@@ -136,6 +139,7 @@ impl Default for StabilizationManager {
             pose_estimator: Arc::new(synchronization::PoseEstimator::default()),
 
             lens_profile_db: Arc::new(RwLock::new(LensProfileDatabase::default())),
+            canonical_camera_db: Arc::new(RwLock::new(CanonicalCameraDatabase::default())),
 
             input_file: Arc::new(RwLock::new(InputFile::default())),
 
@@ -1169,6 +1173,7 @@ impl StabilizationManager {
             smoothing:  Arc::new(RwLock::new(self.smoothing.read().clone())),
             input_file: Arc::new(RwLock::new(self.input_file.read().clone())),
             lens_profile_db: self.lens_profile_db.clone(),
+            canonical_camera_db: self.canonical_camera_db.clone(),
 
             // NOT cloned:
             // stabilization


### PR DESCRIPTION
/claim #742

## Scope

This PR covers sub-task 1 only: add a canonical camera/lens data store sourced from the current Gyroflow lens profile database and LensFun, and wire it into the existing resource/update path. No UI, Qt, or QML selector behavior is changed here.

## What changed

- Added `resources/camera_presets/canonical_lenses.json`.
  - Current generated contents: version 37, 258 brands, 52 mounts, 2,638 cameras, 7,111 lenses, and 6,517 observed setup rows.
  - Sources recorded in the file:
    - `gyroflow/lens_profiles` commit `bf0976d039d27a64b54517adfa941443865a492e`
    - `lensfun/lensfun` commit `01e64b74507d9b818478f0e02f338fada8dd5680`
- Added `gyroflow_core::canonical_camera_database`.
  - Defines serde-backed Rust structs for sources, mounts, brands, cameras, sensors, lenses, and observed camera/lens setups.
  - Loads from the user lens profile data dir first, then bundled `resources/camera_presets`, with static include support for mobile/bundled builds.
  - Provides initial lookup helpers for brand, camera, lens, and setup rows.
- Added the canonical store to `StabilizationManager` so it loads alongside the existing `LensProfileDatabase`.
- Extended the existing lens profile release/update path to download `canonical_lenses.json` from `gyroflow/lens_profiles` releases next to `profiles.cbor.gz`.
- Updated the legacy lens profile loader to ignore `canonical_lenses.json` if it appears as a loose JSON file or inside the CBOR profile bundle.
- Kept the existing lens profile JSON and `profiles.cbor.gz` formats unchanged.

## Companion release asset change

This app-side PR expects `gyroflow/lens_profiles` releases to publish `canonical_lenses.json` next to `profiles.cbor.gz`. I am opening a companion PR against `gyroflow/lens_profiles` that:

- Adds the same `canonical_lenses.json` at repo root.
- Updates `compress.rs` to skip `canonical_lenses.json` when building `profiles.cbor.gz`.
- Updates `.github/workflows/release.yml` to upload/release both `profiles.cbor.gz` and `canonical_lenses.json`.

## Schema rationale

The canonical schema is an identity/index layer, not a replacement for Gyroflow lens profiles. Distortion coefficients, recording settings, and calibration payloads stay in the existing `LensProfile` JSON format.

The schema records source provenance because later tasks need to distinguish submitted Gyroflow setup profiles from LensFun catalog data. Gyroflow profile rows create observed `setups` with `profile_keys` pointing back to existing profile files. LensFun rows populate catalog cameras, lenses, mounts, crop factors, and aliases without pretending LensFun calibration entries are Gyroflow stabilization profiles.

Mount, sensor, and crop-factor fields are optional so the database can be useful immediately with noisy existing Gyroflow metadata while allowing sub-task 2 to enrich compatibility data without another format break.

## Validation

- `jq` schema/count check for `resources/camera_presets/canonical_lenses.json`
  - Passes: schema version 1, positive version, 2 sources, 52 mounts, 258 brands, 2,638 cameras, 7,111 lenses, 6,517 setup rows.
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`
  - Passes in `gyroflow/gyroflow`.
- `cd src/core && CARGO_HOME=/home/lando/.cargo RUSTUP_HOME=/home/lando/.rustup PATH=/home/lando/.cargo/bin:$PATH cargo test -q canonical_camera_database`
  - Passes: 2 focused canonical database tests.
- `cd src/core && CARGO_HOME=/home/lando/.cargo RUSTUP_HOME=/home/lando/.rustup PATH=/home/lando/.cargo/bin:$PATH cargo test -q`
  - Passes.
- Root `cargo test`
  - Build dependencies installed and Qt6 selected with `QMAKE=qmake6`.
  - Reaches untouched rendering code, then fails because the local/system FFmpeg bindings do not expose D3D12 symbols referenced by existing Gyroflow code:
    - `AV_HWDEVICE_TYPE_D3D12VA`
    - `AV_PIX_FMT_D3D12`
  - This failure is outside the canonical camera/lens database files touched by this PR.

## Follow-up plan for sub-tasks 2-8

1. Enrich the canonical data with reviewed camera compatibility, mount compatibility, sensor size names, and crop factors.
2. Add calibrator UI selection against the canonical camera list, keeping an explicit Other/manual fallback.
3. Replace text search with brand -> model -> lens selection backed by canonical setup rows and observed LensProfile availability.
4. Surface LensFun catalog entries in the selector separately from Gyroflow stabilization profiles.
5. Add profile review state per canonical setup so bad submitted profiles can be hidden without deleting the setup identity.
6. Pre-populate selector values from video metadata by matching metadata strings against canonical aliases and source keys.
7. Reject new lens profile submissions unless the selected camera, lens, and setup distinction are clear enough to generate canonical setup keys.
