### PR TITLE
Render UX: allow optical-only workflows without sync-point warning loop

### DIFF
--- a/src/ui/App.qml
+++ b/src/ui/App.qml
@@ -307,8 +307,14 @@ Rectangle {
                                 ]);
                                 return;
                             }
-                            const usesQuats = ((motionData.item.hasQuaternions && motionData.item.integrationMethod === 0) || motionData.item.hasAccurateTimestamps) && motionData.item.filename == vidInfo.item.filename;
-                            if (!usesQuats && controller.offsets_model.rowCount() == 0 && !allowSync) {
+                            const hasMotionDataForClip = motionData.item.filename == vidInfo.item.filename &&
+                                (motionData.item.hasRawGyro || motionData.item.hasQuaternions || motionData.item.hasAccurateTimestamps);
+                            const usesQuats = ((motionData.item.hasQuaternions && motionData.item.integrationMethod === 0) || motionData.item.hasAccurateTimestamps) &&
+                                motionData.item.filename == vidInfo.item.filename;
+
+                            // Optical-only workflows do not have sync points by definition.
+                            // Keep the warning only when motion data is actually loaded for this clip.
+                            if (hasMotionDataForClip && !usesQuats && controller.offsets_model.rowCount() == 0 && !allowSync) {
                                 messageBox(Modal.Warning, qsTr("There are no sync points present, your result will be incorrect. Are you sure you want to render this file?"), [
                                     { text: qsTr("Yes"), clicked: () => { allowSync = true; renderBtn.render(); }},
                                     { text: qsTr("No"), accent: true },


### PR DESCRIPTION
This improves optical-only stabilization workflow for issue #45.

### Problem
When no motion data is loaded, render flow still warns about missing sync points. For optical-only stabilization this warning is misleading and blocks throughput.

### Change
- Added `hasMotionDataForClip` guard.
- Missing-sync warning is now shown only when motion data exists for the current clip.
- Optical-only jobs can proceed without the redundant warning loop.

/claim #45

Note: demo video will be attached in follow-up comment.

## Demo video
- https://github.com/aimqwest/gyroflow/releases/download/aimqwest-pr-demos-20260512/pr1159-demo-v6.mp4
