### PR TITLE
Lens profile search: normalize LensFun punctuation variants

### DIFF
--- a/src/core/lens_profile_database.rs
+++ b/src/core/lens_profile_database.rs
@@ -278,6 +278,11 @@ impl LensProfileDatabase {
 
     pub fn search(&self, text: &str, favorites: &HashSet<String>, aspect_ratio: i32, aspect_ratio_swapped: i32) -> Vec<(String, String, String, bool, f64, i32, String)> {
         let text = text.to_ascii_lowercase()
+            // Normalize common LensFun naming punctuation.
+            // Example: "18–55mm f/3.5-5.6" -> "18-55mm f 3.5-5.6"
+            .replace('–', "-")
+            .replace('—', "-")
+            .replace('/', " ")
             .replace("bmpcc4k",  "blackmagic pocket cinema camera 4k")
             .replace("bmpcc6k",  "blackmagic pocket cinema camera 6k")
             .replace("bmpcc",    "blackmagic pocket cinema camera")


### PR DESCRIPTION
Small but practical step toward smoother LensFun integration for #150.

### What changed
- Normalized Unicode dashes (`–`, `—`) to ASCII `-` in lens-profile search text.
- Normalized `/` to whitespace in search text (helps `f/2.8`, model separators, and LensFun-style names).

### Why
LensFun and camera metadata often use punctuation variants that users do not type consistently. This reduces false-negative matches when looking up lens profiles tied to LensFun naming conventions.

/claim #150

Note: this is an incremental UX/search improvement and not the full distortion-rescale implementation.

## Demo video
- https://github.com/aimqwest/gyroflow/releases/download/aimqwest-pr-demos-20260512/pr1160-demo-v6.mp4
