### PR TITLE
Fix over-zoom at partial lens correction strengths

### DIFF
--- a/src/core/gpu/opencl_undistort.cl
+++ b/src/core/gpu/opencl_undistort.cl
@@ -485,9 +485,10 @@ float2 undistort_coord(float2 out_pos, __global KernelParams *params, __global c
     ///////////////////////////////////////////////////////////////////
     // Add lens distortion back
     if (params->lens_correction_amount < 1.0f) {
-        float2 factor = (float2)max(1.0f - params->lens_correction_amount, 0.001f); // FIXME: this is close but wrong
         float2 out_c = (float2)(params->output_width / 2.0f, params->output_height / 2.0f);
-        float2 out_f = (params->f / params->fov) / factor;
+        // Use the same calibrated output intrinsics across all lens-correction strengths.
+        // The strength mix happens below on coordinates; scaling focal length here over-zooms mid strengths.
+        float2 out_f = params->f / params->fov;
 
         float2 new_out_pos = out_pos;
 

--- a/src/core/gpu/wgpu_undistort.wgsl
+++ b/src/core/gpu/wgpu_undistort.wgsl
@@ -471,9 +471,10 @@ fn undistort_coord(position: vec2<f32>) -> vec2<f32> {
     ///////////////////////////////////////////////////////////////////
     // Add lens distortion back
     if (params.lens_correction_amount < 1.0) {
-        let factor = max(1.0 - params.lens_correction_amount, 0.001); // FIXME: this is close but wrong
         let out_c = vec2<f32>(f32(params.output_width) / 2.0, f32(params.output_height) / 2.0);
-        let out_f = (params.f / params.fov) / factor;
+        // Use the same calibrated output intrinsics across all lens-correction strengths.
+        // The strength mix happens below on coordinates; scaling focal length here over-zooms mid strengths.
+        let out_f = params.f / params.fov;
 
         var new_out_pos = out_pos;
 

--- a/src/qt_gpu/undistort.frag
+++ b/src/qt_gpu/undistort.frag
@@ -182,9 +182,10 @@ void main() {
     ///////////////////////////////////////////////////////////////////
     // Add lens distortion back
     if (params.lens_correction_amount < 1.0) {
-        float factor = max(1.0 - params.lens_correction_amount, 0.001); // FIXME: this is close but wrong
         vec2 out_c = vec2(params.output_width / 2.0, params.output_height / 2.0);
-        vec2 out_f = (params.f / params.fov) / factor;
+        // Use the same calibrated output intrinsics across all lens-correction strengths.
+        // The strength mix happens below on coordinates; scaling focal length here over-zooms mid strengths.
+        vec2 out_f = params.f / params.fov;
 
         vec2 new_out_pos = texPos;
 


### PR DESCRIPTION
Fixes the partial lens-correction over-zoom described in #384 by keeping output intrinsics consistent when adding distortion back, and only blending coordinates by `lens_correction_amount`.

Changes:
- Remove extra focal-length scaling by `(1 - lens_correction_amount)` in the add-distortion-back path.
- Apply the same correction consistently in all GPU paths:
  - `src/core/gpu/opencl_undistort.cl`
  - `src/core/gpu/wgpu_undistort.wgsl`
  - `src/qt_gpu/undistort.frag`

Why this fixes it:
- Mid strengths (e.g. 50%) were effectively double-scaled: once by focal scaling and again by coordinate blending, causing over-zoom and leaving FOV unused.
- Keeping `out_f` calibrated and blending only coordinates produces monotonic behavior between 0% and 100% lens correction.

/claim #384

I can attach a short demo video in a follow-up comment if maintainers want a specific sample clip/setting matrix.


## Demo video
- https://github.com/aimqwest/gyroflow/releases/download/aimqwest-pr-demos-20260512/pr1161-demo-v6.mp4
