### PR TITLE
Fix partial lens correction zoom scaling

### DIFF
--- a/src/core/gpu/opencl_undistort.cl
+++ b/src/core/gpu/opencl_undistort.cl
@@ -485,9 +485,8 @@ float2 undistort_coord(float2 out_pos, __global KernelParams *params, __global c
     ///////////////////////////////////////////////////////////////////
     // Add lens distortion back
     if (params->lens_correction_amount < 1.0f) {
-        float2 factor = (float2)max(1.0f - params->lens_correction_amount, 0.001f); // FIXME: this is close but wrong
         float2 out_c = (float2)(params->output_width / 2.0f, params->output_height / 2.0f);
-        float2 out_f = (params->f / params->fov) / factor;
+        float2 out_f = params->f / params->fov;
 
         float2 new_out_pos = out_pos;
 

--- a/src/core/gpu/stabilize_spirv/src/stabilize.rs
+++ b/src/core/gpu/stabilize_spirv/src/stabilize.rs
@@ -80,9 +80,8 @@ pub fn undistort(uv: Vec2, params: &KernelParams, matrices: &MatricesType, coeff
     ///////////////////////////////////////////////////////////////////
     // Add lens distortion back
     if params.lens_correction_amount < 1.0 {
-        let factor = (1.0 - params.lens_correction_amount).max(0.001); // FIXME: this is close but wrong
         let out_c = vec2(params.output_width as f32 / 2.0, params.output_height as f32 / 2.0);
-        let out_f = params.f / params.fov / factor;
+        let out_f = params.f / params.fov;
         let mut new_out_pos = out_pos;
 
         if (flags & 2) == 2 { // Has digial lens

--- a/src/core/gpu/wgpu_undistort.wgsl
+++ b/src/core/gpu/wgpu_undistort.wgsl
@@ -471,9 +471,8 @@ fn undistort_coord(position: vec2<f32>) -> vec2<f32> {
     ///////////////////////////////////////////////////////////////////
     // Add lens distortion back
     if (params.lens_correction_amount < 1.0) {
-        let factor = max(1.0 - params.lens_correction_amount, 0.001); // FIXME: this is close but wrong
         let out_c = vec2<f32>(f32(params.output_width) / 2.0, f32(params.output_height) / 2.0);
-        let out_f = (params.f / params.fov) / factor;
+        let out_f = params.f / params.fov;
 
         var new_out_pos = out_pos;
 

--- a/src/core/stabilization/cpu_undistort.rs
+++ b/src/core/stabilization/cpu_undistort.rs
@@ -521,9 +521,8 @@ impl Stabilization {
                 let bg = Vector4::<f32>::new(params.background[0], params.background[1], params.background[2], params.background[3]) * params.max_pixel_value;
                 let bg_t: T = PixelType::from_float(bg);
 
-                let factor = (1.0 - params.lens_correction_amount).max(0.001); // FIXME: this is close but wrong
                 let out_c = Vector2::new(params.output_width as f32 / 2.0, params.output_height as f32 / 2.0);
-                let out_f = Vector2::new(params.f[0] / params.fov / factor, params.f[1] / params.fov / factor);
+                let out_f = Vector2::new(params.f[0] / params.fov, params.f[1] / params.fov);
 
                 // let drawing_enabled = !drawing.is_empty() && (params.flags & 8) == 8;
                 let fill_bg = (params.flags & 4) == 4;

--- a/src/qt_gpu/undistort.frag
+++ b/src/qt_gpu/undistort.frag
@@ -182,9 +182,8 @@ void main() {
     ///////////////////////////////////////////////////////////////////
     // Add lens distortion back
     if (params.lens_correction_amount < 1.0) {
-        float factor = max(1.0 - params.lens_correction_amount, 0.001); // FIXME: this is close but wrong
         vec2 out_c = vec2(params.output_width / 2.0, params.output_height / 2.0);
-        vec2 out_f = (params.f / params.fov) / factor;
+        vec2 out_f = params.f / params.fov;
 
         vec2 new_out_pos = texPos;
 


### PR DESCRIPTION
Closes #384.

## What changed
- Removed the extra `1 / (1 - lens_correction_amount)` focal scaling from the partial lens-correction render path.
- Applied the same correction across CPU, OpenCL, WGPU, Qt fragment shader, and SPIR-V source paths.

## Why
The zoom/FOV solver path uses `params.f / params.fov` when evaluating partially corrected lens points, but the render paths inflated that focal length for partial correction. At values such as 50%, the render path therefore behaved more conservatively than the FOV solver and left usable FOV on the table.

## Validation
- `git diff --check`
- Verified there are no remaining touched render-path occurrences of the old `FIXME` scaling.

I could not run `cargo` locally because this machine does not have `rustc`/`cargo` installed.