### PR TITLE
Add selector-backed lens profile registry and calibrator validation

### DIFF
--- a/resources/camera_registry.json
+++ b/resources/camera_registry.json
@@ -1,0 +1,24481 @@
+{
+  "version": 1,
+  "cameras": [
+    {
+      "brand": "纽曼",
+      "model": "LF0779-4663",
+      "lenses": [
+        "Unknown"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ACTIVEON",
+      "model": "CX",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "Lyfe Titan",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "Magicam s60",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "S50 pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AEE",
+      "model": "S90R",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AIKUCAM",
+      "model": "NANO1",
+      "lenses": [
+        "341A"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "B8",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 4 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 6 Plus",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 7",
+      "lenses": [
+        "G7",
+        "Stock Lens",
+        "standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 7 Le",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Brave 8",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "EK7000",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "EK7000pro",
+      "lenses": [
+        "170º",
+        "Wide Angle"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "Keychain",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "KeyChain_1920x1080",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "snapX",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "V50",
+      "lenses": [
+        "omnivision"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "V50 Elite",
+      "lenses": [
+        "-",
+        "Factory",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "v50 pro",
+      "lenses": [
+        "stock",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "V50 X",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AKASO",
+      "model": "v50x",
+      "lenses": [
+        "Caddx LS108"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Aksogo",
+      "model": "SnapX",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Andoer",
+      "model": "AN7000",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Aolbea",
+      "model": "Body camera",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apeman",
+      "model": "A100",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apeman",
+      "model": "A100 Trawo",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "A77",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apeman",
+      "model": "A80",
+      "lenses": [
+        "None",
+        "Ultra Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "apeman",
+      "model": "A87",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apexcam",
+      "model": "M80 Air",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPad Pro 11-inch (2020)",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 11",
+      "lenses": [
+        "ultra wide 13mm",
+        "wide 26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 11 Pro",
+      "lenses": [
+        "1X",
+        "Zoom 1",
+        "med lensHD 1080"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 11 Pro Max",
+      "lenses": [
+        "Ultra Wide 13mm 0.5x",
+        "Ultra Wide: ƒ/2.4 aperture and 120° FOV",
+        "Wide 26mm 1x",
+        "Wide Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12",
+      "lenses": [
+        "0.5",
+        "1.0",
+        "26mm",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12 Mini",
+      "lenses": [
+        "1x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12 Pro",
+      "lenses": [
+        "1",
+        "1 X",
+        "12",
+        "26mm",
+        "Back Telephoto camera (51mm equiv.)",
+        "Back camera (26mm equiv.)",
+        "Normal"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 12 Pro Max",
+      "lenses": [
+        "0.5X",
+        "0.5x",
+        "1x",
+        "Ultra Wide",
+        "Wide lense"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13",
+      "lenses": [
+        "1x",
+        "26mm",
+        "Wide angle"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 3x",
+      "lenses": [
+        "GyroCam"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 mini",
+      "lenses": [
+        "Main Lens",
+        "ultra wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 Pro",
+      "lenses": [
+        "0.5x",
+        "13mm",
+        "1x",
+        "26 mm",
+        "3 times",
+        "3x",
+        "Iphone 13 pro",
+        "Main",
+        "Main Lens",
+        "Standard",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 Pro Max",
+      "lenses": [
+        "0.5 Wide",
+        "1 X",
+        "1 standard",
+        "26 mm",
+        "26mm",
+        "Main Lens 1x",
+        "X3",
+        "iPhone",
+        "x0.5",
+        "苹果"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13 Pro (v1.1)",
+      "lenses": [
+        "UltraWide",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 13pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14",
+      "lenses": [
+        "24mm",
+        "26mm",
+        "26mm Blackmagic App",
+        "IOS",
+        "前置",
+        "后置26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14 Pro",
+      "lenses": [
+        "1x",
+        "24mm",
+        "3x",
+        "Main 24mm",
+        "Telephoto",
+        "Wide",
+        "Wide + Magnet",
+        "main cam"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14 Pro Max",
+      "lenses": [
+        "1x",
+        "24 mm",
+        "24MM F1.78",
+        "pro max"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14 Pro Mox",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 14pm",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15",
+      "lenses": [
+        "26mm Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 Pro",
+      "lenses": [
+        "13",
+        "24 mm with Freewell Cinemorphic 1.55x",
+        "24mm",
+        "24mm 1.78",
+        "Ultra wide (0.5x)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 Pro 24mm",
+      "lenses": [
+        "Freewell Sherpa Anamorphic 1.33x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 PRO GA",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15 Pro Max",
+      "lenses": [
+        "13mm 60 fps vertical",
+        "24mm",
+        "Apple",
+        "Ultra-Wide",
+        "x1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 15pro",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 26mm",
+      "lenses": [
+        "4k"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 4",
+      "lenses": [
+        "高清60fps"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 6s",
+      "lenses": [
+        "4k25"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 7",
+      "lenses": [
+        "back"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 7 Plus",
+      "lenses": [
+        "28mm F/1.8",
+        "HDR",
+        "wide angle 28 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 8",
+      "lenses": [
+        "Apple Iphone 8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone 8 Plus",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone Pro max",
+      "lenses": [
+        "0.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE",
+      "lenses": [
+        "se lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE 2019",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE (2nd generation)",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE (3rd gen)",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone SE2",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone se3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone X",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone XR",
+      "lenses": [
+        "28mm equivalent",
+        "SIRUI 18mm",
+        "iphone Xr"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone XS",
+      "lenses": [
+        "26mm",
+        "XS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone xs 2x zoom",
+      "lenses": [
+        "2x zoom"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Apple",
+      "model": "iPhone XS Max",
+      "lenses": [
+        "12 MP"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Arducam",
+      "model": "12.3MP 1/2.3 Inch IMX477 HQ Camera Module",
+      "lenses": [
+        "6mm CS Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "35",
+      "lenses": [
+        "Laowa 12mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "Alexa 35",
+      "lenses": [
+        "Ultra Prime 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "Alexa LF",
+      "lenses": [
+        "Xeen 35mm",
+        "Xeen 85mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ARRI",
+      "model": "Alexa Mini",
+      "lenses": [
+        "27mm Cooke S4",
+        "40 mm Cooke S4",
+        "40mm Cooke s4 (02)",
+        "ARRI CarlZeiss Ultra PRIME 24mm t1.9",
+        "CarlZeiss Master PRIME 24mm T1.9",
+        "Laowa 12mm",
+        "Zeiss Master PRIME T2.0"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ASUS",
+      "model": "ROG Phone 7 Ultimate",
+      "lenses": [
+        "Sony IMX766"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ASUS",
+      "model": "Zenfone6 ZS630KL",
+      "lenses": [
+        "Main Cam",
+        "Wide Cam"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Asus",
+      "model": "Zenphone 9",
+      "lenses": [
+        "1x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ausek",
+      "model": "AT-Q40C",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "AXNEN",
+      "model": "A10",
+      "lenses": [
+        "F2.5, f2.68 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "BETAFPV",
+      "model": "HD_X65HD",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "BetaFPV",
+      "model": "Nano HD",
+      "lenses": [
+        "nano hd"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Biwond",
+      "model": "EX3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackberry",
+      "model": "BB2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackberry",
+      "model": "Key2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Cinema Camera 6K",
+      "lenses": [
+        "7artisans 35mm",
+        "Canon Ultrasonic 50mm F/1.4 EF",
+        "Canon Ultrasonic 50mm f/1.4",
+        "Dulens 31mm - EF-L sigma",
+        "Dulens APO 31mm",
+        "Dulens APO 58mm",
+        "IRIX 30T",
+        "LUMIX S 18/F1.8 18mm",
+        "LUMIX S 18mm f1.8",
+        "Laowa 11mm",
+        "Leica Elmarit-R 35mm",
+        "Leica Summilux-R 35-70mm",
+        "Nisi Athena",
+        "Nisi Athena 25",
+        "Otus 28 1.4",
+        "Sigma 24-70mm F2.8 DG DN | Art 019 24mm",
+        "Sigma 28-45mm F1.8 DG DN | Art 024 28mm",
+        "Sigma 28-45mm F1.8 DG DN | Art 024 35mm",
+        "Sigma 28-45mm F1.8 DG DN | Art 024 40mm",
+        "Sigma 28-45mm F1.8 DG DN | Art 024 45mm",
+        "Sigma 28-70mm F2.8 DG DN | Contemporary 021 28mm",
+        "Sigma 28-70mm F2.8 DG DN | Contemporary 021 35mm",
+        "Sigma 28-70mm F2.8 DG DN | Contemporary 021 50mm",
+        "Sigma 28-70mm F2.8 DG DN | Contemporary 021 70mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Cinema Pocket Camera 6K G2",
+      "lenses": [
+        "SIGMA 24mm F1.8 EX DG Macro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Micro Cinema Camera",
+      "lenses": [
+        "Laowa 7.5mm F2.0",
+        "Laowa 7.5mm T 2.1",
+        "Rokinon 12mm",
+        "Rokinon 16mm w Metabones 0.58 Speedbooster"
+      ],
+      "crop_factor": 2.88,
+      "sensor_size": "1-inch",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Micro Studio Camera 4K",
+      "lenses": [
+        "Olympus Zuiko 12-40mm f2.8 PRO"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Micro Studio Camera 4K G2",
+      "lenses": [
+        "17mm",
+        "DJI MFT 15mm",
+        "DJI MFT 15mm F1.7 ASPH 15mm",
+        "LEICA DG SUMMILUX 9/F1.7 9mm",
+        "LUMIX G 14/F2.5 14mm",
+        "Laowa 10mm MFT T2.1 Cine",
+        "Laowa 6mm f/2.0 ZeroD MFT",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm MFT",
+        "Laowa 7.5mm T2.1 Cine",
+        "Laowa 7.5mm f2.0",
+        "Laowa 9mm",
+        "Laowa 9mm f2.8",
+        "Laowa Zero-D Cine 6mm T2.1",
+        "Lumix 14mm f2.5",
+        "OLYMPUS M.14-42mm F3.5-5.6 EZ 14mm",
+        "Olympus M.ZUIKO 9mm F8,0 Body Cap Fisheye",
+        "Olympus M.Zuiko - 15 mm - f/8.0 Body Cap",
+        "Panasonic LUMIX 14mm F2.5 Pancake",
+        "TTArtisan 10mm f/2",
+        "laowa 7.5mm F2.0"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocker Cinema Camera 4K",
+      "lenses": [
+        "Sigma 18-50mm f2.8-4.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera",
+      "lenses": [
+        "Laowa 9 mm, F2,8",
+        "Olympus 12mm f2.0",
+        "SLR Magic 8mm",
+        "Samyang 8mm 3.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 2013",
+      "lenses": [
+        "Lumix 12-32mm G Vario"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera (2013 first model)",
+      "lenses": [
+        "Lumix 12-35mm f2.8 I (H-HS12035)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 4K",
+      "lenses": [
+        ".58x Metabones  EF-S18-35/1.8 15mm",
+        ".64x EF24-105mm f/4L IS II USM 15mm",
+        ".64x EF24-105mm f/4L IS II USM 22mm",
+        ".64x Sigma DC 17-70/2.8-4 OS HSM 19mm",
+        ".64x Sigma DC 8-16/4.5-5.6 EX HS 5mm",
+        ".64x Tamron 24-70/2.8 SP VC USD 15mm",
+        ".64x Tamron 24-70/2.8 SP VC USD 45mm",
+        ".718-35mm F1.8 DC HSM | Art 013 13mm",
+        ".7EF24-70mm f/2.8L II USM @ 17mm",
+        ".7x Sigma DC 10-20/4-5.6 EX HSM 7mm @10mm",
+        ".7x Sigma DC 10-20/4.2-5.6 EX HS 7mm",
+        ".7x Sigma DC 17-50/2.8 EX OS HSM 12mm",
+        ".7x Sigma DC 17-70/2.8-4 OS HSM 12mm",
+        ".7xEF36mm f/1.0 36mm",
+        "0.71xEF50mm f/1.0 36mm",
+        "12mm",
+        "12mm 2.8 olympus",
+        "15mm",
+        "15mm 1.7 dji",
+        "15mm Lumix",
+        "15mm Panasonic",
+        "15mm dji m4/3",
+        "1740f4 12mm",
+        "17mm Laowa Cine",
+        "20mm",
+        "20mm AstrHori f8.0",
+        "24mm",
+        "35mm Meike MFT",
+        "50mm",
+        "55mm",
+        "7.5",
+        "7.5mm",
+        "7.5mm fish eye",
+        "7Artisans 25mm F1.8",
+        "7Artisans 7.5mm",
+        "7Artisans 7.5mm F2.8",
+        "7artisans 12mm F2.8",
+        "7artisans 35mm",
+        "8mm",
+        "8mm drl",
+        "AF NIKKOR 24mm F2.8",
+        "Brightin Star 7.5",
+        "Canon 10-18mm",
+        "Canon 24-105mm STM",
+        "Canon 50mm 1.8",
+        "Canon 50mm F1.8",
+        "Canon EF24mm f/2.8 IS USM 16mm",
+        "Canon FD 24mm",
+        "Canon FD 24mm f1.4 w/ Zhongyi Lens Turbo II",
+        "Canon FD 24mm f2.8 SSC",
+        "Canon FD 50mm f1.4",
+        "Canon Zoom Lens 24-105mm EF",
+        "Contax 50mm F1.4 x Metabones .64 Cine XL",
+        "Contax Distagon 2,8/28",
+        "Contax Vario-Sonnar 4/80-200",
+        "DJI 15mm",
+        "DJI 15mm 1.7",
+        "DJI 15mm F1.7",
+        "DJI 15mm f/1.7 MFT ASPH",
+        "EF Sigma 18-35mm f/1.8 om 20mm F4.8",
+        "EF100-400mm f/4.5-5.6L IS II USM 70mm",
+        "Ektar2 25mm",
+        "H-X015",
+        "Helios 44-2 58mm f2",
+        "Helios 44-2 58mm,f2",
+        "IAOWA 7.5mm",
+        "Irex 15mm with.64x Speedbooster",
+        "LAOWA",
+        "LAOWA 6mm",
+        "LAOWA 6mm cine",
+        "LAOWA 7.5",
+        "LAOWA 7.5mm",
+        "LAOWA 7.5mm 2.0",
+        "LAOWA 9mm",
+        "LAOWA C&D-Dreamer MFT 10mm F2.0 10mm",
+        "LAOWA C&D-Dreamer MFT6.0mm F2.0 6mm",
+        "LEICA DG 12-60/F2.8-4.0 12mm",
+        "LEICA DG SUMMILUX 15/F1.7  15mm",
+        "LUMIX G 14/F2.5  14mm",
+        "LUMIX G 20/F1.7 20mm",
+        "LUMIX G 20/F1.7 II 19mm",
+        "LUMIX G 25/F1.7 25mm",
+        "LUMIX G 25/F1.7 26mm",
+        "LUMIX G 42.5/F1.7  44mm",
+        "LUMIX G VARIO 12-35/F2.8  12mm",
+        "LUMIX G VARIO 12-35/F2.8  19mm",
+        "LUMIX G VARIO 12-35/F2.8  26mm",
+        "LUMIX G VARIO 12-35/F2.8  34mm",
+        "LUMIX G VARIO 12-35/F2.8II 12mm",
+        "LUMIX G VARIO 12-35/F2.8II 18mm",
+        "LUMIX G VARIO 12-35/F2.8II 25mm",
+        "LUMIX G VARIO 12-35/F2.8II 34mm",
+        "LUMIX G VARIO 12-60/F3.5-5.6 12mm",
+        "LUMIX G VARIO 12-60/F3.5-5.6 18mm",
+        "LUMIX G VARIO 14-140/F3.5-5.6",
+        "LUMIX G VARIO 14-140/F3.5-5.6  15mm",
+        "LUMIX G VARIO 14-45/F3.5-5.6 12mm",
+        "LUMIX G VARIO 45-150/F4.0-5.6  45mm",
+        "Laowa 10mm",
+        "Laowa 10mm Zero-D",
+        "Laowa 10mm f8",
+        "Laowa 17mm T1.9",
+        "Laowa 17mm f1.8",
+        "Laowa 6mm 2.1",
+        "Laowa 6mm T2.1",
+        "Laowa 6mm f/2 Zero-D MFT Lens for MFT",
+        "Laowa 7.5 mm",
+        "Laowa 7.5 mm f2.0",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm F2.0",
+        "Laowa 7.5mm F4",
+        "Laowa 7.5mm MFT F2",
+        "Laowa 7.5mm T2.1",
+        "Laowa 7.5mm f/2",
+        "Laowa 7.5mm f/2.1T",
+        "Laowa 7.5mm f2 mtf",
+        "Laowa 7.5mm f2.0",
+        "Laowa 7mm 2.1T",
+        "Laowa 9mm",
+        "Laowa 9mm 2.8",
+        "Laowa 9mm F2.8",
+        "Laowa 9mm MFT",
+        "Laowa 9mm ZeroD",
+        "Laowa 9mm f 2.8",
+        "Laowa 9mm f/2.8",
+        "Laowa 9mm f2.8",
+        "Laowa C&D-Dreamer MFT6.0mm F2.0 6mm",
+        "Laowa Cine 7.5mm T2.1",
+        "Laowa FF14mm",
+        "Laowa FF14mm F4",
+        "Laowa MFT 7.5mm F2.0 7mm",
+        "Laowa Nanomorph 20mm",
+        "Laowa Nanomorph 27 mm",
+        "Laowa Nanomorph 50mm",
+        "Leica DG Summilux 9mm F1.7",
+        "Lowa 12mm",
+        "Lumix",
+        "Lumix 12-35",
+        "Lumix 12-35 2.8",
+        "Lumix 12-35 f2.2",
+        "Lumix 20mm",
+        "Lumix 20mm 1.33 Anamorphic",
+        "MEIKE F1.8 25MM",
+        "MEIKE MICRO CINE",
+        "MFT Laowa 10mm F2.0",
+        "Meike 12mm",
+        "Meike 12mm T2.2",
+        "Meike 16mm M43 Cine",
+        "Meike 25mm",
+        "Meike 25mm f2.2",
+        "Meike 35mm f/1.8",
+        "Meike 50mm",
+        "Meike 8mm T2.9",
+        "Meike Cinema Lens 12mm T2.2",
+        "Meike Cinema Lens 35mm T2.2",
+        "Meike Cinema lens 16mm T2.2",
+        "Meke f1.4 35mm",
+        "Mitakon Speedmaster Cinema Lens 17mm T1.0",
+        "Mitakon Speedmaster Cinema Lens 35mm T1.0",
+        "Mitakon T1 50mm",
+        "Navitar 6mm",
+        "OLYMPUS M.12-40mm F2.8 12mm",
+        "OLYMPUS M.12-40mm F2.8 40mm",
+        "OLYMPUS M.12-50mm F3.5-6.3 12mm",
+        "OLYMPUS M.12-50mm F3.5-6.3 50mm",
+        "OLYMPUS M.12mm F2.0 12mm",
+        "OLYMPUS M.17mm F1.8 17mm",
+        "OLYMPUS M.45mm F1.8 45mm",
+        "Olympus 12-40 f2,8",
+        "Olympus 12-40 mm f/2.8",
+        "Olympus 12mm 2.0",
+        "Olympus 12mm F2.0",
+        "Olympus 17mm f1.8",
+        "Olympus 45mm",
+        "Olympus 45mm 1.8",
+        "Olympus 9mm f8 Fisheye Body Cap",
+        "Olympus M. Zuiko Digital ED 12-40mm f/2.8 PRO",
+        "Pananonic 25mm (x2 crop factor)",
+        "Panasonic",
+        "Panasonic 12-25mm",
+        "Panasonic 12-35 II",
+        "Panasonic 15mm",
+        "Panasonic 7/14mm f4 set on 9mm",
+        "Panasonic H-ES12060E 12-60mm/F2.8-4.0",
+        "Panasonic H-X015",
+        "Panasonic Leica 10-25",
+        "Panasonic Lumix 7-14mm",
+        "Panasonic Lumix G X 12-35 f2.8 @12mm",
+        "Panasonic Lumix G X Vario PZ 14-42mm f/3.5-5.6 ASPH. POWER O.I.S.",
+        "Panasonic Lumix Vario G X III 12-35mm f2.8",
+        "Pentax 31mm limited",
+        "Porst 35mm f/1.8",
+        "Rokinon 12mm T2.2",
+        "Rokinon Cine Ds 35mm t/1.5",
+        "SAMYANG 25mm T1.5 UMCII",
+        "SAMYANG 7.5MM T3.5",
+        "SIGMA 16mm F1.4 DC DN | C 017 16mm",
+        "SIRUI ANAMORPHIC 24 mm",
+        "SLR MAGIC 8mm",
+        "SLR Magic 25mm T0.95 Hyperprime Cine III",
+        "SLR Magic 8mm f/4.0 Ultra Wide Angle MFT",
+        "SLR Magic 8mm f4.0",
+        "SLR Magic MicroPrime CINE 50mm T1.4",
+        "SLRMAGIC 17MM T1.6",
+        "SLRMAGIC 25MM T0.95",
+        "SLRmagic 8mm",
+        "SP AF 17-50/2.8 XR Di II LD Asp. IF A16",
+        "SRL Magic 8mm F4",
+        "Samyang 12mm",
+        "Samyang 12mm F2",
+        "Samyang 12mm T2.2",
+        "Samyang 12mm f2",
+        "Samyang 16mm",
+        "Samyang 24mm",
+        "Samyang 35mm",
+        "Samyang 85 EF Metabones 0.71",
+        "Samyang 85mm",
+        "Sigma 14mm f/1.8",
+        "Sigma 14mm f1.8 DG HSM Art",
+        "Sigma 16mm",
+        "Sigma 18-31mm",
+        "Sigma 18-35",
+        "Sigma 18-35 VILTROX @ 35mm",
+        "Sigma 18-35mm",
+        "Sigma 18-35mm 1.8 (without speedbooster)",
+        "Sigma 18-50mm f2.8-4.5",
+        "Sigma 18mm",
+        "Sigma 24-105 f/4 with Viltrox 0.71x Speedbooster",
+        "Sigma 30mm 1.4",
+        "Sigma DC 14-200mm f/3.5-6.3 Viltrox EF-M2 - 14mm",
+        "Sigma DC 14-200mm f/3.5-6.3 Viltrox EF-M2 - 80mm",
+        "Sigma DC EF17-50mm f/2.8 17mm",
+        "Sigma EX DC HSM 10-20 f/3.5",
+        "Sirui 35mm",
+        "Sirui 35mm f/1.8 Anamorphic 1.33x",
+        "Sirui Anamorphic 24mm",
+        "Sirui Anamorphic 50mm",
+        "Sirui Anamorphic 75mm",
+        "Sirui Nightwalker 24mm/1.2",
+        "Sirui Nightwalker 35mm/1.2",
+        "Sirui Nightwalker 55mm/1.2",
+        "Super Takumar 50mm,f1.4 50mm",
+        "TAMRON A16 17-50mm",
+        "TAMRON EF 17-50 + Viltrox 0.71X",
+        "TTArtisan 25mm f2",
+        "TTArtisan APS-C 10mm f2.0",
+        "TTartisan 25mm 1.33 Anamorphic",
+        "Takumar 50mm f1.4",
+        "Tamron SP 17 - 50 mm F/2.8 (Nikon F)",
+        "Tokina 11-20mm f2.8 + Viltrox EF-M2 II",
+        "Tokina 11-20mm f2.8 @14mm + Viltrox EF-M2 II 0.71x",
+        "Venus Optics Laowa 7.5mm f/2 MFT",
+        "VenusOptics Laowa 12mm F/2.8",
+        "Vespid Prime 40mm",
+        "Vivitar 28 f2.5 Viltrox .71",
+        "WESLEY 24MM F1.4",
+        "canon ef 18-55",
+        "laowa",
+        "laowa 7.5",
+        "laowa 9mm f2.8",
+        "laowa6mmt2.1",
+        "laowa7.5",
+        "lowa 7.5mm",
+        "lumix7-14",
+        "olympus 12mm",
+        "samyang 14mm 0.64x",
+        "samyang 7.5mm f3.5",
+        "samyang7.5",
+        "sigma 17-50 + VILTROX",
+        "sirui 24mm mft",
+        "zeiss Classic makro 50mm f2",
+        "七工匠35MM",
+        "七工匠35mm",
+        "美科16MM",
+        "美科16mm",
+        "美科50mm"
+      ],
+      "crop_factor": 0.75,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 4K V2",
+      "lenses": [
+        "Laowa 7.5 M43"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 6K",
+      "lenses": [
+        "12 24mm",
+        "18mm S35 Meike",
+        "35mm",
+        "36mm",
+        "9mm T2.9 Sony E",
+        "BMPCC 4K DZOFILM  35mm",
+        "Canon 10-18",
+        "Canon 10-18 5.6",
+        "Canon 10-18mm",
+        "Canon 10-18mm 4.5-5.6",
+        "Canon 10-18mm 4.6-5.6 IS STM",
+        "Canon 10-18mm F4.5-5.6 IS",
+        "Canon 16-35 2.8f II",
+        "Canon 16-35mm 2.8 LUSM",
+        "Canon 16-35mm L Series",
+        "Canon 16-35mm f.4 L USM",
+        "Canon 16-35mm f4 L",
+        "Canon 18mm",
+        "Canon 24-70 f2.8",
+        "Canon 50mm",
+        "Canon EF 16-35mm f/2.8L 16mm",
+        "Canon EF 24-105",
+        "Canon EF 24-105 IS II",
+        "Canon EF 24-105mm f/4L IS II USM 24mm",
+        "Canon EF 24-70mm f/2.8L II USM 24mm",
+        "Canon EF 50mm f/1.8 STM 50mm",
+        "Canon EF 85mm f/1.8 USM 85mm",
+        "Canon EF L 16-35mm f2.8 II USM",
+        "Canon EF-S 10-18mm",
+        "Canon EF-S 10-18mm f/4.5-5.6 IS STM 10mm",
+        "Canon EF-S 10-18mm f/4.5-5.6 IS STM 11mm",
+        "Canon EF-S 17-55mm f/2.8 IS USM 17mm",
+        "Canon EF-S 24mm f/2.8 STM 24mm",
+        "DZOFILE 21mm",
+        "DZOFILM 21mm T2.1",
+        "DZOFILM 25mm",
+        "DZOFILM 35mm T2.1",
+        "DZOFILM 75mm T2.1",
+        "DZOLIFM 4K 36mm",
+        "Dulens",
+        "EFS 10-18mm",
+        "FZOLIMF 75mm T2.1",
+        "Hoya_@_35mm",
+        "LAOWA 9mm",
+        "LAOWA 9mm CINE RF",
+        "LAOWA 9mm Cine RF",
+        "LAOWA 9mm MFT on E",
+        "LAOWA 9mm T2.9 RF",
+        "LAOWA FF 14mm F4.0 C&D-Dreamer 14mm",
+        "Laowa 10mm Cookie Sony E Mount",
+        "Laowa 10mm f/4 Cookie",
+        "Laowa 12 MM",
+        "Laowa 12mm",
+        "Laowa 12mm 2.8",
+        "Laowa 14MM",
+        "Laowa 14mm RF",
+        "Laowa 27mm Anamorphic",
+        "Laowa 7.5mm F/2.9 CINE",
+        "Laowa 9mm",
+        "Laowa 9mm 2.8",
+        "Laowa 9mm E Mount",
+        "Laowa 9mm RF",
+        "Laowa 9mm Zero D E Mount",
+        "Laowa 9mm f/2.8 Zero-D",
+        "Laowa 9mm f2.8",
+        "Laowa Cine 7.5mm F/2.9",
+        "Laowa FF 11mm",
+        "Laowa FFii 14mm F4.0 C&D-Dreamer",
+        "Laowa Nanomorph 35mm 2,4T Sony E",
+        "Laowa f4.0 10mm",
+        "Meike s35 35mm",
+        "Nikon_Nikkor_16mm",
+        "Nikon_Nikkor_20mm",
+        "Nikon_Nikkor_24mm",
+        "Nikon_Nikkor_28mm",
+        "Nikon_Nikkor_35mm",
+        "Nikon_Nikkor_45mm",
+        "Nikon_Nikkor_55mm",
+        "Rokinon",
+        "Rokinon 20mm T1.9",
+        "SAMYANG 14mm F2.8 fullsize",
+        "SIGMA 17-50 F2.8 17mm",
+        "SIGMA17-50 F2.8 17mm",
+        "Samyang",
+        "Samyang 10mm T3.1",
+        "Samyang 12mm",
+        "Samyang 12mm F2.0",
+        "Samyang Xeen ef 16mm",
+        "Samyang/Rokinon Cine 35mm t1.4",
+        "Sigma 10-20mm f/3.5 EX DC HSM 10mm",
+        "Sigma 17-35 2.8-4",
+        "Sigma 17-70mm f/2.8-4 DC Macro OS HSM @ 34mm",
+        "Sigma 18-35 F1.8",
+        "Sigma 18-35mm",
+        "Sigma 18-35mm F1.8",
+        "Sigma 18-35mm f/1.8 DC 18mm",
+        "Sigma 18-35mm f/1.8 DC HSM 18mm",
+        "Sigma 18-35mm f/1.8 DC HSM 35mm",
+        "Sigma 24/70 f2.8",
+        "Sigma 50-100",
+        "Sigma 50mm f/1.4 EX DG HSM 50mm",
+        "Sigma 8mm f/3.5 EX DG Circular Fisheye 8mm",
+        "Sigma Art 18-35mm 1:1.8",
+        "TTartisan 17mm f/1.4 Sony E",
+        "Tamron 10-24mm f/3.5-4.5 Di II VC HLD 12mm",
+        "Tamron 15-35mm",
+        "Tokina 11-16",
+        "Tokina 11-16 F2.8",
+        "Tokina 11-16 f2.0",
+        "Tokina 11-20 F2.8",
+        "Tokina 12-28mm F4",
+        "Tokina 28-70 2.8-4.3",
+        "Tokina AT-X 12-28mm f/4 PRO DX 12mm",
+        "Tokina SD 11-16mm f2.8 (IF) DX",
+        "Unknown 16mm",
+        "Venus Laowa 100mm f/2.8 2X Ultra Macro APO 100mm",
+        "Voigtlander 15mm f/4.5 Super-Wide Heliar (V1)",
+        "Voigtlander 21mm f/3.5",
+        "Wallimex 10mm EF",
+        "cp2 35mm",
+        "laowa 11,,",
+        "laowa 12mm",
+        "samyang 10mm  t3.1",
+        "samyang 14mm",
+        "sigma 10mm f.4",
+        "sigma 18 35 1 8"
+      ],
+      "crop_factor": 1.55,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 6K G2",
+      "lenses": [
+        "Canon EF-S 18-135mm f/3.5-5.6 IS 18mm",
+        "Carl Zeiss Planar 50mm f/1.4",
+        "Samyang 12mm",
+        "Samyang 16mm f/2.0 ED AS UMC CS",
+        "Sigma 18-35mm",
+        "Sigma 18-35mm f/1.8 DC 18mm",
+        "Sigma 18-35mm f/1.8 DC HSM Art",
+        "Sigma art 11mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera 6K Pro",
+      "lenses": [
+        "10mm Rokinon",
+        "14 mm",
+        "20-35",
+        "24mm T1.5 FF | 017 24mm",
+        "35mm",
+        "Canon 20-35",
+        "Canon 24-105 mm",
+        "Canon 24-105mm",
+        "Canon EF 11-24mm f/4L USM 11mm",
+        "Canon EF 16-35mm f/4L IS USM 16mm",
+        "Canon EF 24-105mm f/4L IS II USM 35mm",
+        "Canon EF 24-70mm f/2.8L II USM 24mm",
+        "Canon EF 24-70mm f2.8",
+        "Canon EF 24mm f/2.8 IS USM 24mm",
+        "Canon EF 40mm f/2.8 STM 40mm",
+        "Canon EF-S 10-18mm f/4.5-5.6 IS STM 10mm",
+        "Canon EF-S 10-18mm f/4.5-5.6 IS STM 18mm",
+        "Carl Zeiss Flektogon 20mm",
+        "Carl Zeiss Flektogon 35mm",
+        "Carl Zeiss Pancolar 50mm",
+        "Contax Zeiss 15mm f3.5",
+        "Contax Zeiss 35mm f1.4",
+        "Contax Zeiss 50mm f1.4",
+        "Contax Zeiss 85mm f1.4",
+        "DZO Vespid 21mm",
+        "Dzofilm Pictor Zoom 14-30 T2.8",
+        "Great Joy 35mm",
+        "Great Joy 85mm 1.8X Anamorphic",
+        "Irix Cine 11mm",
+        "Laowa 12mm Zero D",
+        "Olympus 24mm f2.8 OM H.Zuiko Auto-W",
+        "Pentax 50mm f1.2",
+        "Rokinon 10mm T3.1",
+        "Rokinon 10mm T3.1 Cine DS",
+        "Rokinon 24mm",
+        "Rokinon 8mm T/3.8 8mm",
+        "Rokinon Cine DS 16mm",
+        "Rokinon cine ds 14mm",
+        "Rokinon cine ds 24mm",
+        "Rokinon cine ds 35mm",
+        "Rokinon cine ds 50mm",
+        "Samyang 14mm",
+        "Samyang 35mm f/1.4",
+        "Sigma 17-50mm f/2.8 EX DC OS HSM 17mm",
+        "Sigma 17-50mm f/2.8 OS HSM 17mm",
+        "Sigma 18-35",
+        "Sigma 18-35mm f/1.8 DC 19mm",
+        "Sigma 18-35mm f/1.8 DC HSM @ 18mm",
+        "Sigma 18-35mm f/1.8 DC HSM @ 23mm",
+        "Sigma 18-35mm f/1.8 DC HSM @ 35mm",
+        "Sigma 24-70mm f/2.8 DG OS HSM 24mm",
+        "Sigma Art 18-35 @20mm",
+        "Sigma Art 18-35@18mm",
+        "Sigma Art 18-35@35mm",
+        "Sigma Art 18-35mm @18mm",
+        "Sigma or Tamron 24-70mm f/2.8 24mm",
+        "Tamron 10mm",
+        "Tokina 11",
+        "Zeiss CP3 15mm",
+        "Zeiss distagon ZE 25mm",
+        "contax 28mm",
+        "dzo vespid 40mm 40mm",
+        "sigma 18mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera C4K",
+      "lenses": [
+        "Nokton 10.5 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera HD",
+      "lenses": [
+        "Panasonic LUMIX 14mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera OG",
+      "lenses": [
+        "Olympus Fisheye Body Cap Lens  9-9mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera Original",
+      "lenses": [
+        "Tamron 35mm F/1.8 VC",
+        "Tamron SP 35mm F/1.8",
+        "Voigtlander 17.5mm F0.05",
+        "sigma 18-35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket Cinema Camera SHIMA",
+      "lenses": [
+        "18-35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Pocket OG",
+      "lenses": [
+        "Arriflex Zeiss S16 9.5",
+        "Laowa 7.5mm F2.0"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Ursa Mini 12k",
+      "lenses": [
+        "DZO 20-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "Ursa Mini 4.6K PL",
+      "lenses": [
+        "18-35 T2 PL"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "URSA Mini Pro 12K",
+      "lenses": [
+        "DZO 20-55",
+        "Rokinon xeen 24mm 1.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackmagic",
+      "model": "URSA Mini Pro 4.6K",
+      "lenses": [
+        "24-105mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackshark",
+      "model": "4",
+      "lenses": [
+        "26mm",
+        "26mm front wide",
+        "26mm main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blackvue",
+      "model": "DR900x Plus",
+      "lenses": [
+        "Blackvue"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Blaupunkt",
+      "model": "bp 6410",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Ant",
+      "lenses": [
+        "16:9"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Avatar HD",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "AVATAR-HD PRO",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Avatar Moonlight",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Baby Turtle",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "BabyTurtle",
+      "lenses": [
+        "1.8mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "CADDX Nebula Pro Nano",
+      "lenses": [
+        "F/2.0"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "DJI Camera",
+      "lenses": [
+        "Standard Vista Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Loris",
+      "lenses": [
+        "1.8mm",
+        "4K"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Loris 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Lorris",
+      "lenses": [
+        "Nano 4K"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nano Walksnail",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Nano",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Pro Micro",
+      "lenses": [
+        "2.1mm f/2.1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Nebula Pro Nano",
+      "lenses": [
+        "2.1mm f/2.1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "nebula pro vista kit",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Orca",
+      "lenses": [
+        "M12 G7",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Orca 4K",
+      "lenses": [
+        "M12 7G",
+        "Orca 4k"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Orca 4K 25fps LDC",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Peanut",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Polar",
+      "lenses": [
+        "starlight"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Polar Nano",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Polar Starlight",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Ratel",
+      "lenses": [
+        "2.1mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Ratel V2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Tarsier",
+      "lenses": [
+        "v2 lens",
+        "双摄"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Tarsier 4K",
+      "lenses": [
+        "F/2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Tarsier v2",
+      "lenses": [
+        "TARSIER",
+        "V2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "ThumbPro",
+      "lenses": [
+        "4KSW"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Turtle",
+      "lenses": [
+        "Caddx LS106"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Turtle v1",
+      "lenses": [
+        "glass 3rd party"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "turtle_v2",
+      "lenses": [
+        "2.1",
+        "2.1mm",
+        "2.1mm Special Glass Lens",
+        "CaddxRatel 2.1mm",
+        "GoPro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Vista",
+      "lenses": [
+        "DJI camera",
+        "nebula pro nano"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Caddx",
+      "model": "Walnut",
+      "lenses": [
+        "Caddx/Caddx_Walnut_LDC_4k60_4k_16by9_3840x2160-59.94fps wide",
+        "Caddx/Caddx_Walnut_NO-LDC_1080P120_1080p_16by9_1920x1080-120fps wide",
+        "Caddx/Caddx_Walnut_NO-LDC_1080P60_1080p_16by9_1920x1080-59.94fps wide",
+        "Caddx/Caddx_Walnut_NO-LDC_4k60_4k_16by9_3840x2160-59.94fps wide",
+        "LDC Wide",
+        "NA",
+        "NO-LDC",
+        "NO-LDC Wide",
+        "Wide",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "caddx",
+      "model": "walnut cam",
+      "lenses": [
+        "Caddx/Caddx_Walnut_LDC_1080P120_1080p_16by9_1920x1080-120fps wide",
+        "Caddx/Caddx_Walnut_NO-LDC_2.7k30_2.7k_4by3_2720x2040-29.97fps wide",
+        "Caddx/Caddx_Walnut_NO-LDC_4k30_12M_4k_4by3_4000x3000-29.97fps wide",
+        "Caddx/Caddx_Walnut_NO-LDC_4k60_4k_16by9_3840x2160-59.94fps wide",
+        "Caddx/Walksnail_Avatar_V2_Camera_1080p_16by9_60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "CamPark",
+      "model": "X30",
+      "lenses": [
+        "150"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "CamPark",
+      "model": "X40",
+      "lenses": [
+        "170° Wide Fish-eye",
+        "170°HD Wide-angle fish-eye"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "100D Magic Lantern",
+      "lenses": [
+        "Samyang 24mm F1.4 ED AS IF UMC"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1100D",
+      "lenses": [
+        "Canon EF 18-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1300D",
+      "lenses": [
+        "EF 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1DX",
+      "lenses": [
+        "24-35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "1DX Mark II",
+      "lenses": [
+        "16-35 F4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200 d2",
+      "lenses": [
+        "EF-S 18-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200D",
+      "lenses": [
+        "EF-S 24mm 2.8 STM"
+      ],
+      "crop_factor": 1.6,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200d Mark II",
+      "lenses": [
+        "EFS 17-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "200D / SL2",
+      "lenses": [
+        "Sigma EX DC 18-50 f2.8"
+      ],
+      "crop_factor": 1.6,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "250D",
+      "lenses": [
+        "Sigma 18- 35 1:1,8 DC",
+        "ef-s18-15 f/3.5-5.6 IS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "4000D",
+      "lenses": [
+        "EF-S 18-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "550D",
+      "lenses": [
+        "50mm",
+        "Lens Kit 18-55MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D mark 2",
+      "lenses": [
+        "50-2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D Mark 4",
+      "lenses": [
+        "canon 16-35mm",
+        "ef16-35f2.8III"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D Mark II",
+      "lenses": [
+        "24mm",
+        "50",
+        "70-200mm usm F4",
+        "Sigma 20mm",
+        "Takumar 55 f/1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D Mark iii",
+      "lenses": [
+        "24-105",
+        "50 mm f1.8 STM",
+        "50mm f1.8 STM",
+        "Canon EF 24-70 f2.8",
+        "EF24-70 2.8",
+        "Sigma 20/1.8",
+        "canon ef 70-200 L USM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D Mark IV",
+      "lenses": [
+        "11-24",
+        "24-105",
+        "24-105 f4",
+        "CANON EF 50 MM 1.4",
+        "CANON EF 50MM 1.4",
+        "Canon 24-105mm f4",
+        "EF 50mm 1.8 STM",
+        "EF24-70 f2.8",
+        "EF24-70f2.8 II",
+        "Sigma 50-100mm f1.8",
+        "ef 24-70 f4.0"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5D4",
+      "lenses": [
+        "24-70",
+        "EF 24-70 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "5R",
+      "lenses": [
+        "24-70mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "600D",
+      "lenses": [
+        "18-55mm",
+        "18mm",
+        "50 mm 1.8",
+        "Canon kit lenses2",
+        "Tamron 17-50 XR DiII SP",
+        "canon lens ef 50mm 1:1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "60D",
+      "lenses": [
+        "50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "650D",
+      "lenses": [
+        "Canon 50mm STM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "6D",
+      "lenses": [
+        "14-70",
+        "16-35 f/4 L",
+        "28mm",
+        "50MM 1.8",
+        "50mm",
+        "50mm 1.8",
+        "Canon 50/1.8",
+        "canon 24-105",
+        "ef24-105"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "6D Mark 2",
+      "lenses": [
+        "24-105"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "6D Mark II",
+      "lenses": [
+        "24-70",
+        "90mm Tamron 2.8f",
+        "Canon 16-35 f 2.8L",
+        "Canon 50 mm 1/4",
+        "EF 50mm",
+        "canon 50 mm 1.4",
+        "canon 50mm",
+        "canon zoom lens ef 24-70 1:2.8 l ii usm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "700D",
+      "lenses": [
+        "17-50mm F2.8",
+        "EFS-18-135",
+        "efs 55-250mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "700D / T5i",
+      "lenses": [
+        "50mm 1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "700D T5i X7i",
+      "lenses": [
+        "85mm EF",
+        "EF-S 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "70d",
+      "lenses": [
+        "18-200",
+        "50MM.8",
+        "50mm",
+        "50mm1.8",
+        "Canon  EF 24-105",
+        "Canon EF 35 1:2 IS",
+        "佳能18-200"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "750D",
+      "lenses": [
+        "18-135",
+        "18-55mm IS-STM",
+        "conon zoom 55-250"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "77d",
+      "lenses": [
+        "50mm 1.8f"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "7D",
+      "lenses": [
+        "16-35F4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "800D",
+      "lenses": [
+        "50.F1.8",
+        "50/1.8",
+        "50mm",
+        "EF35-135 F4-5.6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "80D",
+      "lenses": [
+        "24mm f2.8",
+        "Canon EF-S 18-135mm f/3.5-5.6 IS NANO USM",
+        "EFS 18-135 mm f/3.5-5.56 IS USM",
+        "Yongnuo EF YN 50mm F/1.8",
+        "canon 18-55",
+        "efs 18-135 mm",
+        "sigma 18-35",
+        "sigma 30mm f1.4",
+        "sigma dc 17-50 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "90D",
+      "lenses": [
+        "10-22 mm",
+        "18-135 ISUSM",
+        "18-135mm_IS_USM",
+        "18-55",
+        "50mm f1.8",
+        "CANON 24 2.8",
+        "CANON ULTASONIC EF 50mm 1:1.4",
+        "Canon18-135",
+        "EF-S 135MM",
+        "canon 18-135"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C100",
+      "lenses": [
+        "18-135"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C100 MKII",
+      "lenses": [
+        "Canon 24-70mm f/2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C200",
+      "lenses": [
+        "Rokinon 24mm f1.5",
+        "Samyang 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C300",
+      "lenses": [
+        "16-35 mm f2.8 L",
+        "24-195 f4 @24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C300 Mk 1",
+      "lenses": [
+        "Canon 24-105 f4 @ 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C70",
+      "lenses": [
+        "0.71+17-40F4",
+        "0.71+26-35F4 16MM",
+        "14mm",
+        "50 1.8 STM",
+        "7tart 10mm",
+        "CANON 24MM 1.2",
+        "CANON EF 16-35 2.8",
+        "EF24-105",
+        "EF85",
+        "RF 24-70mm f/2.8L IS USM",
+        "RF-EF0.71+24-70F4-16MM",
+        "RF24 1.8",
+        "Tokina 11-20",
+        "X0.71+16-35F4-16MM",
+        "X0.71+16-35F4-35MM",
+        "canon 35mm",
+        "tamron 18-200mm f3.5-f6.3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "C80",
+      "lenses": [
+        "FD50mm 1.4",
+        "Nisi Athena 18mm PL"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Canon R",
+      "lenses": [
+        "RF 50mm f.1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "d700",
+      "lenses": [
+        "EFS 18-55MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 1 DX MK3",
+      "lenses": [
+        "16-35 EF 2.8 mk2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 100D",
+      "lenses": [
+        "18-55",
+        "18MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 1100D",
+      "lenses": [
+        "EFS 18-55mm",
+        "efs 18 a 55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 2000D",
+      "lenses": [
+        "18-55mm",
+        "CANON 18-55mm Kitlens",
+        "Default",
+        "ef-s"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 200D",
+      "lenses": [
+        "Canon 35mm",
+        "EF 50mm",
+        "Tamron 18-200mm",
+        "efs 18-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 250D",
+      "lenses": [
+        "EFS 18-135",
+        "EFS 18-135MM",
+        "Prime 50mm",
+        "la mini"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 4000D",
+      "lenses": [
+        "Tamron"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 50D",
+      "lenses": [
+        "24mm",
+        "Canon EF 50mm 1.8f"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 550D",
+      "lenses": [
+        "18-55",
+        "Canon 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 5D Mark II",
+      "lenses": [
+        "50mm 1.8 Old",
+        "Canon EF USM 16-35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 5D Mark IV",
+      "lenses": [
+        "Canon 16-35",
+        "Canon EF 50mm",
+        "EF 24-105 IS USM",
+        "EF-16-35mm",
+        "Sigma Art 35mm f/1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 5DIII",
+      "lenses": [
+        "24-105"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6 Mark 2",
+      "lenses": [
+        "Canon 24-70mm Ultrasonix"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 600D",
+      "lenses": [
+        "18",
+        "18-55",
+        "Helios 44-4 68mm",
+        "Sigma 30mm 1.4ART",
+        "prinzflex 28mm f2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 60D",
+      "lenses": [
+        "18-135 @ 35mm",
+        "EFS18-135mm",
+        "Sigma 18-200",
+        "Tamron 11-20 F2.8"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D",
+      "lenses": [
+        "24-105 f/4",
+        "35mm",
+        "Canon 16-35 2.8L Mk2",
+        "Canon 50mm f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D Mark II",
+      "lenses": [
+        "24-70",
+        "Canon 50mm 1.4",
+        "Canon EF 24-105 f4",
+        "Sigma 24-70mm f2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D mk2",
+      "lenses": [
+        "150mm canon"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6D2",
+      "lenses": [
+        "EF 24-105"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6DII",
+      "lenses": [
+        "canon EF 24-70 F4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 6R",
+      "lenses": [
+        "EF 50 f1.8",
+        "EF 50/1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 700D",
+      "lenses": [
+        "EF-S 18-55 Kit Lens",
+        "Nikkor 35mm DX f/1.8G",
+        "Sigma 10-20mm f3.5",
+        "Sigma 18-250 OS HSM"
+      ],
+      "crop_factor": 1.6,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 70D",
+      "lenses": [
+        "13-55",
+        "17 40",
+        "Canon 18-135mm f3.5-6.3 IS STM",
+        "Fisheye 8mm",
+        "Gelios 44M4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 750D",
+      "lenses": [
+        "EFS 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 77D",
+      "lenses": [
+        "EFS-18-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 7D",
+      "lenses": [
+        "Canon 28-135mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 800D",
+      "lenses": [
+        "CanonEF lens 50mm F1.8",
+        "EFS 18-55",
+        "EFS 18-55MM",
+        "ef-s15-85"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 80d",
+      "lenses": [
+        "EF-S 18-135mm f/3.5-5.6 IS",
+        "EFS 17-55 2.8",
+        "Sigma Art 30mm 1.4",
+        "Sigma Dc 17-70mm 2.8-4.5",
+        "Tamron 18-200"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 80D18-135 f/3.5-5.6",
+      "lenses": [
+        "canon efs"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 850D",
+      "lenses": [
+        "Canon 18-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS 90D",
+      "lenses": [
+        "EF 17-40 4.0",
+        "EFS18-35mm",
+        "Sigma 18-35mm DC",
+        "Sigma Art 18-35mm f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS C100mkii",
+      "lenses": [
+        "Canon 24-105mm 3.5-5.6 IS STM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS C200",
+      "lenses": [
+        "100mmMacro",
+        "Canon 100mm macro",
+        "CinemaLens 14mm",
+        "Sigma 18-35 @35",
+        "Sigma 18-35mm",
+        "Tokina 11-20mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS C70",
+      "lenses": [
+        "16-35 2.8",
+        "Sigma 18-35mm f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M",
+      "lenses": [
+        "15-45 mm",
+        "15-45mm",
+        "15-45mm f3.5-5.6",
+        "15-45mm f3.5-5.6 kit lens",
+        "17-55 f.28",
+        "22",
+        "22MM",
+        "22MM F2",
+        "22mm",
+        "22mm F2.0",
+        "22mm F2.0 Canon EF-M",
+        "25mm F1.8 7Artisans",
+        "28MM 2.8 IS USM",
+        "28mm",
+        "35mm F1.2 7Artisans",
+        "35mm f/1.8",
+        "50mm",
+        "55mm F1.4 7Artisans",
+        "7 Artisan 7.5",
+        "7 Artisans 25mm f.18",
+        "7 Artisans 25mm f1.8",
+        "7 artisans 25mm",
+        "7A 7.5mm 2.8",
+        "7Artisans 12mm",
+        "7Artisans 7.5mm 2.8f",
+        "7Artisans25mm",
+        "7artistian 25mm 1.8",
+        "Brightin Star 10mm F5.6",
+        "Brightin Star 10mm f5.6",
+        "Canon 15-45mm",
+        "Canon 2MM F2 STM",
+        "Canon EF-M 15-45mm IS STM at 15mm",
+        "Canon EF-M 18-55mm 1:3,5-5.6 IS STM",
+        "Canon EFS 18-55mm",
+        "C口35mm",
+        "EF 28MM 2.8 IS USM",
+        "EF 40MM 2.8MM",
+        "EF-M 15-45mm",
+        "EF-M 15-45mm IS STM at 15mm",
+        "EF-M 22MM",
+        "EF-M 22mm 2.0",
+        "EF-M 22mm f/2 STM",
+        "EFM 18-55",
+        "EOS M 22mm",
+        "Fujian 35mm",
+        "MIR-24M",
+        "MIR-24M f/2 ANAMORPHIC MOD",
+        "Meike 35mm F1.4",
+        "PANCAKE 22MM F2",
+        "Pentax 8.5mm",
+        "Pergear 10mm f5.6 fisheye",
+        "RISESPRAY 7,5mm",
+        "Risespray 7.5mm",
+        "Rockstar 10mm",
+        "Rokinon 14mm T3.1 + Viltrox 0.71x Speedbooster",
+        "SMC Pentax 50mm F1.4",
+        "Samyang 16mm F2.0",
+        "Samyang 8mm",
+        "Sigma 16mm 1.4",
+        "Sigma 17-50 f2.8-4.5",
+        "Sigma Super Wide II 24mm f/2.8",
+        "Sigma Super-Wide II 24mm f/2.8",
+        "TTArtisan 17mm f/1.4",
+        "TTArtisan 50 mm f1.2",
+        "TTArtisans 35mm f1.4",
+        "TTartisan 17mm",
+        "TTartisans 17mm f1.4",
+        "Takumar 28mm 3.5",
+        "Tamron 15-30 F2.8",
+        "Tokina 11-16",
+        "Tokina 11-16 f2.8 Pro DX I",
+        "Tokina 12-24 F4",
+        "Tokina Pro DX 11-16mmViltrox Speedbooster EF-EOS M2 0.71x",
+        "ZEISS 28MM",
+        "ZUIKO 28mm f3.5",
+        "brightin star 10mm f5.6",
+        "ef-s 24mm 2.8",
+        "efm 15-45"
+      ],
+      "crop_factor": 2.71,
+      "sensor_size": "1-inch",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS m crop mood",
+      "lenses": [
+        "15 45 at 15mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M MLV",
+      "lenses": [
+        "35mm Fujian TV"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M100",
+      "lenses": [
+        "EF-M 15-45mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M50",
+      "lenses": [
+        "15-45",
+        "Brigthin star 10mm f5.6",
+        "CANON",
+        "Canon 15-45",
+        "Canon 50mm f1.8",
+        "EF-M 15-45",
+        "Sigma 30mm f1.4 EF-M",
+        "Tamaron 17-50 f2.8 LD SP IF"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M50 Mark 2",
+      "lenses": [
+        "SIGMA 16mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M50 Mark II",
+      "lenses": [
+        "15 - 45 mm",
+        "7Artisan 25mm",
+        "Kit 15-45mm IS STM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "eos m50 mii",
+      "lenses": [
+        "15-45 efm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M6",
+      "lenses": [
+        "Sigma 56mm f1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M6 Mark II",
+      "lenses": [
+        "24-70",
+        "Canon 50mm f/1.8 II",
+        "Sigma 24-70 EX DG"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS M6II",
+      "lenses": [
+        "11-22 EFM",
+        "18MM",
+        "32MM",
+        "7Artisans 7.5mm",
+        "EFM22"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Mark II",
+      "lenses": [
+        "SIgma 18-35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R",
+      "lenses": [
+        "16 mm 2.8 STM",
+        "24-70mm EF",
+        "35mm f1.8",
+        "50 mm f1.8",
+        "50mm 1.8",
+        "Canon 24 - 105 F4.0L",
+        "Canon 24-105",
+        "Canon 24-200",
+        "Canon 24-70mm 2.8f",
+        "Canon EFS 10-18mm",
+        "RF 24-105",
+        "RF15-35mm F2.8 L IS USM",
+        "Sigma 17-50",
+        "Sigma 35mm f1.8 Art",
+        "Sigma EF 24mm f/1.4 Art",
+        "Tamron 15-30 F/2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R10",
+      "lenses": [
+        "18mm",
+        "35mm",
+        "45mm",
+        "50mm f1.8",
+        "Canon RF-S18-150 IS STM KIT",
+        "EF 20-35 f.3.6-4.5",
+        "EFS 10mm",
+        "F5-7.1 55-210",
+        "RF",
+        "RF 50mm",
+        "RF-S 18-150mm F3.5-6.3 IS STM",
+        "RF-S 18-45mm F4.5-6.3 is STM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R5",
+      "lenses": [
+        "14-35MM",
+        "14-35mm",
+        "16-35 2.8 L USM III",
+        "16mm",
+        "16mm 2,8f",
+        "16mm rf 2.8",
+        "24-240",
+        "50mm 1.2 USM",
+        "CANON 16-35MM",
+        "Canon 14-35 mm",
+        "Canon 24-105",
+        "Canon CN-E 14mm",
+        "Canon RF 16mm",
+        "Laowa 14 mm F/4 FF RL Zero-D",
+        "RF 16mm f2.8",
+        "RF 24-105",
+        "RF 24-105mm F4L IS USM",
+        "RF 24-105mmF4 IS USM",
+        "RF 24-105mmF4L IS USM",
+        "RF 24mmF/1.8 IS STM",
+        "RF 24mmF1.8 IS STM",
+        "RF 35mm f1.8",
+        "RF 50mm f1.8",
+        "RF15-35",
+        "RF24-70mm F2.8 L IS USM",
+        "Rf 35mm F1.8 Macro IS STM",
+        "SAMYANG 14MM",
+        "SAMYANG 35MM",
+        "Sigma 35mm f1.4",
+        "Sigma135",
+        "Tamron 24-70 f2.8",
+        "Tamron 24-70mm F2.8 Di VC G2 EF",
+        "canon RF 16mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R50",
+      "lenses": [
+        "Canon 18-45"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R5c",
+      "lenses": [
+        "24-105 f4",
+        "7Artisans 10mm F2.8",
+        "Canon 50mm",
+        "Laowa 11mm 4.5 FF",
+        "Laowa 12-24mm",
+        "Laowa 12mm f/2.8 Zero-D",
+        "Laowa 14mm F2,0 Zero-D",
+        "Laowa 14mm F4.0",
+        "Laowa10mmF4",
+        "RF 24 105 f4",
+        "RF 24-70 f2.8",
+        "RF16 2.8",
+        "RF24 105 f4",
+        "rf24 105F4L"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R6",
+      "lenses": [
+        "24-105",
+        "24-108 IS USM（24mm）",
+        "24-150",
+        "24-70mm F 2.8",
+        "24-70mm F2.8 70mm",
+        "Canon 16 mm F2.8",
+        "Canon EF 1.8",
+        "Laowa 15mm F4 MACRO",
+        "RF 16mm 2.8",
+        "RF 24-105 F/4-7.1",
+        "RF 24-70",
+        "RF35MM F1.8",
+        "Samyang 14mm",
+        "Tokina 16mm",
+        "VM-10mmF5.6",
+        "rf24-105 f4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS r6 mark II",
+      "lenses": [
+        "RF24-105mm F4-7.1 IS STM",
+        "RF70-200mm F4 L IS USM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R62",
+      "lenses": [
+        "RF35-1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R7",
+      "lenses": [
+        "18",
+        "Canon RF 18-150",
+        "Canon RF18-150",
+        "RF 24-105mm F4 L IS USM",
+        "SIGMA 24-70 F/2.8",
+        "Tamron 24-70 f/2.8"
+      ],
+      "crop_factor": 1.6,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS R8",
+      "lenses": [
+        "24-240mm f4.5",
+        "24105",
+        "48",
+        "50",
+        "501",
+        "70",
+        "EF24-70/4L",
+        "RF 100-400 F5.6-8 @ 100mm",
+        "RF 100-400 F5.6-8 @ 135mm",
+        "RF 100-400 F5.6-8 @ 200mm",
+        "RF 100-400 F5.6-8 @ 300mm",
+        "RF 100-400 F5.6-8 @ 400mm",
+        "RF 24-105 F4-7.1 @ 105mm",
+        "RF 24-105 F4-7.1 @ 35mm",
+        "RF 24-105 F4-7.1 @ 50mm",
+        "RF 24-105 F4-7.1 @ 70mm",
+        "RF 24-105 F4-7.1 @ 85mm",
+        "RF 24-50 f4.5-6.3",
+        "RF 24-70 f/2.8",
+        "RF 50MM F1.8 STM",
+        "RF 85mm f2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel T100",
+      "lenses": [
+        "EF 70-300mm",
+        "EF-S 18-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS REBEL T5i",
+      "lenses": [
+        "EFS 18-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel T6",
+      "lenses": [
+        "TAMRON"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel T6i",
+      "lenses": [
+        "Canon EFS 18-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS Rebel t8i",
+      "lenses": [
+        "ef 50 mm f/1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS RP",
+      "lenses": [
+        "50",
+        "EF-S 10-18mm",
+        "EF-S 24mm f2.8 STM",
+        "RF 16mm 2.8",
+        "RF 24-105",
+        "RF 24-105 f4-7.1 @f4",
+        "RF15-30mm f4.5-6.3 IS STM",
+        "SIGMA 35MM F1,4 ART",
+        "canon 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOS T6S",
+      "lenses": [
+        "Rokinon 35mm f1.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "EOSD 1 DX MK3",
+      "lenses": [
+        "EF 16-35mm 2.8 MK2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "G7X Mark 2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "G7X Mark II",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "G9X M2",
+      "lenses": [
+        "G9X M2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Legria G20",
+      "lenses": [
+        "default"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "m100",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M200",
+      "lenses": [
+        "Viltrox 23mm 1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M50",
+      "lenses": [
+        "11-22",
+        "7artisans 7.5mm",
+        "Canon 15-45 @ 15mm",
+        "Canon 15-45 @15mm",
+        "Canon 15-45mm @15mm",
+        "Canon EF-M 22mm f/2 STM",
+        "EF 40mm F2.8",
+        "EF 85mm F1.8",
+        "EF-M 11-22mm f/4-5.6 IS STM",
+        "kit 18mm",
+        "kit55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M50 Mark 1",
+      "lenses": [
+        "Laowa C-Dreamer 9mm F2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "m50 mark 2",
+      "lenses": [
+        "15-45mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M50 mark I",
+      "lenses": [
+        "Ttartisan 35mm 1.4 ef-m"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "m50 mark II",
+      "lenses": [
+        "Canon 24-70 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M6 II",
+      "lenses": [
+        "Samyang 12 mm F2",
+        "Sigma 30 1.4",
+        "Tamron 11-18"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "M6 Mark II",
+      "lenses": [
+        "Canon 50mm UltraSonic"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Mark2",
+      "lenses": [
+        "Sigma 17-50 F2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R",
+      "lenses": [
+        "SIGMA 17-50 @ 17mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R10",
+      "lenses": [
+        "18-45 @ 18mm",
+        "184185",
+        "EF 40 2.8",
+        "EFS18-135MMUSM",
+        "RFS10-18",
+        "RFS10-18MM",
+        "RFS10-18mm",
+        "SIRUI24MMT1.2",
+        "SIUI24MMT1.2",
+        "Sigma 10-20 1:4-5.6",
+        "Sigma 10-20mm 1:4-5.6 DC HSM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R3",
+      "lenses": [
+        "16 f2.8",
+        "35mm 1.8 RF",
+        "RF 24-70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R5",
+      "lenses": [
+        "16",
+        "16 mm Rf f2.8",
+        "16-35L F4 IS",
+        "16-35mm F2.8",
+        "16mm 2.8",
+        "24-105",
+        "24-70",
+        "24-70mm",
+        "35 mm 1.8 RF",
+        "35 mm RF",
+        "50",
+        "50L F1.2",
+        "50mm F1.4",
+        "7artisans 10mm f2.8",
+        "85mm",
+        "CANON 16-35MM F4",
+        "CANON LENS RF24-105mm F4 L IS USIM",
+        "Canon 16mm F2.8",
+        "Canon 24-105",
+        "Canon 24-70",
+        "Canon FD 35mm 2.8",
+        "Canon R5C",
+        "Cosina 20mm f3.8",
+        "EF-L 16-35",
+        "EF16-35 F4",
+        "Laowa Zero-D 9mm T2.9",
+        "RF24 2.8",
+        "RF85mm",
+        "ef16-35",
+        "fisheye 15mm 2.8",
+        "rf24-70f2.8",
+        "rf50mm1.2",
+        "tla007",
+        "七工匠10mm鱼眼",
+        "星耀9mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R5 C",
+      "lenses": [
+        "Meyer-Optik Gorlitz Biotar 58mm f/1.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R50",
+      "lenses": [
+        "18-55",
+        "18mm - 45mm",
+        "50-1.8",
+        "50mm 1.4",
+        "Canon EF 50mm",
+        "Ef 24 105",
+        "RF 55-210mm",
+        "STM50 1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R5C",
+      "lenses": [
+        "16F2.8",
+        "24-105mm F/4 RF",
+        "24-70",
+        "24_105_F4_L@50mm",
+        "35",
+        "Canon",
+        "Canon 16-35mm F4 IS",
+        "Canon Lens RF16mm F2.8 STM",
+        "Canon RF 14-24mm F4L",
+        "Canon RF16mm F2.8",
+        "Carl Zeiss Jena Flektogon",
+        "Helios44-2",
+        "LAOWA10MM",
+        "Laowa 10mm f2.8",
+        "Laowa 11/4.5",
+        "Laowa 11mm_4.5",
+        "Laowa 12mm f/2.8 Zero-D",
+        "Laowa 7.5 F2.8",
+        "Laowa Nanomorph",
+        "Laowa Nanomorph 35mm",
+        "RF 15-35 2.8",
+        "RF16 2.8",
+        "RF16mm F2.8 STM",
+        "RF24 105 F4",
+        "RF24-70F2.8",
+        "RF24-70mmF2.8",
+        "RF24105F4L@24mm",
+        "Rf24-70F2.8",
+        "Rf24-70F2.8l",
+        "TT35mm",
+        "canon rf 14-24mm f4l",
+        "ef501.2",
+        "laowa 14mm f4",
+        "rf 24-70mm",
+        "rf24-70mm",
+        "rf28",
+        "rf28mm",
+        "tt35"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6",
+      "lenses": [
+        "24-105",
+        "50 mm",
+        "50MM STM",
+        "50mm f.18 stm",
+        "50mm stm",
+        "Canon",
+        "Canon 15-35mm 2.8",
+        "Canon 50mm 1.8 STM",
+        "EF 24-70 at 35mm",
+        "RF 24-105mm F4",
+        "RF 24-105mm F4 24mm",
+        "RF 24-70mm f2.8 L IS USM",
+        "RF24-105",
+        "ROKINON 35",
+        "Sirui 35mm T2.9 Saturn",
+        "Tamron SP VC 24-70mm F2.8",
+        "sigma 24-70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 m2",
+      "lenses": [
+        "Ef 16-35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 Mark II",
+      "lenses": [
+        "16 MM",
+        "24105",
+        "2470RF24mm",
+        "EF 16-35mm F2.8 II 16mm",
+        "EF 24-105mm F4 105mm",
+        "EF 24-105mm F4 50mm",
+        "Rf 24-105 F4",
+        "Rf24-105 F4",
+        "SIGMA 35MM",
+        "rf 24-105 F4",
+        "rf 24-105 f4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 MarkII",
+      "lenses": [
+        "RF24-105 F4 L"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 Mii",
+      "lenses": [
+        "Sigma 35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 Mk II",
+      "lenses": [
+        "Canon 24-70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6 mk2",
+      "lenses": [
+        "Sigma"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "r6 mkii",
+      "lenses": [
+        "tamron"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R62",
+      "lenses": [
+        "RF 24-105MM F4-7.1",
+        "RF 24-105mm F4-7.1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R6ii",
+      "lenses": [
+        "24-105"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R7",
+      "lenses": [
+        "10-18",
+        "100-500 RF",
+        "18-150",
+        "50mmf1.8",
+        "7Artisans",
+        "7Artisans 7.5mm",
+        "Canon 18-150",
+        "Canon 50mm",
+        "Canon 50mm f1.4",
+        "EF17-40",
+        "EF24f1.4",
+        "EFS 10-18mm",
+        "RF50mm",
+        "RFS18-150",
+        "Sigma18-35",
+        "canon 18/55 EFS",
+        "rfs 10-18",
+        "sigma 10-20"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "R8",
+      "lenses": [
+        "16-35mm f/4",
+        "16-F1.8",
+        "16-F2.8",
+        "16-f1.8",
+        "16mm 2.8",
+        "24-105 f4-7.1",
+        "24-105stm",
+        "24-50",
+        "24mm-50mm",
+        "50mm 1.8 stm",
+        "Canon 16-35 EF",
+        "Canon 50mm 1.8",
+        "Canon EF 24-105mm F4 USM",
+        "Canon RF 16mm",
+        "EF 50mm STM",
+        "EF2470",
+        "RF 14-35mm",
+        "RF24mm 1.8",
+        "RF24mm1.8",
+        "Sigma 35 mm ART",
+        "Sigma 35mm",
+        "Sirui 24mm f/1.2",
+        "Temron17-35-17MM",
+        "ef24-70f2.8",
+        "rf35f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Rebel EOS SL3",
+      "lenses": [
+        "Canon EF 50mm STM",
+        "Canon EF-S 18-55mm f/4-5.6 IS STM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Rebel EOS T6",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Rebel sl2",
+      "lenses": [
+        "50mm f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "rebel t7",
+      "lenses": [
+        "18-55",
+        "CANON 158-55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "RP",
+      "lenses": [
+        "7artisans 50mm spectrum T2.0",
+        "Canon RF 24-105mm",
+        "EF50MM F1.2",
+        "RF 50 mm 1.8",
+        "RF 50mm F1.8",
+        "RF50mm F1.8",
+        "RF85MM F1.2",
+        "TAMRON 35mm f1.4",
+        "canon rf 24-50 f4-6.3 is stm",
+        "tamron 70-300"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Sl2/200D",
+      "lenses": [
+        "Sigma 18-35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "SL3",
+      "lenses": [
+        "EFS 10-18mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "SX740hs",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "T4i/650D",
+      "lenses": [
+        "Cannon 50mm 1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "t6",
+      "lenses": [
+        "50 mm f/1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "t6 d1300",
+      "lenses": [
+        "ef50mm f/1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "T6i",
+      "lenses": [
+        "18-135@18mm",
+        "50mm",
+        "Canon 18-55",
+        "Canon 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "T7i",
+      "lenses": [
+        "10-15 verttical 10",
+        "10-18mm",
+        "50mm 1.8",
+        "Canon 50mm 1.8",
+        "Canon 50mm f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "T8i",
+      "lenses": [
+        "15mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "Vixia HF200",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Canon",
+      "model": "XA50",
+      "lenses": [
+        "Shortest F"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "China_ActionCam",
+      "model": "China_Noname",
+      "lenses": [
+        "Sony"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Chronos",
+      "model": "CR14-1.0",
+      "lenses": [
+        "Comutar TV Zoom Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "cleep",
+      "model": "cleep wereable",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Cooau",
+      "model": "CU SPC02",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "COOAU",
+      "model": "SPC06",
+      "lenses": [
+        "Ojo de pez f/2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "COTUO",
+      "model": "Q6TR",
+      "lenses": [
+        "180度鱼眼",
+        "F1.8F2.66"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Crosstour",
+      "model": "4K wifi",
+      "lenses": [
+        "2.3mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Crosstour",
+      "model": "CT 9000",
+      "lenses": [
+        "2.3mm",
+        "20mp"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Crosstour",
+      "model": "CT7000",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "cyanchen",
+      "model": "15-85",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Cycliq",
+      "model": "Fly12 sport",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DDPAI",
+      "model": "mini3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DDPAI",
+      "model": "Mini5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Decathlon",
+      "model": "G-eye-900",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Denver",
+      "model": "ACK-8062W",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Digital Bolex",
+      "model": "D16",
+      "lenses": [
+        "Angénieux 17-68mm 1:2.2 Type 4x17B",
+        "Carl Zeiss Jena Tevidon 10mm",
+        "Computar MC TV Lens 1:15"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Digma",
+      "model": "850",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "4D",
+      "lenses": [
+        "DL 35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Action",
+      "lenses": [
+        "1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Action 1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "action 3",
+      "lenses": [
+        "FOV 155 f/2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air",
+      "lenses": [
+        "Air"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air 2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air 2S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air 3",
+      "lenses": [
+        "24 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air Unit",
+      "lenses": [
+        "14.66",
+        "DJI 2.1 mm, f/2.1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air2",
+      "lenses": [
+        "4K"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Air2s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "caddx vista dji",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "DJI FPV Drone",
+      "lenses": [
+        "14.66 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "DJI MINI SE",
+      "lenses": [
+        "35mm, f2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FPV",
+      "lenses": [
+        "1/2.3” CMOS",
+        "14,66 mm",
+        "14.66",
+        "4K60p",
+        "60",
+        "Base Lens",
+        "CMOS de 1/2.3\"",
+        "Normal",
+        "STD",
+        "dji fpv"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FPV Air Unit",
+      "lenses": [
+        "2.1 mm, f/2.1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "FPV skyliner",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Goggles2 From Avata",
+      "lenses": [
+        "O3 air Unit"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic",
+      "lenses": [
+        "Air 2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 2",
+      "lenses": [
+        "ZOOM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 2 Pro",
+      "lenses": [
+        "HASSELBLAD28MM",
+        "Hassleblad"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 2 Zoom",
+      "lenses": [
+        "DJI Mavic 2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mavic 2pro",
+      "lenses": [
+        "28mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3",
+      "lenses": [
+        "L2D-20c 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 C1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 C2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 Classic",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic 3 Pro Hasselblad 4/3",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Air 1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "MAVIC AIR 2",
+      "lenses": [
+        "AIR 2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Air 2s 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic mini",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic mini 2 se 2.7 k",
+      "lenses": [
+        "Mavic mini 2 se"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Pro 1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic Pro 2",
+      "lenses": [
+        "28mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic3 PRO 3x",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mavic3Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mini 2",
+      "lenses": [
+        "1/2.3\" CMOS",
+        "1/2.3\" CMOS FOV: 83º",
+        "1/2.3”",
+        "1/2.3” CMOS FOV: 83°",
+        "FOV: 83°"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini 2 4K 30 fps",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini 2 se",
+      "lenses": [
+        "Mini2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "MINI 3",
+      "lenses": [
+        "CMOS",
+        "CMOS 1/1.3\""
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "MINI 3 PRO",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini 4 pro",
+      "lenses": [
+        "1/1.3 inch"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mini Pro 3",
+      "lenses": [
+        "1/1.3-in CMOS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Mini2",
+      "lenses": [
+        "FOV83"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "mini3",
+      "lenses": [
+        "1/1.3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "O4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "O4 Lite",
+      "lenses": [
+        "148° Custom Wide Angle Lens",
+        "Flywoo O4 Wide lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo",
+      "lenses": [
+        "STOCK"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Action",
+      "lenses": [
+        "145degree f/2.8",
+        "F2.8",
+        "Orginal",
+        "Original",
+        "STOCK",
+        "Standard",
+        "standard",
+        "stock"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Action 1",
+      "lenses": [
+        "1",
+        "DJI",
+        "Default",
+        "Dewarp_OFF"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Action 3",
+      "lenses": [
+        "Dewarp",
+        "FOV: 145° f/2.8",
+        "Ultra Wide 155°"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Pocket",
+      "lenses": [
+        "1/2.3英寸",
+        "none"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Osmo Pocket 1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "OsmoPocket3",
+      "lenses": [
+        "20mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 3 Advanced",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 4",
+      "lenses": [
+        "FOV 94 degree 20 mm f.2.8 focus infinity"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 4 Pro V1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Phantom 4 prov2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "Pocket 2",
+      "lenses": [
+        "Freewell Anamorphic",
+        "Wide Angle Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "vista",
+      "lenses": [
+        "凤凰HD"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "X7",
+      "lenses": [
+        "24"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "ZEMMUSE X7",
+      "lenses": [
+        "DL-S 16mm F2.8 ND ASPH"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "DJI",
+      "model": "ZENMUSE X7",
+      "lenses": [
+        "C-Dreamer 9mm F2.8",
+        "DL-S 16mm F2.8 ND ASPH"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Dogcam",
+      "model": "Bullet R+",
+      "lenses": [
+        "135"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "drift",
+      "model": "ghost xl pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Drift",
+      "model": "xl pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "duoke",
+      "model": "DK020p",
+      "lenses": [
+        "xxx"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eachine",
+      "model": "Lizard105S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eachine",
+      "model": "TX06 700tvl",
+      "lenses": [
+        "130°"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eken",
+      "model": "h9",
+      "lenses": [
+        "original"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Eken",
+      "model": "H9R",
+      "lenses": [
+        "170FOV"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "EKEN",
+      "model": "HR9S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Evolio",
+      "model": "iSmart 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ezviz",
+      "model": "S2",
+      "lenses": [
+        "155 deg"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fairphone",
+      "model": "5",
+      "lenses": [
+        "13mm",
+        "13mm Ultrawide",
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Feiyu Tech",
+      "model": "Pocket 2s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Feiyu-Tech",
+      "model": "Pocket3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fimi",
+      "model": "Fimi x8 2022 v2",
+      "lenses": [
+        "soni f1/6 48mp"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "FIMI",
+      "model": "plam 2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fimi",
+      "model": "x8 mini v2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Firefly",
+      "model": "Firefly 8SE",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Firefly",
+      "model": "Hawkey Naked 4K",
+      "lenses": [
+        "170"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Firefly",
+      "model": "Xlite2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Forcite",
+      "model": "MK1S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Forever",
+      "model": "SC-410",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Box",
+      "lenses": [
+        "v1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Box 2",
+      "lenses": [
+        "DEFAULT",
+        "Default",
+        "Wide",
+        "stock"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Box2",
+      "lenses": [
+        "stock"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Digisight Nano",
+      "lenses": [
+        "Foxeer CL1213 8MP 1.7mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Digisight V3",
+      "lenses": [
+        "Standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "HS1177",
+      "lenses": [
+        "2.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Legend 1",
+      "lenses": [
+        "Sony"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Legend 2+",
+      "lenses": [
+        "12MP"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Legend1",
+      "lenses": [
+        "Sony"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Lite",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "mix",
+      "lenses": [
+        "FHD"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Mix V2",
+      "lenses": [
+        "Runcam RC25G"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "PREDATOR MICRO V5",
+      "lenses": [
+        "1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Razer Pico",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Foxeer",
+      "model": "Razor Pico",
+      "lenses": [
+        "1.8mm M7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Freefly",
+      "model": "Wave",
+      "lenses": [
+        "12mm Magic Microprime Cine",
+        "Canon 10-18 @ 10mm",
+        "Laowa",
+        "Laowa 12mm",
+        "Laowa 9mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "100S减焦",
+      "lenses": [
+        "宾得645 75 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "100S 0.7X",
+      "lenses": [
+        "75MM F2.8"
+      ],
+      "crop_factor": 0.56,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX100ii",
+      "lenses": [
+        "110mmf2",
+        "45-100"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "GFX100S",
+      "lenses": [
+        "GF45mm",
+        "GF63mm",
+        "PENTAX TAKUMAR SMC 55MM F1.8",
+        "SIGAM 35 ART",
+        "SMC TAKUMAR 50MM F1.4",
+        "TAKUMAR SMC 55MM F1.8",
+        "TS-E24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "H2S",
+      "lenses": [
+        "Laowa 10mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "HS25EXR Pinefix",
+      "lenses": [
+        "24-720 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E2",
+      "lenses": [
+        "16-50F3.5-5.6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-E4",
+      "lenses": [
+        "Fujinon 27mm 2,8 WR",
+        "Rokinon 12mm f/2.0"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-H1",
+      "lenses": [
+        "XF 16-55 F/2.8",
+        "Zeiss Touit"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-H2",
+      "lenses": [
+        "FUJINON 10-24",
+        "FUJINON 18-120",
+        "Zeiss Touit 2.8/12mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-H2S",
+      "lenses": [
+        "16-55mm",
+        "18",
+        "27 1.2",
+        "35mm",
+        "35mm f1.4",
+        "35mm_1.2t",
+        "50mm",
+        "Canon EF 17-40mm f/4L USM",
+        "Contax Zeiss 25mm/f2.8 via Metabones Speedbooster",
+        "Contax Zeiss 35mm/f2.8 via Metabones Speedbooster",
+        "Contax Zeiss 50mm/f1.4 via Metabones Speedbooster",
+        "DZ35",
+        "DZ35mm",
+        "DZ50",
+        "DZ50mm",
+        "FujiFilm XF 16-80F4",
+        "Fujifilm 16mm 2.8",
+        "Fujinon XF 16-55mm F2.8 R LM WR @ 16mm",
+        "Laowa 33mm f/0.95",
+        "Sigma 18-50 (18mm)",
+        "Sigma18-50",
+        "TTArtisan",
+        "Tamron 17-70mm f2.8",
+        "V27 1.2",
+        "Viltrox 13mm 1.4",
+        "XF 16-55mm",
+        "XF18-120",
+        "XF35mm F1.4",
+        "XF8mm",
+        "dz35",
+        "sigma 18-50",
+        "viltrox 23mm f1.4",
+        "xf 56 1.2",
+        "唯卓仕75mm f1.2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "x-pro 3",
+      "lenses": [
+        "xf33 f1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-Pro3",
+      "lenses": [
+        "XF16-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-S/X-T",
+      "lenses": [
+        "Sigma 18-35",
+        "Sigma 18-35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "x-s10",
+      "lenses": [
+        "15-45",
+        "16 80",
+        "18-55mm f2.8",
+        "7Artisan 7.5mm F/2.8 II X",
+        "Canon 10-18mm",
+        "FUJINON 18-55 F/2.8-4 R LM OIS",
+        "Sigma 18-50 2.8 DC",
+        "XC15-45mm"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-S10_T3_T30_T4",
+      "lenses": [
+        "Sigma 18-35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-S20",
+      "lenses": [
+        "FUJINON XC15-45mmF3.5-5.6 OIS PZFUJINON XC15-45mmF3.5-5.6 OIS PZ",
+        "Fijinon 15-55mm f3.5",
+        "Fuji",
+        "Fujifilm XC 15-45mm",
+        "Tamron",
+        "Tamron 17-70mm",
+        "Viltrox 13mm F1.4",
+        "XF 33mm f/1.4 R LM WR",
+        "XF16-55mmF2.8 R LM WR"
+      ],
+      "crop_factor": 1.6,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T/X-S",
+      "lenses": [
+        "Carl Zeiss Jena 50mm",
+        "Cimko 28mm",
+        "Helios 44M"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T1",
+      "lenses": [
+        "Sugma 8-16",
+        "ttartisans 17mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T100",
+      "lenses": [
+        "xc 50 203"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "x-T15",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T2",
+      "lenses": [
+        "1545",
+        "18-55",
+        "18-55mm @18 mm",
+        "50mm",
+        "Fuji XC 16-50mm OIS II",
+        "Meike 35mm 1.7",
+        "Samyang MF 12mm",
+        "XC1545mm"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T20",
+      "lenses": [
+        "MEIKE 35mm",
+        "XC 16-50mm",
+        "XF 18-55mm",
+        "XF 23mm F2",
+        "XF 35mm 1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T200",
+      "lenses": [
+        "kit15-45"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T3",
+      "lenses": [
+        "10-24 f4",
+        "10-24f4",
+        "14mm f2.8",
+        "15-45",
+        "17-50mm (28mm)",
+        "18-55 Fujinon",
+        "7artisan 7.5mm",
+        "Carl Zeiss Jena 20mm f4",
+        "Carl Zeiss Jena Flektogon 4/20",
+        "Fujifilm",
+        "Fujinon",
+        "Fujinon 16-80",
+        "Fujinon 18-55",
+        "Fujinon XF 14mm 2.8",
+        "Industar 61",
+        "Kamlan 50mm f1.1",
+        "LAOWA CF 9mm F2.8 Zero-D",
+        "Laowa 7.5mm",
+        "Laowa 9mm 2.8",
+        "Laowa C-Dreamer 9mm F2.8",
+        "Minolta Rokkor 58mm f/1.4",
+        "Minolta Rokkor MD 24mm f/2.8",
+        "Mitakon Speedmaster 35mm f0.95",
+        "Rokinon 12mm F2.0 NCS CS",
+        "Rokinon 12mm F2.0 NCS CS Ultra Wide Angle",
+        "Rokinon 12mm f2",
+        "Samyang 12mm",
+        "Samyang 8mm f2.8",
+        "Sigma 17-50 @ 17mm",
+        "Sigma 17-50 @ 21mm",
+        "Sigma 17-50 @ 35mm",
+        "Sigma 17-50 @ 50mm",
+        "VILTROX AF13/1.4XF",
+        "Viltrox 13mm f1.4",
+        "Viltrox 33mm f1.4",
+        "XC 35mm F2",
+        "XF 18-55",
+        "XF 18-55mm @18mm",
+        "XF18-55",
+        "fujinon 14mm f2.8",
+        "fujinon 18-55",
+        "funinon 18-55",
+        "samyang 12mm",
+        "viltrox 24",
+        "xc15-45  15",
+        "xc35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T30",
+      "lenses": [
+        "10MM F8",
+        "27mm",
+        "35mm fuji",
+        "7.5mm f2.0",
+        "Fujinon 18-55",
+        "TTArtisan 25mm F2.0",
+        "Viltrox 23mm",
+        "Viltrox 33mm f1.4",
+        "samyang 12 mmf",
+        "samyang 12mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T30 II",
+      "lenses": [
+        "XF18-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T4",
+      "lenses": [
+        "16-55 f2.8",
+        "16-80 / f4",
+        "18-55",
+        "18-55 Kit lens",
+        "18-55@18mm",
+        "1855",
+        "23MM f2.0",
+        "23mm",
+        "7artisans 35mm f0.95",
+        "FUJIFILM XF 16-55mm f/2.8 R LM WR",
+        "Fujifilm龙16mmf1.4",
+        "Fujinon 10-24",
+        "Fujinon XF16-80mmF4 R OIS WR",
+        "Samyang 12mm T2.2",
+        "VILTROX 35MM",
+        "Viltrox 13mm",
+        "XF23",
+        "helios 44-2",
+        "laowa 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X-T5",
+      "lenses": [
+        "18-55",
+        "TAMROM 18-300mm 18mm",
+        "TAMRON 18-300mm 18mmF4",
+        "Tamron 11-20",
+        "VILTROX  27mm F1.2",
+        "VILTROX 27mm F1.2",
+        "XF 18-55 f2.8-4",
+        "XF 27mm F1.2",
+        "fx 18-55 f2.8"
+      ],
+      "crop_factor": 1.14,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100F",
+      "lenses": [
+        "Fujinon 23mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100V",
+      "lenses": [
+        "23",
+        "FUJINON 23MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "X100V 4K 30P",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "xe4",
+      "lenses": [
+        "14 28",
+        "14 f2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XH-2",
+      "lenses": [
+        "TT Artisans 25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XH-2s",
+      "lenses": [
+        "16-55 F2.8",
+        "18mm",
+        "FX 16-55mm",
+        "xf18-200mmF4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XH2",
+      "lenses": [
+        "18-35",
+        "1835",
+        "35mm 1.4F"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "xh2s",
+      "lenses": [
+        "13mm Viltrox",
+        "16-55 2.8",
+        "18-55",
+        "75mm Viltrox",
+        "Samyang 12mm",
+        "Touit12 2.8",
+        "tamron 18-300",
+        "vzs 27 1.2",
+        "xf18-200 f4 18mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XS-10",
+      "lenses": [
+        "15-45mm",
+        "Viltrox 27 F1.2",
+        "XC 15-45mm",
+        "XC15-45"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XS-20",
+      "lenses": [
+        "Tamron 17-70mm f2,8 Di III-A VC RXD Fuji X"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XS10",
+      "lenses": [
+        "Tamron 17-70mm",
+        "XF16-55",
+        "腾龙18300"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "Xs20",
+      "lenses": [
+        "Fujinon 16-55mm F2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-20",
+      "lenses": [
+        "XC 15-45MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-3",
+      "lenses": [
+        "Canon FD 35mm F2.0",
+        "fujifilm xf 18-55mm f/2.8-4.0",
+        "fujinon 18-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-30",
+      "lenses": [
+        "Sigma 56mm f1.4",
+        "sigma 56mm f1.4",
+        "xc 35mm f2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-30 II",
+      "lenses": [
+        "XC35MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT-4",
+      "lenses": [
+        "18-55 mm",
+        "18-55mm",
+        "XF 16-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT200",
+      "lenses": [
+        "15-45mm",
+        "KIT 15-45"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT3",
+      "lenses": [
+        "16-55",
+        "35",
+        "35mm",
+        "7Artisans Vision Cine Lens 25mm T1.05",
+        "7Artisans Vision CineLens 35mm T1.05",
+        "Canon FD 24mm f2 + Metabones Speedbooster",
+        "Canon FD 28mm F2.0",
+        "Canon FD 35mm f2 + Metabones Speedbooster",
+        "Canon FD 50mm 1.4 + Metabones Speedboster",
+        "Canon FD 85mm 1.8 + Metabones Speedbooster",
+        "Canon fd 50mm 1.4",
+        "FUJINON 23 F2",
+        "FujiX 18-55",
+        "VILTROX AF 13mm F1.4 XF",
+        "Viltrox 23mm f1.4",
+        "sigma18-35",
+        "viltrox 13f1.4",
+        "viltrox 85mm 1.8",
+        "xc35mm"
+      ],
+      "crop_factor": 1.77,
+      "sensor_size": "Micro Four Thirds",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT30",
+      "lenses": [
+        "xc15-45"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT4",
+      "lenses": [
+        "16-55 (16)",
+        "Viltrox 13mm 1.4",
+        "XF 18-55",
+        "XF 18mm f/1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Fujifilm",
+      "model": "XT5",
+      "lenses": [
+        "23 1.4",
+        "Tamron 18-300 18mm F4",
+        "XF ZOOM 16-80"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "fujitsu",
+      "model": "F-52A",
+      "lenses": [
+        "広角"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "fujitsu",
+      "model": "f52a",
+      "lenses": [
+        "27mm",
+        "広角",
+        "超広角",
+        "通常広角"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Gadnic",
+      "model": "Extreme 13",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Garmin",
+      "model": "Virb Ultra 30",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Garmin",
+      "model": "Virb Ultra30",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Garmin",
+      "model": "Virb XE",
+      "lenses": [
+        "Standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "General Mobile",
+      "model": "GM22 pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "General Mobile",
+      "model": "GM22Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GhostStop",
+      "model": "Phasm Cam",
+      "lenses": [
+        "Unknown"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Gitup",
+      "model": "Git2P",
+      "lenses": [
+        "90 degree"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 3 XL",
+      "lenses": [
+        "Open Camera, no zoom, 4K"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4 XL",
+      "lenses": [
+        "MotionCam"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4a",
+      "lenses": [
+        "28mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4a 5g",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 4XL",
+      "lenses": [
+        "4k+"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 6",
+      "lenses": [
+        "24mm",
+        "Main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 6 Pro",
+      "lenses": [
+        "17mm",
+        "17mm ultrawide",
+        "Main Camera",
+        "Main Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 6a",
+      "lenses": [
+        "28mm main",
+        "Main 28mm",
+        "Sony a7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7",
+      "lenses": [
+        "25mm",
+        "Rear",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7 25mm",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "pixel 7 main",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7 Pro",
+      "lenses": [
+        "1/25mm",
+        "121 mm",
+        "14mm",
+        "25mm",
+        "5x Telephoto",
+        "Anamorphic 1.55x",
+        "Main Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7 Pro 12MP Ultrawide",
+      "lenses": [
+        "13.4mm f/2.2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 7A",
+      "lenses": [
+        "14mm",
+        "26mm",
+        "53mm",
+        "Main",
+        "Main Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 8",
+      "lenses": [
+        "25mm",
+        "Main",
+        "pixel 25 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Google",
+      "model": "Pixel 8 Pro",
+      "lenses": [
+        "115mm Telephoto",
+        "13mm",
+        "1x",
+        "25mm",
+        "Primary",
+        "Telephoto (10x)",
+        "Telephoto (5x)",
+        "Wide (1x)",
+        "tele"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPlus CamPro",
+      "model": "4K Sports Ultra HD DV",
+      "lenses": [
+        "170"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO (2014)",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO 2018",
+      "lenses": [
+        "Factory Default"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO_2024",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO 3+black",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO 4 Session",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO Session",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO10 Black",
+      "lenses": [
+        "Anamorphic 1.212",
+        "Anamorphic 1.2121x",
+        "Kase 1.33x Anamorphic Lens",
+        "Linear",
+        "Max",
+        "Max Wide",
+        "Narrow",
+        "Wide"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO11 Black",
+      "lenses": [
+        "Linear",
+        "Linear + anamorph",
+        "Max Wide",
+        "Narrow",
+        "Wide",
+        "Wide + Neweer Anamorphic 1.33x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO11 Black Mini",
+      "lenses": [
+        "Linear",
+        "Max Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO12 Black",
+      "lenses": [
+        "Hyperview",
+        "Max",
+        "Max Lens 2.0",
+        "Max Wide",
+        "MaxLensMOD2.0",
+        "MaxLensMOD2.0Wide",
+        "MaxLensMod2.0",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO13 Black",
+      "lenses": [
+        "Superview",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO2014",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Hero3",
+      "lenses": [
+        "NOSE",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Hero3+Black",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO3+ Silver",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO4",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO4 Black",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO4 Session",
+      "lenses": [
+        "GRAN ANGULAR",
+        "Wide",
+        "by FredoxFpv"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO4 Silver",
+      "lenses": [
+        "WIDE"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Hero5(2018)",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO5 Black",
+      "lenses": [
+        "4:3",
+        "Linear",
+        "Medium",
+        "Narrow",
+        "Superview",
+        "Wide",
+        "Wide 2.7k 60fps",
+        "超宽"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO5 Black (FW-hacked Hero 2018)",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO5 Session",
+      "lenses": [
+        "Linear",
+        "Medium",
+        "Narrow",
+        "Superview",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO6 Black",
+      "lenses": [
+        "Linear",
+        "Superview",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7 Black",
+      "lenses": [
+        "Linear",
+        "Superview",
+        "WW",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7 Silver",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO7 White",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO8 Black",
+      "lenses": [
+        "Linear",
+        "Narrow",
+        "Superview",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO9",
+      "lenses": [
+        "SkyReat Anamorphic"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "HERO9 Black",
+      "lenses": [
+        "Anomorphic 16/9",
+        "Linear",
+        "Max",
+        "Max Lens Wide",
+        "Max Wide",
+        "Max lens Wide",
+        "Narrow",
+        "UltraWide",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Max",
+      "lenses": [
+        "Linear",
+        "Max",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Session",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Session 4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "GoPro",
+      "model": "Session4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Goxtreme",
+      "model": "enduro black",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Goxtreme",
+      "model": "Vision+",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "H7S",
+      "model": "V50 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Happymodel",
+      "model": "Mobula7 HD",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hasselblad",
+      "model": "EQV",
+      "lenses": [
+        "2.8 28mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "鹰眼裸狗",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "2k",
+      "lenses": [
+        "Hawkeye/Thumb2K5_16_9_50fps.json"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "鹰眼4K卡录",
+      "lenses": [
+        "WIDE"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "4K split",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly 6S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly 8SE",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly micro 2",
+      "lenses": [
+        "Micro2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly naked II",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Q6",
+      "lenses": [
+        "120 deg",
+        "170"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "firefly Split",
+      "lenses": [
+        "170'",
+        "170FOV"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Split 4K",
+      "lenses": [
+        "Hawkeye/HawkeyeNaked2K5_16_9_50fps.json"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Split Mini 4K",
+      "lenses": [
+        "Foxeer M12 1.7mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Split v4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly V2",
+      "lenses": [
+        "2.8 160 DEGREE"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly Whoop Split",
+      "lenses": [
+        "165 degrees"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly X Lite",
+      "lenses": [
+        "150",
+        "Sony",
+        "Ultra Wide",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Firefly X Lite II",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "FireFlyV4",
+      "lenses": [
+        "V50X"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "FireflyXLite II",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Hawkeye",
+      "lenses": [
+        "Hawkeye/HawkeyeNaked2K5_4_3_50fps.json",
+        "Hawkeye/Thumb2K5_16_9_50fps.json",
+        "Hawkeye/Thumb2K5_4_3_50fps.json",
+        "HawkeyeTh1080P_16_9_30fpsN.json"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked",
+      "lenses": [
+        "Hawkeye/HawkeyeNaked1080P_16_9_50fps.json",
+        "Hawkeye/HawkeyeNaked2K5_16_9_50fps.json",
+        "Hawkeye/HawkeyeNaked4K_16_9_30fps.json"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked 4K",
+      "lenses": [
+        "170"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked/Split",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Naked4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Split 4K mini",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Split Cam 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "SplitCam4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "SplitV5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Thumb",
+      "lenses": [
+        "Hawkeye/Thumb1080P_16_9_50fps.json",
+        "Hawkeye/Thumb2K5_16_9_50fps.json",
+        "Hawkeye/Thumb2K5_4_3_30fps.json",
+        "Hawkeye/Thumb2K5_4_3_50fps.json",
+        "Hawkeye/Thumb4K_16_9_30fps.json",
+        "标准镜头"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "THUMB 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "Thumb2",
+      "lenses": [
+        "Hawkeye/Thumb2K5_4_3_50fps.json",
+        "Hawkeye_Thumb2.json"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Hawkeye",
+      "model": "卡录V4.0",
+      "lenses": [
+        "SONY 12MP"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HDZero",
+      "model": "HDZero_Nano",
+      "lenses": [
+        "Default"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Holy Stone",
+      "model": "HS510",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HolyStone",
+      "model": "HolyStone 360s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "20 pro",
+      "lenses": [
+        "Sony IMX586"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "70 pro",
+      "lenses": [
+        "Sony IMX800"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "80",
+      "lenses": [
+        "27"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "8x Sony",
+      "lenses": [
+        "Fix"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "90",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "荣耀90gt",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "honor",
+      "model": "9i",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "honor",
+      "model": "ANP-AN00",
+      "lenses": [
+        "1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "M5P",
+      "lenses": [
+        "24mm",
+        "94mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor",
+      "model": "X7b Rear Main Camera",
+      "lenses": [
+        "24mm f/1.75 ASPH"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Honor 80",
+      "model": "Honor 80",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HP",
+      "model": "AC 100",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HP",
+      "model": "ac100",
+      "lenses": [
+        "none"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "10s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "40p",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate",
+      "lenses": [
+        "x7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mate 10Pro",
+      "lenses": [
+        "Leica"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate 40pro+",
+      "lenses": [
+        "超广角"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate 50 pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate 50pro",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mate 60 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate30",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate50 pro",
+      "lenses": [
+        "1.0X"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "mate50pro",
+      "lenses": [
+        "miancamer"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mate60 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "HUAWEI",
+      "model": "MATEPAD11",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "MateX2",
+      "lenses": [
+        "Rear",
+        "RearCamera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "meta 50 pro 1x",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "meta40pro",
+      "lenses": [
+        "Octa-PD"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Mets40pro华为",
+      "lenses": [
+        "华为"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Nova 2i RNE-L22",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "nova 7i",
+      "lenses": [
+        "unknown"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "Nova7",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P20",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P20 Pro",
+      "lenses": [
+        "Leica"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P30",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p30 pro",
+      "lenses": [
+        "Wide Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P30pro main_F1.6",
+      "lenses": [
+        "f1.6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p40",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P40 1.0",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P40 Pro",
+      "lenses": [
+        "Laica"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p40 sx",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p50",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P50PRO",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60",
+      "lenses": [
+        "4k",
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60 Pro",
+      "lenses": [
+        "4x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p60 pro main",
+      "lenses": [
+        "Sony"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "p60 pro sony main lens",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60PRO",
+      "lenses": [
+        "75mm4K"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P60pro 4K24mm",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Huawei",
+      "model": "P8 Lite 2017",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "huawei",
+      "model": "P9",
+      "lenses": [
+        "leica"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "IconnTechs",
+      "model": "4K Ultra HD",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "iFlight",
+      "model": "GOCam GR",
+      "lenses": [
+        "Sony IMX577 12MP 1/2.3”"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "iFlight",
+      "model": "GOCam PMGR",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Infinix",
+      "model": "Open Camera",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "infinix hot 30",
+      "model": "infinix hot 30",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta Titan",
+      "model": "Insta Titan",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "Ace",
+      "lenses": [
+        "LinearHorizon 75",
+        "Pov 111"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "Ace Pro",
+      "lenses": [
+        "Pov 111",
+        "Pov 113",
+        "Ultra",
+        "Ultrawide 109"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "EVO",
+      "lenses": [
+        "Unknown"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "Go",
+      "lenses": [
+        "Unknown",
+        "fisheye"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "GO 2",
+      "lenses": [
+        "Linear",
+        "Narrow",
+        "Pov",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "GO 3S",
+      "lenses": [
+        "Ultrawide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "ONE R",
+      "lenses": [
+        "1 inch",
+        "1-inch Wide F3.2 14.4mm",
+        "4K"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "ONE RS",
+      "lenses": [
+        "4K BOOST"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "One RS 1-Inch 360 Edition",
+      "lenses": [
+        "Ultrawide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "ONE X2",
+      "lenses": [
+        "Ultrawide 137",
+        "Ultrawide 148"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "OneR",
+      "lenses": [
+        "1-inch",
+        "1-inch Ultrawide 110",
+        "15mm olympus MFT",
+        "1inch",
+        "1inch (Linear)",
+        "4K",
+        "4K_Backbone_F0.95-6mm-1x2.7in",
+        "4k",
+        "6mm Laowa MFT Cine 5k",
+        "Leica F3.2 14.4mm",
+        "Linear 58",
+        "Linear 64",
+        "Linear 94",
+        "Ultrawide",
+        "Ultrawide 104",
+        "Ultrawide 110",
+        "Ultrawide 64",
+        "Ultrawide 80",
+        "Ultrawide 88",
+        "Ultrawide 96",
+        "Wide 68",
+        "Wide 76",
+        "Wide 98",
+        "Zeiss Tevidon 10mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "OneR 1inch",
+      "lenses": [
+        "Ultrawide 110"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "OneRS",
+      "lenses": [
+        "1 inch mod",
+        "1inch",
+        "1inch 5.7K",
+        "1inch 5.7k",
+        "1inch 6K wide",
+        "4K BOOST 16:9",
+        "4K BOOST 4:3",
+        "4K BOOST 6K",
+        "4K Boost",
+        "4K Boost Lens (Ultrawide 104)",
+        "4k BOOST LENS",
+        "4k boost lens",
+        "5K25 10mm MFT Laowa",
+        "5k25",
+        "5k25 7.5mm Laowa MFT",
+        "Leica 1\" Ultrawide 80",
+        "Leica 1inch",
+        "Linear 66",
+        "Linear 88",
+        "Ultrawide 104",
+        "Ultrawide 110",
+        "Ultrawide 80",
+        "Ultrawide 88",
+        "Ultrawide 88 (4K Boost Lens)",
+        "Ultrawide 96",
+        "Unknown1 104",
+        "Wide 86"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "SMO 4K",
+      "lenses": [
+        "Standard",
+        "Ultrawide",
+        "Ultrawide 104",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Insta360",
+      "model": "X4",
+      "lenses": [
+        "X4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "iqoo",
+      "model": "10",
+      "lenses": [
+        "23mm 1×"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "IQOO",
+      "model": "Z9 Turbo",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "IQOO 9",
+      "model": "26MM",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Iqoo Z3",
+      "model": "Samsung ISOCELL GW3 sensor",
+      "lenses": [
+        "26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "IZI",
+      "model": "ONE",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "JJRC X5",
+      "model": "2K Epik",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "JVC",
+      "model": "GY-HM180U",
+      "lenses": [
+        "4.6MM-56MM 1:1.2~3.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "KF102",
+      "model": "KF102",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "Mavo 8k",
+      "lenses": [
+        "35",
+        "45",
+        "55",
+        "80"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "Mavo Edge",
+      "lenses": [
+        "Dulens 31"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "MAVO LF",
+      "lenses": [
+        "35MM + OPTEX 0.5",
+        "35MM MAMIYA",
+        "Samyang 24mm t1.5",
+        "Samyang 50mm F1.4",
+        "sanyang 35 1.4",
+        "takumar 35mm f2.0"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Kinefinity",
+      "model": "TERRA 4K",
+      "lenses": [
+        "DULENS 31mm",
+        "TOKINA 11-16mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "kinefinity",
+      "model": "Terra4K",
+      "lenses": [
+        "canonEF24-105(24mm)",
+        "canonEF24-105(50mm)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lamax",
+      "model": "X8 Electra",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LAMAX",
+      "model": "X9.1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lamax",
+      "model": "X9.2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "Q3",
+      "lenses": [
+        "28mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LEICA",
+      "model": "SL2",
+      "lenses": [
+        "SUPER VARIO ELMAR 16-35 ASPH"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Leica",
+      "model": "sl2-s",
+      "lenses": [
+        "dulens 58",
+        "dulens58+1.5x",
+        "leica 50/1.4+1.5x",
+        "leica m50+1.5",
+        "m50+1.5x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lenovo",
+      "model": "K6 Note",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Lenovo",
+      "model": "Mirage VR405",
+      "lenses": [
+        "VR180",
+        "fisheye"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "G8",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "LG G7 ThinQ",
+      "lenses": [
+        "Main camera f1.6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "V35",
+      "lenses": [
+        "16mm",
+        "Main 31mm f1.6",
+        "Wide 16mm",
+        "Wide 18mm f1.9"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "V40",
+      "lenses": [
+        "16mm 1.9",
+        "26mm 1.5",
+        "50mm 2.4",
+        "Main  26mm f1.5",
+        "Main 26mm",
+        "Tele 53mm",
+        "Tele 53mm f2.4",
+        "Wide 16mm f1.9"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "V50",
+      "lenses": [
+        "27mm",
+        "53mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "v50 27mm f1.5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG",
+      "model": "v60",
+      "lenses": [
+        "26mm",
+        "27mm",
+        "58mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "LG V30",
+      "model": "Motion cam",
+      "lenses": [
+        "Ultra Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Maginon",
+      "model": "AC-500",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "mate40pro",
+      "model": "mate40",
+      "lenses": [
+        "1X"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Matecam",
+      "model": "4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "MEIZU",
+      "model": "Note9",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "1S",
+      "lenses": [
+        "4.35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "ActionCam",
+      "lenses": [
+        "B"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "ActionCamera v2",
+      "lenses": [
+        "A2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "Maxi 4K",
+      "lenses": [
+        "A",
+        "Lens B",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "Mini V1",
+      "lenses": [
+        "B type (135°)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobius",
+      "model": "Mobius 1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Mobula",
+      "model": "7HD 1S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "MOMA",
+      "model": "探境",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Monster",
+      "model": "Monster FQ777 F8",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Morecam",
+      "model": "M9",
+      "lenses": [
+        "JK05"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge+",
+      "lenses": [
+        "Telephoto 84mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 20",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 20 Pro",
+      "lenses": [
+        "Câmera principal",
+        "Motion Cam",
+        "lente principal"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 2023",
+      "lenses": [
+        "25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge 40 Pro",
+      "lenses": [
+        "15mm",
+        "24mm",
+        "52mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Edge S Pro",
+      "lenses": [
+        "main 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "G100",
+      "lenses": [
+        "Main lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "g13",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "G41",
+      "lenses": [
+        "G41"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "g7 plus",
+      "lenses": [
+        "12px"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G Power",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G200",
+      "lenses": [
+        "lente principal"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G200 5G",
+      "lenses": [
+        "25 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G60s",
+      "lenses": [
+        "1x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G72",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto G8 Power Omnivision OV16E10",
+      "lenses": [
+        "Main wide camera 28mm ƒ/ 1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "Moto One Fusion+",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "moto X30 Pro",
+      "lenses": [
+        "23 f/1.95"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Motorola",
+      "model": "RAZR 2023",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "My GEKO Gear",
+      "model": "ORBIT 960",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "NECKER",
+      "model": "v5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "NICEBOY",
+      "model": "VEGA",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Niceboy",
+      "model": "VEGA 6",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "niceboy",
+      "model": "vega x play",
+      "lenses": [
+        "all-glass, 170°"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "1-J2",
+      "lenses": [
+        "11-27.5mm f3.5-5.6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "170",
+      "lenses": [
+        "800"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "24-120",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "62",
+      "lenses": [
+        "501.2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "7200",
+      "lenses": [
+        "140mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "810",
+      "lenses": [
+        "2470"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix b500",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "COOLPIX P900",
+      "lenses": [
+        "2000 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Coolpix P950",
+      "lenses": [
+        "1000mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "CoolPix W300",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D 3300",
+      "lenses": [
+        "DX 18-105 f3.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D-750",
+      "lenses": [
+        "Nikon 24-120 F4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3100",
+      "lenses": [
+        "DX18-55mm",
+        "NIKKOR 18mm",
+        "Nikkonor AF 85mm",
+        "Nikkor 50mm 1.8",
+        "Nikon AF-S  DX NIKKOR 18-55mm 1:3.5-5.6G VR"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "d3200",
+      "lenses": [
+        "AF-S 18-55",
+        "AF-SNIKKOR 55-200",
+        "AF-SNIKKOR55-200",
+        "NIKON DX 18-55",
+        "nikkor"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3300",
+      "lenses": [
+        "18-55mm",
+        "NIKKOR 50MM",
+        "af-s 18-55"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3400",
+      "lenses": [
+        "AF-P NIKKOR 18-55mm",
+        "Nikkor 18-55mm 1:3.5-5.6G",
+        "Tamron"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D3500",
+      "lenses": [
+        "Sigma 50mm F1.8",
+        "af-p nikkor 18-55 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D500",
+      "lenses": [
+        "Nikkor 35mm 1.8g DX"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5100",
+      "lenses": [
+        "Meike Optics MK 8mm f3.5",
+        "Nikkor",
+        "Nikkor 35mm F/1.8",
+        "SWM VR ED IF67",
+        "Tamron Aspherical"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5200",
+      "lenses": [
+        "18-55mm",
+        "AF-S DX NIKKOR\n18-55mm f/3.5-5.6G VR",
+        "DX AF-S KIKKOR 18-55mm 1:3.5-5.6G VR SWM",
+        "Kit 18-55mm",
+        "Tamron 24-70mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5300",
+      "lenses": [
+        "50 mm f1.8",
+        "50mm 1.8G",
+        "AF-S DX NIKKOR 18-140mm VR",
+        "AF-S Nikkor 18-55 DX VR",
+        "AFP 18-55 Nikkor",
+        "Helios",
+        "Nikkor 18-55 AFP"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5500",
+      "lenses": [
+        "18-55",
+        "Sigma 17-50mm f2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D5600",
+      "lenses": [
+        "AF-S DX NIKKOR 18-140MM",
+        "AF-S Nikkor 18-140mm DX VR"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D610",
+      "lenses": [
+        "NIKON AFS 24-70mm @ 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "d7000",
+      "lenses": [
+        "AF-S NIKKOR 18-105mm1* 3.5-5.6G ED",
+        "AF-S Nikkor 18-105mm 1*3.5-5.6 ED",
+        "AF-S Nikkor 35mm 1:1.8G",
+        "vr 18-105"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D7100",
+      "lenses": [
+        "16-85mm",
+        "Nikkor 1:4-5.6G",
+        "Nikkor 55 - 200mm 1:4-5.6 GED VR",
+        "Nikkor AF 50 mm 1:18 D",
+        "Nikkor AF-S 35mm 1:1 8G",
+        "TOKINA SD 11-16 f.2.8 (IF) DXII"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D7200",
+      "lenses": [
+        "18-105 f/3.5-5.6G",
+        "50mm",
+        "AF NIKKOR 50mm f/1.8D",
+        "AF-S 18-140mm f3.5-5.6G VR",
+        "DX 18-105"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D750",
+      "lenses": [
+        "24-85"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D7500",
+      "lenses": [
+        "16-80 f2.8-4E @ 24mm",
+        "17-55mm f/2.8",
+        "50MM 1.8",
+        "AF-S DX NIKKOR\n18-140mm f/3.5-5.6G ED VR",
+        "Sigma 18-35 F1.8 @ 18mm",
+        "TAMARON 10 24",
+        "nikon 16-80",
+        "sigma 18-35 f1.8 @ 18mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D780",
+      "lenses": [
+        "Tamron 35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D800",
+      "lenses": [
+        "24-120mm f4 @ 120mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "d810",
+      "lenses": [
+        "24-70",
+        "24-70/2.8G",
+        "24-70/f2.8",
+        "70-300mm f4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "D850",
+      "lenses": [
+        "24-70 2.8 ED NIKKOR",
+        "24-70 2.8 G ED",
+        "24-70 2.8G ED",
+        "24-70s 2.8",
+        "35mm",
+        "Nikon 14-24"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "j",
+      "lenses": [
+        "10mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Keymission 120",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "KeyMission 170",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Nikon 5100",
+      "lenses": [
+        "Nikon 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "NIKON Z5",
+      "lenses": [
+        "40mm f2",
+        "VITROX 85mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "NIKON Z6",
+      "lenses": [
+        "NIKON Z 24-70 F4S"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "p950",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z 50",
+      "lenses": [
+        "z 16-50"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z 6",
+      "lenses": [
+        "AF Nikkor 35-70mm F2.8 D",
+        "Sigma 35mm F1.4 A"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z 6 II",
+      "lenses": [
+        "28mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z 6II",
+      "lenses": [
+        "Nikon 35 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z 8",
+      "lenses": [
+        "NIKKOR Z24-70 F2.8 S",
+        "Nikon AF-S Nikkor 14-24mm f/2.8G ED 14mm",
+        "Nikon AF-S Nikkor 14-24mm f/2.8G ED 24mm",
+        "Nikon AF-S Nikkor 50mm f/1.8G",
+        "SIGMA 85mm f/1.4 DG HSM Art",
+        "TAMRON SP 35mm F/1.4 Di USD",
+        "Z 24-120mm F4(24mm)",
+        "z 24-120 f4.0s",
+        "z 24-70 f2.8s"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z fc",
+      "lenses": [
+        "Sigma 16mm f/1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z30",
+      "lenses": [
+        "12-28mm @ 12mm",
+        "12-28mm @ 28mm",
+        "16-50 DX",
+        "16-50mm @ 16mm",
+        "18-140",
+        "18-140mm @ 18mm",
+        "24-70f4s",
+        "24mm 1.7",
+        "35mm",
+        "35mm 1.8",
+        "75mm",
+        "DX 12-28 F3.5-5.6",
+        "DX 16-50",
+        "DX 16-50mm",
+        "DX12-28 F3.5-5.6",
+        "Nikkor 35mm",
+        "Nikkor40mm",
+        "SIGMA 18-35",
+        "Sigma 30mm 1:1.4 DC DN",
+        "Sigma 56mm",
+        "TTArtisan AF 27/2.8",
+        "Viltrox 33mm",
+        "Z DX 12-28mm f/3.5-5.6 PZ VR",
+        "Z12-28",
+        "Z16-50mm @ 16mm",
+        "Z35mm 1.8",
+        "Z50-250mm @ 50mm",
+        "nikon50-250",
+        "v 56mm",
+        "viltrox 27mm f1.2"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z30 DX",
+      "lenses": [
+        "Z 40mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z5",
+      "lenses": [
+        "14-30",
+        "24-70",
+        "24-70f4",
+        "AF-S NIKKOR 35mm 1:1.8G",
+        "AF-S NIKKOR 50MM 1:1.4G",
+        "AF-S NIKKOR 5MM 1:1.4G",
+        "Z 24-200mm",
+        "z 24-70 f4s"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z50",
+      "lenses": [
+        "40/2",
+        "Laowa 9mm F2.8",
+        "NIKKOR 16-50 f/3.5-6.3",
+        "NIKKOR Z DX 16-50mm f/3.5-6.3",
+        "Viltrox 13mm f1.4 Z",
+        "Z DX 18-140"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z6",
+      "lenses": [
+        "14-30 F4S",
+        "14-30mm F4S",
+        "14-30mm f4s @ 14mm",
+        "16-35mm Nikkor",
+        "24-70 F4",
+        "2470F4",
+        "2470f4",
+        "28.mm",
+        "28mm",
+        "28mm 1:2.8",
+        "35mm/f1.8",
+        "AF-S Nikkor 50mm 1.8 G",
+        "Irix 15mm f2.4",
+        "NIKKOR Z 14-30mm f/4 S Lens",
+        "Nikkor 28mm/2.8",
+        "Nikkor 50mm 1:1.8 G",
+        "Nikkor DX 16-50 3.5-6.3",
+        "Nikkor S 20mm",
+        "Nikkor S 20mm f1.8 S",
+        "Nikkor S 24 - 70",
+        "Nikkor Z 24-70 F/4",
+        "Nikkor Z 24-70 f2.8 @24mm",
+        "Nikkor Z 24-70 f2.8 @35mm",
+        "Nikkor Z 24-70mm",
+        "Nikkor Z 24-70mm@70mm",
+        "Nikkor Z35s 1.8",
+        "Nikon 14-30/4 S",
+        "Samyang 12mm",
+        "Sony FE 1.4/24 GM",
+        "Sony FE 24mm/1.4 GM",
+        "ZEISS 21/2.8",
+        "nikon 24 mm 2.8D",
+        "z 14_24 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z6 I",
+      "lenses": [
+        "Nikkor 50mm 1.4 G",
+        "Nikkor 50mm f1.4 G"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z6 II",
+      "lenses": [
+        "24-200",
+        "24-70mm @ 24mm",
+        "24-70mm @ 70mm",
+        "35 1.8",
+        "35 1.8S",
+        "NIKKOR 20mm/2.8D",
+        "Z 28-75 f2.8",
+        "Z 85 f1.8",
+        "Z24-70mm f2.8 @ 24mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z62",
+      "lenses": [
+        "24-70f4",
+        "24200",
+        "50 1.4G",
+        "501.8s",
+        "Nikkor 24-120",
+        "z501.8s",
+        "尼康24-200f4-6.3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z6ii",
+      "lenses": [
+        "14-30mm",
+        "24-200@24/4-6.3",
+        "36mm Viltrox f1.8",
+        "7Artizan 12mm T2.9",
+        "Nikkor 28mm 2,8",
+        "Nikkor Z 24-70/4@24mm",
+        "Nikkor Z 35 mm 1.8",
+        "SWM VR ED IF 16-35mm",
+        "Sigma 14-24mm f2.8 @ 14mm",
+        "z254-120"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "z7",
+      "lenses": [
+        "24-70",
+        "Nikon Z6 14-30mm",
+        "Tamron 24-70",
+        "Tokina 16-28"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z7i",
+      "lenses": [
+        "Sigma"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z7ii",
+      "lenses": [
+        "14-30",
+        "24-70 F4",
+        "NIKKOR 24-70",
+        "z 24-70 f4",
+        "z24 70 F4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z8",
+      "lenses": [
+        "24-120 F4",
+        "24-70/F4",
+        "28-75(28)FX",
+        "28-75(28DX)",
+        "50mm 1.2s",
+        "70-200",
+        "NIKKOR Z 14-24mm f/2.8 S",
+        "NIKKOR z24-70 F2.8s",
+        "Nikkor 24-120mm f4 S @ 35mm",
+        "Nikkor z27-70 F2.8s",
+        "Z 600mm f/6.3 VR S",
+        "Z24-702.8S",
+        "nikkor 14-30",
+        "sirui 50mm",
+        "z 24-120 f4.0",
+        "深光 35mm F0.95",
+        "深光 35mm f0.95"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "Z9",
+      "lenses": [
+        "105f2.8G",
+        "14-30",
+        "Nikkor Z 24-70 f2.8 @ 24mm",
+        "Z 35mm F1.8",
+        "Z 50mm F1.8",
+        "Z105mm",
+        "z 24-120 f4.0",
+        "z24-120mm @ 24mm",
+        "z35mm 1.8",
+        "z85mm 1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "ZF",
+      "lenses": [
+        "Nikkor Z 24-70 f4 S @ 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "zf c",
+      "lenses": [
+        "nikkor Z DX 16-50mm f/3.5-6.3 VR"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nikon",
+      "model": "ZFC",
+      "lenses": [
+        "Viltrox 13mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nokia",
+      "model": "1020",
+      "lenses": [
+        "PureView",
+        "PureView 41MPix"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nokia",
+      "model": "7 Plus",
+      "lenses": [
+        "Main lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nothing",
+      "model": "Phone",
+      "lenses": [
+        "15mm",
+        "25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nothing",
+      "model": "Phone 1",
+      "lenses": [
+        "IMX776"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nova7",
+      "model": "Nova7",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Novatek",
+      "model": "96675",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Nubia",
+      "model": "NX721J",
+      "lenses": [
+        "36"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "NWO JAPAN",
+      "model": "Generation Pro",
+      "lenses": [
+        "IMX 368"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ODRVM",
+      "model": "1080P Wifi",
+      "lenses": [
+        "6G"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ODRVM",
+      "model": "Action Cam",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "E-M1 II",
+      "lenses": [
+        "Olympus 12-40mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "M10 MARK IV",
+      "lenses": [
+        "LUMIX LEICA 9mm",
+        "Lumix Leica 9mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-5",
+      "lenses": [
+        "12-40mm f2.8",
+        "17mm f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-D 10 MARK III",
+      "lenses": [
+        "M.ZUIKO 14-42"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-D E-M10 Mark III",
+      "lenses": [
+        "Olympus M.Zuiko Digital ED 40-150mm f/4-5.6 R @ 40mm"
+      ],
+      "crop_factor": 2.0,
+      "sensor_size": "Micro Four Thirds",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OLYMPUS",
+      "model": "OM-D EM 10 MARK IIIS",
+      "lenses": [
+        "ZUIKO 14-42 IIR",
+        "ZUIKO 45MM 1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OM-D Mark 3s",
+      "lenses": [
+        "M.Zuiko 14-42"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OMD 10 mark III",
+      "lenses": [
+        "M.ZUIKO 14-42 IIR"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OMD EM-10 Mk. III",
+      "lenses": [
+        "ZUIKO 45mm 1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "OMD mark II",
+      "lenses": [
+        "SIGMA 16mm F1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "Stylus 1s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Olympus",
+      "model": "TG-6",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OmniVision",
+      "model": "ov16a1q_i_aac",
+      "lenses": [
+        "ov16a1q_i_aac"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "11",
+      "lenses": [
+        "25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "11 CPH2451",
+      "lenses": [
+        "25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "12r",
+      "lenses": [
+        "17mm",
+        "25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "5T",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "6T",
+      "lenses": [
+        "Default lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "7",
+      "lenses": [
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "7 PRO",
+      "lenses": [
+        "Main sensor"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "7T",
+      "lenses": [
+        "1x",
+        "Motioncam",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "8",
+      "lenses": [
+        "Sony IMX 586"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "8 Pro",
+      "lenses": [
+        "13mm",
+        "26 mm",
+        "26mm",
+        "Main",
+        "Wide lens 26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "8T",
+      "lenses": [
+        "grand angle"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9 Pro",
+      "lenses": [
+        "24 mm Main camera",
+        "24mm",
+        "81 mm Tele",
+        "Main Lens",
+        "Medium",
+        "MotionCam Primary 24mm",
+        "Primary"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9 pro Film mode",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "9T",
+      "lenses": [
+        "Mobile/wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "oneplus",
+      "model": "ace3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "HD1913",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ONEPLUS",
+      "model": "IZI",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord 1",
+      "lenses": [
+        "Wide(x1)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord 2",
+      "lenses": [
+        "Main 23mm f/1.88"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oneplus",
+      "model": "Nord 2 5G FHD OpenCamera Sensors",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord 2T",
+      "lenses": [
+        "Sony IMX 355"
+      ],
+      "crop_factor": 0.6,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord CE2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Nord N10",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "OnePlus 5",
+      "lenses": [
+        "Main camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "OnePlus 8 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Oneplus 9 Pro",
+      "lenses": [
+        "23mm Main Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OnePlus",
+      "model": "Open",
+      "lenses": [
+        "24mm",
+        "OnePlusOpen",
+        "Oneplus Open"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "A15",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "A16",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "A74 4G",
+      "lenses": [
+        "Oppo"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Find X 6 Pro",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "Find X2 Pro",
+      "lenses": [
+        "26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Find X5 pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "findx6 主摄",
+      "lenses": [
+        "主摄"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "IQOO",
+      "lenses": [
+        "12"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "K9X",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "PHY110",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "reno 10",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Reno 4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Reno 4 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Oppo",
+      "model": "Reno 6 5G",
+      "lenses": [
+        "Main lens",
+        "x0.6 film mode"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "reno5",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "X6 pro 24mm",
+      "lenses": [
+        "24mm_4 x 3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "OPPO",
+      "model": "X7U",
+      "lenses": [
+        "23mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Orion",
+      "model": "819L",
+      "lenses": [
+        "sony"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Overmax",
+      "model": "X-Bee drone 9.5 fold",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "AG-DVX200",
+      "lenses": [
+        "Leica Dicomar",
+        "Leica dicomar"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BGH-1",
+      "lenses": [
+        "Laowa MFT 7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BGH1",
+      "lenses": [
+        "DJI",
+        "H-F007014 7-14mm",
+        "H-H025K",
+        "LAOWA 7.5 C-Dreamer",
+        "LAOWA 7.5 mm C-DREAMER",
+        "LAOWA 7.5mm f/2 MFT",
+        "Laowa",
+        "Laowa 10mm MFT",
+        "Laowa 10mm Zero D",
+        "Laowa 17mm 1.8 MFT",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm - F2",
+        "Laowa 7.5mm f/2 MFT",
+        "Leica 10-25mm F1.7 @10mm",
+        "Leica 15mm DG SUMMILUX",
+        "Leica 9mm",
+        "Lumix 12-35",
+        "Lumix 12-35@12mm",
+        "Olympus 12mm",
+        "Olympus 8-18@14",
+        "Olympus 9-18 @9mm",
+        "Olympus 9-18@14",
+        "Olympus 9mm",
+        "SAMYANG 7.5mm FISHEYE",
+        "Samyang 12mm",
+        "Sirui Anamorphic 24mm",
+        "slrmagic 8mm"
+      ],
+      "crop_factor": 2.0,
+      "sensor_size": "Micro Four Thirds",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BGH6",
+      "lenses": [
+        "LAOWA 9MM T2.9 CINE"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "BS1H",
+      "lenses": [
+        "16-35",
+        "Laowa 14mm",
+        "Sigma 20mm DN NG",
+        "Sigma 20mm f/2.0 DG DN Contemporary",
+        "sigma 20mm DN NG"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-BGH1",
+      "lenses": [
+        "Samyang/Rokinon - 12mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S5",
+      "lenses": [
+        "20-60mm f3.5-5.6",
+        "laowa 15mm f/4.5 zero-d shift"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DC-S5M2X",
+      "lenses": [
+        "Lumix S 50mm f/1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC-G7",
+      "lenses": [
+        "Lumix G Vario 14-42/F3.5-5.6 II ASPH"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "DMC GH4",
+      "lenses": [
+        "Lumix 14m"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "EVA1",
+      "lenses": [
+        "31mm Dulens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "FZ10002",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "FZ2000",
+      "lenses": [
+        "LEICA F2.8-4.5 24-480mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "FZ2500",
+      "lenses": [
+        "36"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "fz82",
+      "lenses": [
+        "lumix dc vario"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G 100",
+      "lenses": [
+        "G 12-32 f3.5-5.6",
+        "G vario 12-32 f3.5-5.6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G100",
+      "lenses": [
+        "12-60 12端",
+        "1260-12",
+        "Meike 35mm F1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "panasonic",
+      "model": "G7",
+      "lenses": [
+        "14mm",
+        "7artisans 7,5mm",
+        "Laowa 7.5mm",
+        "Olympus 17mm Pro",
+        "Panasonic Lumix H-H025",
+        "sigma 18-35",
+        "奥林巴斯40-150"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G70",
+      "lenses": [
+        "Standart Lens (includet)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G80",
+      "lenses": [
+        "12-60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G85",
+      "lenses": [
+        "12-60mm",
+        "12-60mm varrio",
+        "12mm f/3.5",
+        "Lumix 25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G9",
+      "lenses": [
+        "12-60mm",
+        "14mm",
+        "42.5mm f1.2 Panna  Leica",
+        "9mm Pana Leica DG H-X09",
+        "H-FS12060",
+        "H-NS043",
+        "H-X09",
+        "Laowa 7.5mm",
+        "Leica 12-60mm",
+        "Panasonic 25mm f/1.7",
+        "Panasonic 25mm f1.7",
+        "Panasonic Leica 15mm"
+      ],
+      "crop_factor": 2.0,
+      "sensor_size": "Micro Four Thirds",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G92",
+      "lenses": [
+        "奥林巴斯 17F1.2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "G95D",
+      "lenses": [
+        "H-FS12032"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GF15",
+      "lenses": [
+        "H-PS14042"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GHˆ",
+      "lenses": [
+        "12-40"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH-2",
+      "lenses": [
+        "Panasonic 15mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH2",
+      "lenses": [
+        "olympus 25 f1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH3",
+      "lenses": [
+        "14mm",
+        "25mm 1.7f",
+        "7-14",
+        "Olympus 12mm  84º",
+        "Venus Optics Laowa 7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH4",
+      "lenses": [
+        "20mm",
+        "25f1.8",
+        "7Artisans 12mm F2.8",
+        "H-FS4140",
+        "HH014 14 mm F2.5",
+        "LUMIX 14-42",
+        "LUMIX HD 14-42",
+        "Laowa 7.5mm",
+        "Laowa 9mm 2.8 Zero-D",
+        "Leica 12-60",
+        "Lumix 14mm",
+        "Lumix 25mm",
+        "Lumix 8mm",
+        "Lumix HD 14-42",
+        "Olympus 12mm",
+        "Olympus 45mm",
+        "Olympus Digital",
+        "Olympus Digital 24mm",
+        "Olympus M.ZUIKO 12mm",
+        "Samyang 12mm",
+        "Sigma 10-20mm 1:4-5.6",
+        "Sigma 18-35 Aputure Lens regain",
+        "Sigma 18-35mm Aputure Lens Regain",
+        "Sigma 18-35mm Aputure Lens regain",
+        "Tokina 11 16mm",
+        "Venus Optics Laowa 7.5mm F2.0",
+        "slr 8mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5",
+      "lenses": [
+        "12-40 2.8 pro",
+        "12-60mm",
+        "14mm",
+        "15mm",
+        "251.4+TPK-16Z",
+        "25MM",
+        "30mm Macro",
+        "7artisans 25mm",
+        "Canon 24-105 F4 L",
+        "HELIOS 44-2 58MM",
+        "LAOWA 7.5MM",
+        "LUMIX G X VARIO 12-35mm / F2.8 II ASPH. / POWER O.I.S.",
+        "LUMIX Leica DG Vario 12-60",
+        "Laowa",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm f2.0",
+        "Laowa 7.5mm f2.0 MFT",
+        "Leica 12-60",
+        "Leica DG Vario 12-60",
+        "Lumix 12-35",
+        "Lumix 12-35MM  2.8",
+        "Meike 6.5mm f2",
+        "Olimpus",
+        "Olympus 16mm_M.ZUIKO DIGITAL_ED 8mm f1.8_Fisheye PRO",
+        "Panasonic 12-60",
+        "SIRUI 35MM MFT",
+        "Samyang 7.5mm F3.5",
+        "Voigtlander 42,5",
+        "olympus",
+        "olympus 12-40 pro 2.8",
+        "olympus 50mm 1.8 + pixco",
+        "samyang 35mm f1.5",
+        "sigma 16mm",
+        "Гелиос 81Н F2.0 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5 II",
+      "lenses": [
+        "Laowa 7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5 m2",
+      "lenses": [
+        "Leica"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5M2",
+      "lenses": [
+        "LUMIX G VARIO 14-140/F3.5-5.6  14mm",
+        "LUMIX G VARIO 14-140F3.5-5.6  14mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH5S",
+      "lenses": [
+        "12-35 F2.8 M43",
+        "12-60",
+        "14-140",
+        "15mm",
+        "7.5mm laowa",
+        "7artisans  M43 25mm",
+        "Canon",
+        "LAOWA 7.5MM",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm f2.8",
+        "Laowa7.5mm f2.0",
+        "Lumix 12-35",
+        "Olympus 12-40mm f2.8",
+        "Olympus M.Zuiko",
+        "SIGMA DC 17-70 28mm",
+        "SLR 8mm",
+        "Samyang 14mm",
+        "Samyang 85mm F1.5",
+        "lumix 12-35",
+        "奥林巴斯1250",
+        "老蛙 6mm M43",
+        "老蛙 M43 18mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GH6",
+      "lenses": [
+        "12-35mm f/2.8 II ASPH POWER OIS LUMIX G X VARIO",
+        "12-35mm f2.8 II ASPH POWER OIS LUMIX G X VARIO",
+        "12-60",
+        "12-60 (12mm)",
+        "12mm",
+        "14-140 @ 14mm",
+        "18mm",
+        "25mm",
+        "25mm F1.4",
+        "HD12-35 @ 12mm",
+        "LAOWA 6mm",
+        "Laowa 10mm f/2 Zero-D MFT",
+        "Laowa 6 mm",
+        "Laowa 7.5 F2.0",
+        "Laowa 7.5mm F2.0",
+        "Laowa 7.5mm f/2 MFT",
+        "Leica 9mm",
+        "Leica Lumix 12-16",
+        "Lumix 9MM/1.7",
+        "Lumix G 25mm f/1.7 ASPH",
+        "Olympus 12-40mm f2.8 Pro",
+        "SLR8",
+        "Sigma 16mm f/1.4 DC DN Contemporary Lens (MFT)",
+        "Sigma 56mm F1.4 DC DN | C for MFT",
+        "Tamaron 11-16mm",
+        "YN25mm F1.7M",
+        "slr8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GX80",
+      "lenses": [
+        "Sigma 30mm 1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GX85",
+      "lenses": [
+        "12-60",
+        "12-60/3.5-5.6",
+        "7artisans 35mm",
+        "Laowa 7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "GX9",
+      "lenses": [
+        "8mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-1500X",
+      "lenses": [
+        "25-600"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-V785",
+      "lenses": [
+        "29.5mm wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-VX980",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-VX981K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-X1",
+      "lenses": [
+        "standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HC-X1500",
+      "lenses": [
+        "Leica Dicomar"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "HX A1H",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "lumix 300",
+      "lenses": [
+        "leica 1:2.8/4.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LUMIX DC-S5",
+      "lenses": [
+        "20-60mm",
+        "24-105",
+        "AstrHori 10mm F8",
+        "AstrHori 10mmF8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix DMC-G7",
+      "lenses": [
+        "Panasonic 14-42"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix G7",
+      "lenses": [
+        "25mm F1.7 ASPH",
+        "25mm f1.7",
+        "Lumix G 25mm F/1.7",
+        "OLYMPUS 12-50mm3.5-6.3",
+        "Olympus 12MM",
+        "Super-Takumar 35mm f3.5",
+        "Tele-Astranar 400mm f6.3",
+        "kit lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix G85",
+      "lenses": [
+        "50 mm",
+        "DJI 15mm",
+        "Lumix 12-60 1/3.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix G9",
+      "lenses": [
+        "14-140",
+        "7Artisans Vision 50mm T1.4 APSC",
+        "Leica Vario 12-60 f2.8",
+        "Olympus 9-18",
+        "Olympus M.Zuiko Digital 17 mm f/1.8",
+        "Sigma 30mm f1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH3",
+      "lenses": [
+        "Lumix 12-60",
+        "Lumix 20mm F1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH4",
+      "lenses": [
+        "45-175mm",
+        "Laowa 7.5mm MFT",
+        "Lumix 12-35",
+        "Olympus 9-18mm @ 9mm",
+        "meike 3,5mm",
+        "xiaoyi 42.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH4R",
+      "lenses": [
+        "Lumix 12-60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5",
+      "lenses": [
+        "12-35",
+        "25mm",
+        "Laowa 7.5mm",
+        "Leica 12 - 60",
+        "Leica 8-18",
+        "Lumix 15mm",
+        "Olympus 12-200",
+        "Panasonic Lumix G 25mm f/1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5 II",
+      "lenses": [
+        "Canon FD 50mm F/1.8",
+        "OM System 12 - 40mm 1:2.8 II Pro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5ii",
+      "lenses": [
+        "Leica DG 12-60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH5S",
+      "lenses": [
+        "11-16 MM",
+        "12-100",
+        "LUMIX G VARIO 12-35 12mm",
+        "Leica DG 10-25f1.7",
+        "Lumix 12-25",
+        "Lumix 12-35",
+        "Olympus 12-100"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GH6",
+      "lenses": [
+        "10-25",
+        "7Artisans 7.5mm",
+        "9MM/F1.7",
+        "9mm",
+        "Laowa 7.5",
+        "Panasonic Leica DG Summilux 9mm 1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GX5S",
+      "lenses": [
+        "Lumix G X Vario 12-35/2,8 II ASPH"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix GX80",
+      "lenses": [
+        "Olympus 12-40"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix gx9",
+      "lenses": [
+        "14-140 F3.5-5.6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix LX100",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S1",
+      "lenses": [
+        "SIGMA DC 18-50 (28mm)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S1H",
+      "lenses": [
+        "Sigma 24-70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5",
+      "lenses": [
+        "20 mm",
+        "20-60",
+        "50 mm",
+        "Lumix 20-60",
+        "Lumix 20-60mm",
+        "Lumix 2060-20",
+        "Lunix20-60",
+        "SIRUI NightWalker 35mm",
+        "Sigma 28-70mm F2.8 DG DN",
+        "TTArtisan-11mm(Fisheye)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LUMIX S5 II",
+      "lenses": [
+        "20-60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5 Mark 2",
+      "lenses": [
+        "20 - 60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LUMIX S52X",
+      "lenses": [
+        "Sigma 30mm f1.4 DC DN",
+        "Sigma f1.4 30mm DC DN"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5II",
+      "lenses": [
+        "Lumix 20-60mm",
+        "Lumix 35mm 1.8",
+        "Sigma 28-70",
+        "Sigma10-18(10)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lumix S5M2",
+      "lenses": [
+        "TTArtisan"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "Lx100",
+      "lenses": [
+        "Leica",
+        "Vario 1:1.7 - 2.8/10.9-34"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LX15",
+      "lenses": [
+        "25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "LX5",
+      "lenses": [
+        "leica"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "nv_gs280_mindv",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S1",
+      "lenses": [
+        "10mm",
+        "Canon 24-70 @ 35mm",
+        "Canon NFD 28mm",
+        "Lumix 20-60",
+        "Nikon Serie E 28mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S1H",
+      "lenses": [
+        "14-24 sigma",
+        "24-105mm F4 MACRO O.I.S",
+        "Canon EF 24-105mm f4L IS II @ 105mm",
+        "Canon EF 24-105mm f4L IS II @ 24mm",
+        "Canon EF 24-105mm f4L IS II @ 35mm",
+        "Canon EF 24-105mm f4L IS II @ 50mm",
+        "Canon EF 24-105mm f4L IS II @ 70mm",
+        "Canon EF 24-105mm f4L IS II @ 85mm",
+        "Canon EF 24-70",
+        "Kinoptik Tegea 9.8mm f1.8",
+        "Laowa 12mm Zero-D f2.8",
+        "Laowa 12mm f2.8 Zero-D",
+        "Lumix s 20-60",
+        "Schneider Arriflex cine xeno 35mm f2",
+        "Schneider Arriflex cine xenon 28mm f2",
+        "Schneider Arriflex cine xenon 40mm f2",
+        "Schneider Arriflex cine xenon 50mm f2",
+        "Schneider Arriflex cine xenon 75mm f2",
+        "Schneider Arriflex cinegon 18mm f1.8",
+        "dulens43 4.3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5",
+      "lenses": [
+        "14-28",
+        "18mm 1.8",
+        "18mm 1.8f",
+        "20-60mm @  20 mm",
+        "24-105",
+        "24-105 @ 24mm",
+        "24mm-105mm",
+        "7 Artisans 25mm",
+        "EF 16 35 f4L @ 16mm",
+        "Laowa 15mm",
+        "Lumix 20-60",
+        "Lumix 24mm F1.8",
+        "Lumix 35mm f1.8",
+        "S-S35",
+        "S20-60 @20mm",
+        "S50 1.8 F4",
+        "Sigma 16-28mm",
+        "Sigma 70 200 2.8 l mount",
+        "Sigma art 35 mm f1.4",
+        "irix 15mm",
+        "lumix 50 1.8",
+        "lumix20-60f3.5-5.6",
+        "vario 20 60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5 M 1",
+      "lenses": [
+        "Flektogon 35mm/f2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S52",
+      "lenses": [
+        "20-60mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "s52x",
+      "lenses": [
+        "20-60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5II",
+      "lenses": [
+        "20-60",
+        "24-70",
+        "Lumix 24-105 F4",
+        "SIGMA 24-70",
+        "Sigma 28-70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "s5iix",
+      "lenses": [
+        "DZOFILM Vespid Prime 50mm T2.1",
+        "Sigma 24-70 DG DN",
+        "sigma 24-70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S5m2",
+      "lenses": [
+        "16-35 F4",
+        "20-60",
+        "20-60mm @ 20mm",
+        "20-60mm @ 35mm",
+        "2060-20",
+        "24-70 f2.8",
+        "35F1.8",
+        "SR70300",
+        "Sigma28-70/f2.8",
+        "s-s35",
+        "s-s85"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "s5m2x",
+      "lenses": [
+        "20-60mm @ 20mm",
+        "24-70 F2.8",
+        "28-105",
+        "SIGMA2870"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Panasonic",
+      "model": "S9",
+      "lenses": [
+        "LUMIX 50mm 1.8",
+        "Lumix S 50mm 1.8",
+        "Lumix S50 1:1.8"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "6x7",
+      "lenses": [
+        "105mm f2.4 + MetaBones 0.71",
+        "55mm f4 + MetaBones 0.71"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "K-3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "K-5 IIS",
+      "lenses": [
+        "Tamron 18-250"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Pentax",
+      "model": "K3",
+      "lenses": [
+        "Tamron 17-50"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Philips",
+      "model": "adr810",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Poco",
+      "model": "F1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "f1 wide",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "F1 wide 2to1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Poco",
+      "model": "F3",
+      "lenses": [
+        "Vertical"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "f3 stab off",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "f3 stab on",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "F4",
+      "lenses": [
+        "Inbuilt"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "F4GT",
+      "lenses": [
+        "Wide 26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "M4Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Poco",
+      "model": "M5s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "X 3 pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "x3 Pro",
+      "lenses": [
+        "IMX582"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "X5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "x5 pro",
+      "lenses": [
+        "main lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "X5 Pro 5G",
+      "lenses": [
+        "1x zoom"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "POCO",
+      "model": "X6 5G",
+      "lenses": [
+        "1080p Landscape",
+        "OV64B",
+        "idk"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "polaroid",
+      "model": "cube",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RaceCam",
+      "model": "R1 Micro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Raspberry Pi",
+      "model": "Camera Module 3",
+      "lenses": [
+        "IMX708"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Raspberry Pi",
+      "model": "HQ Camera",
+      "lenses": [
+        "3.2mm Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "3 Pro",
+      "lenses": [
+        "28mm F1.7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "6",
+      "lenses": [
+        "Основная"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "6 Pro",
+      "lenses": [
+        "64MP-Main",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "7 5g",
+      "lenses": [
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "7 (RMX2151)",
+      "lenses": [
+        "Sony IMX682 f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "8",
+      "lenses": [
+        "Film It",
+        "Real Me 8",
+        "one"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "8pro",
+      "lenses": [
+        "Realme8pro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "9 pro plus",
+      "lenses": [
+        "main",
+        "main cam"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "C2",
+      "lenses": [
+        "PDAF"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "C67",
+      "lenses": [
+        "Samsung"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "REALME",
+      "model": "GT MASTER",
+      "lenses": [
+        "64MP MAIN"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "GT Neo3 Realme",
+      "lenses": [
+        "Realme"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "RMX2151",
+      "lenses": [
+        "Sony IMX 682",
+        "Sony IMX682"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Realme",
+      "model": "X3 Zoom",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "8k vv",
+      "lenses": [
+        "leica 35 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "DRAGON X",
+      "lenses": [
+        "CANON 24-105",
+        "CANON 24-105 II",
+        "CANON 24-105II",
+        "TOKINA 11-20 ATX"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "DSMC2 GEMINI 5K S35",
+      "lenses": [
+        "ef l 16-35 f4is @ 16.00mm",
+        "ef l 16-35f4is @ 24.00mm",
+        "ef l 16-35f4is @35.00mm",
+        "efl16-35f4is @ 16.00mm",
+        "efl16-35f4is @ 24.00mm",
+        "efl16-35f4is @ 35.00mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "EPIC",
+      "lenses": [
+        "ARRI B SPEED 18MM",
+        "ARRI B SPEED 25MM",
+        "ATLAS ANAMORPHIC 40mm",
+        "ATLAS ORION 25MM",
+        "ATLAS ORION 40MM",
+        "ATLAS ORION 80MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "EPIC DRAGON",
+      "lenses": [
+        "CANON 16-35mm F2.8 Mark ii",
+        "CANON 16-35mm Mkii (20mm)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "EPIC-X",
+      "lenses": [
+        "Canon Zoom EF 24-105mm f/4L IS 24.00mm",
+        "Meike S35 16mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Gemini",
+      "lenses": [
+        "Dulen 31",
+        "Dulens31",
+        "Sigma"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Gemini 5K",
+      "lenses": [
+        "Zeiss Super Speed 25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Helium 8K",
+      "lenses": [
+        "SIGMA 18-35@35mm",
+        "SIGMA ART 18-35@18mm",
+        "Sigma Art 24mm",
+        "Speed Boosted Sigma Art 24mm EF"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "KOMODO",
+      "lenses": [
+        "11mm",
+        "18mm",
+        "35mm Canon FD f3.5",
+        "9mm",
+        "9mm T2.9 Zero-D Cine",
+        "BLAZAR REMUS",
+        "Canon 16mm 2.8",
+        "Canon 50mm 1.8",
+        "Canon EF 24-70 (24)",
+        "Canon EF 24-70ii (24)",
+        "Canon EF 50mm 1.4",
+        "Canon FD 17MM",
+        "Canon RF 16mm",
+        "Contax Zeiss 35mm Viltrox 0.71x",
+        "Contax Zeiss 50mm Viltrox 0.71",
+        "Contax Zeiss 50mm Viltrox 0.71x",
+        "DULEN31 6144 2592",
+        "DULENS 43mm",
+        "DULENS21",
+        "DULENS31",
+        "DULENS31 6144X2592",
+        "DZO - Pictor 12-25mm Zoom",
+        "Konica Hexanon 28mm f1.8",
+        "LAOWA",
+        "LAOWA 10 mm f/4 Cookie",
+        "LAOWA 11mm",
+        "LAOWA 12mm",
+        "LAOWA 15MM",
+        "LAOWA 9 mm ZeroD",
+        "LAOWA 9mm",
+        "LAOWA 9mm T2.9",
+        "Laowa 10mm",
+        "Laowa 11mm RF",
+        "Laowa 11mm f4.5",
+        "Laowa 12mm",
+        "Laowa 14MM F4 FFii RF",
+        "Laowa 14mm F4",
+        "Laowa 14mm f/4 Zero-D DSLR",
+        "Laowa 15MM",
+        "Laowa 15mm",
+        "Laowa 15mm F2.1",
+        "Laowa 15mm Zero-D",
+        "Laowa 16mm",
+        "Laowa 7.5",
+        "Laowa 7.5mm RF Super 35mm",
+        "Laowa 9MM",
+        "Laowa 9mm",
+        "Laowa 9mm Cine",
+        "Laowa 9mm F2.8",
+        "Laowa 9mm T2.9",
+        "Laowa 9mm cine",
+        "Laowa 9mm zeroD cine",
+        "Laowa FFII 11mm F4.5 C-Dreamer",
+        "Laowa FFII 11mm f4.5 C-Dreamer",
+        "Laowa Nanomorph 27mm",
+        "Laowa_9mm",
+        "Leica 28mm F2.8",
+        "Leica R 21mm",
+        "Meike S35 18mm",
+        "Meike S35 25mm",
+        "NIKKOR AI 28mm f/2.8",
+        "NIKKOR AI 85mm f/2",
+        "NIKKOR AIs 20mm f/3.5",
+        "NIKKOR AIs 35mm f/2",
+        "NIKKOR AIs 50mm f/1.4",
+        "Olympus OM 50mm f1.8",
+        "ROKINON 14MM DS",
+        "ROKINON 20mm (EF)",
+        "Red Pro Prime",
+        "Rokinon 14mm ds",
+        "Rokinon 50mm",
+        "Rokinon 85mm T1.5",
+        "SAMYANG 16mm",
+        "SIGMA 18-35",
+        "SIGMA 18-35_35mm",
+        "Sigma 18-25 @20mm 1.8",
+        "Sigma 18-35",
+        "Sigma 18-35 @24mm 1.8",
+        "Sigma 18-35 @35mm 1.8",
+        "Sigma 18-35@35mm",
+        "Sigma 18-35mm F1.8",
+        "Sirui 24mm s35",
+        "Tokina 11-20 (12MM)",
+        "Tokina ATX-i 11-20 F/2.8",
+        "Venus Optics Laowa 9mm T2.9 Zero-D Cine Lens",
+        "Voigtlander 15mm SW-H ASPiii",
+        "Xeen 35mm T1.5",
+        "Xeen 85mm T1.5",
+        "ZEISS OTUS 55mm",
+        "laowa 15mm",
+        "laowa 9mm",
+        "sigma"
+      ],
+      "crop_factor": 1.6,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "KOMODO 6K",
+      "lenses": [
+        "12mm 7Artisans",
+        "14.00mm",
+        "15mm Voigtlander",
+        "15mm laowa cine",
+        "16MM Samyang",
+        "18-35mm F1.8 DC HSM | Art 013 17.00mm",
+        "18-35mm F1.8 DC HSM | Art 013 18.00mm",
+        "18-35mm F1.8 DC HSM | Art 013 19.00mm",
+        "18-35mm F1.8 DC HSM | Art 013 20.00mm",
+        "18-35mm F1.8 DC HSM | Art 013 23.00mm",
+        "18-35mm F1.8 DC HSM | Art 013 24.00mm",
+        "18-35mm F1.8 DC HSM | Art 013 28.00mm",
+        "18-35mm F1.8 DC HSM | Art 013 35.00mm",
+        "24-70mm F2.8 DG OS HSM | Art 017 24.00mm",
+        "24-70mm F2.8 DG OS HSM | Art 017 35.00mm",
+        "24-70mm F2.8 DG OS HSM | Art 017 51.00mm",
+        "24-70mm F2.8 DG OS HSM | Art 017 70.00mm",
+        "24mm",
+        "25MM VESPID PRIME",
+        "25mm",
+        "28",
+        "28mm F1.4 DG HSM | Art 019 28.00mm",
+        "28mm vazen",
+        "30mm F1.4 DC HSM | Art 013 30.00mm",
+        "40mm F1.4 DG HSM | Art 018 40.00mm",
+        "50MM VESPID PRIME",
+        "7Artisans 25mm T1.09",
+        "7Artisans 50mm T2.0 @5K",
+        "7Artisans 50mm T2.0 @6K",
+        "7Artisans Spectrum 50mm T2.0",
+        "9mm",
+        "ARRI B SPEED 25MM",
+        "ARRI Ultra Prime 14mm",
+        "Artisan 7",
+        "Atlas Orion 100mm@T5.6",
+        "Atlas Orion 40mm@T5.6",
+        "Atlas Orion 65mm@T5.6",
+        "Blazar Remus 45mm",
+        "CANON FD 14mm",
+        "CANON FD 20mm",
+        "CANON FD 35mm f2 X0.71",
+        "CANON FD 55mm f1.2 X0.71",
+        "CANON FD LENS 20MM 2.8",
+        "CANON LENS FD 20mm 2.8F",
+        "CHIOPT_28-85(28mm)",
+        "CHIOPT_28-85(35mm)",
+        "CHIOPT_28-85(50mm)",
+        "CHIOPT_28-85(85mm)",
+        "CN-E14mm T3.1 L F 14.00mm",
+        "CN-E18-80mm T4.4 L IS KAS S 19.00mm",
+        "CN-E18-80mm T4.4 L IS KAS S 23.00mm",
+        "CN-E20mm T1.5 L F 20.00mm",
+        "CN-E24mm T1.5 L F 24.00mm",
+        "CN-E24mm T1.5 L F 24mm",
+        "CN-E35mm T1.5 L F 35.00mm",
+        "CN-E50mm T1.3 L F 50.00mm",
+        "CN-E85mm T1.3 L F 85.00mm",
+        "Canon 24-70",
+        "Canon EF 100mm f/2.8L Macro IS USM",
+        "Canon EF 20mm",
+        "Canon EF 24-70mm F/2.8L II USM (5175B010)",
+        "Canon EF 28mm f/1.8 USM",
+        "Canon EF 35mm f/2 IS USM Lens",
+        "Canon EF 40mm f/2.8",
+        "Canon EF 50mm f/1.4 USM",
+        "Canon EF 85mm f/1.4L IS USM",
+        "Canon EF-S 24mm f/2.8",
+        "Canon FD 20mm ZEROOptics",
+        "Canon FD 50 1,4",
+        "Canon L 1.2 35.00mm",
+        "Canon RF14-35",
+        "Canon RF16mm F2.8 STM 16.00mm",
+        "Carl Zeiss  35.00mm",
+        "Carl Zeiss 35.00mm",
+        "Carl Zeiss Distagon ZE  21.00mm",
+        "Carl Zeiss Distagon ZE 21.00mm",
+        "Carl Zeiss Jena DDR Flektogon 2.4/35 MC",
+        "Carl Zeiss Jena Flektogon 20mm T2.8",
+        "Carl Zeiss Planar 1.4/50 HFT",
+        "Contax Zeiss 35mm",
+        "Cooke Panchro",
+        "Cooke Panchro 25mm",
+        "Cooke S4 Mini 35mm",
+        "Cooke SP3 25mm",
+        "DULEN43 6114x2592 50P",
+        "DULEN43 6114x2592 50PDULEN43 6114x2592 50P",
+        "DULEN43 6114x3240 30P",
+        "DULEN431 6114x3240 30P",
+        "DULEN58 6114x2592 50P",
+        "DULEN58 6114x3240 30P",
+        "DULENS",
+        "DULENS 58",
+        "DULENS31",
+        "DULENS31 50P",
+        "DULENS31 6114x3240 30P",
+        "DULENS31 6144x2592 50P",
+        "DULENS58",
+        "DULENS58 6144x2592 50P",
+        "DULENS58 6144x3240 30P",
+        "DZO 20-55",
+        "DZO 25mm",
+        "DZO Pictor Zoom 20-55",
+        "DZO VESPID CYBER 50mm",
+        "DZO VP40",
+        "DZO Vespid Cyber 21mm",
+        "DZO Vespid Cyber 35mm",
+        "DZO Vespid Cyber 50mm",
+        "DZOFILM Catta Ace 35mm-80mm T2.9",
+        "DZOFILM Retro 16mm",
+        "DZOFILM Retro 25mm",
+        "DZOFILM Retro 75mm",
+        "DZOFilm",
+        "DZOFilm 25mm",
+        "DZO_32mm_MACRO",
+        "DZO_90mm_MACRO",
+        "DZo Vespid",
+        "Dzo Vespid 35mm",
+        "EF 40 f/2.8 metabones 0.71",
+        "EF-S10-18mm f/4.5-5.6 IS STM 10.00mm",
+        "EF-S17-55mm f/2.8 IS USM 20.00mm",
+        "EF-S24mm f/2.8 STM 24.00mm",
+        "EF11-24mm f/4L USM 11.00mm",
+        "EF14mm f/2.8L II USM 14.00mm",
+        "EF16-35mm f/2.8L II USM 16.00mm",
+        "EF16-35mm f/2.8L III USM 11.00mm",
+        "EF16-35mm f/2.8L III USM 16.00mm",
+        "EF24-70mm f/2.8L II USM 24.00mm",
+        "EF24-70mm f/2.8L II USM 24mm",
+        "EF24-70mm f/2.8L II USM 28.00mm",
+        "EF24-70mm f/2.8L II USM 35.00mm",
+        "EF24-70mm f/2.8L II USM 50.00mm",
+        "EF24-70mm f/2.8L II USM 70.00mm",
+        "EF24mm f/1.4L II USM 24.00mm",
+        "EF35mm f/1.4L II USM 35.00mm",
+        "EF35mm f/2 IS USM 35.00mm",
+        "EF40mm f/2.8 STM 28.00mm",
+        "EF40mm f/2.8 STM with Metabones Speedbooster 0.71x",
+        "EF50mm f/1.2L USM 50.00mm",
+        "EF50mm f/1.4 50.00mm",
+        "EF50mm f/1.8 STM 50.00mm",
+        "EF70-200mm f/2.8L IS III USM 70.00mm",
+        "EFS 24mm",
+        "Helios 44 KMZ Silver",
+        "Helios 44-2 58MM T2",
+        "Helios 44-2 58mm T2",
+        "Helios 44-2, Canon Speedbooster",
+        "IRIX 30mm",
+        "Irix 11mm",
+        "Irix 15mm T2.6 Cine",
+        "Irix 21mm",
+        "Irix 30mm FF",
+        "Irix 45mm FF",
+        "LAOWA 11MM F4.5",
+        "LAOWA 11mm",
+        "LAOWA 11mm F4.5 C-Dreamer",
+        "LAOWA 12MM S35",
+        "LAOWA 12MM ZERO D",
+        "LAOWA 12mm Cine Zero D",
+        "LAOWA 15",
+        "LAOWA 15mm T2.1 CINE RF",
+        "LAOWA 9mm T2.9 Zero-D Cine",
+        "LAOWA NANOMORPH 1.5X ANAMORPHIC 27MM",
+        "LAOWA PHOTO 9mmF2.8",
+        "LAWOA 15mm 22.1",
+        "Laowa",
+        "Laowa 10mm",
+        "Laowa 11mm f4.5",
+        "Laowa 12mm",
+        "Laowa 14mm",
+        "Laowa 14mm F4.0",
+        "Laowa 14mm FF",
+        "Laowa 14mm RL Zero-D",
+        "Laowa 14mm Zero-D",
+        "Laowa 14mm f4",
+        "Laowa 14mm f4 FF RL",
+        "Laowa 14mm f4.0  c and d dreamer",
+        "Laowa 15mm T2.0 D-Dreamer",
+        "Laowa 15mm T2.1 Cine",
+        "Laowa 15mm f/2 Zero-D",
+        "Laowa 15mm non cine",
+        "Laowa 25mm T2.0 D-Dreamer Kristian FPV",
+        "Laowa 27mm NANOMORPH",
+        "Laowa 7.5mm Cine Lens",
+        "Laowa 7.5mm T/2.9 Cine Lens",
+        "Laowa 9mm",
+        "Laowa 9mm 2.9T cine",
+        "Laowa 9mm CINE",
+        "Laowa 9mm Cine",
+        "Laowa 9mm T2.9",
+        "Laowa 9mm Zero-D",
+        "Laowa 9mm Zero-D Cine",
+        "Laowa Nanomorph 27mm",
+        "Laowa Nanomorph 27mm T2.8",
+        "Laowa Nanomorph 27mm T2.8 1.5x S35",
+        "Laowa Nanomorph 35mm",
+        "Laowa Nanomorph 35mm T2.4 1.5x 35mm",
+        "Laowa Nanomorph 6",
+        "Laowa Nanomorphic 27mm T2.8 1.5x",
+        "Laowa Ranger - 28/75 - 50mm",
+        "Laowa Ranger - 28/75 - 75mm",
+        "Laowa Ranger Lite - 28/75 - 28mm",
+        "Laowa Ranger Lite - 28/75 - 35mm",
+        "Laowa T2.9",
+        "Laowa nanomorphic 27mm T2.8 1.5x",
+        "Laowa_10MM",
+        "Leica 90mm",
+        "Leica Elmarit-R 60mm f2.8",
+        "Leica Elmarit-R f2.8",
+        "Leica Elmarit-r 35 z 35-70 f3.5 + speedbooster",
+        "Leica M 24mm f/1.4 ASPH Summilux-M",
+        "Leica R 15mm f/3.5 Super-Elmar-R",
+        "Leica R 19mm f/2.8 Elmarit-R II",
+        "Leica R 24mm",
+        "Leica R 28mm f/2.8 Elmarit-R II",
+        "Leica R 35-70mm F2.8 3 ogniskowe",
+        "Leica R 35mm",
+        "Leica R 35mm f/2 Summicron-R II",
+        "Leica R 50 z 35-70mm F3.5",
+        "Leica R 50mm",
+        "Leica R 50mm f/1.4 Summilux-R II e60",
+        "Leica R 60mm f/2.8 Macro-Elmarit-R",
+        "Leica R 70 z 35-70mm F3.5",
+        "Leica R 90 with FF Adapter",
+        "Leica R 90mm",
+        "Leica R Vario-Elmar 35-70mm F4 ~ 35mm",
+        "Leica R_24mm",
+        "Leica Summicron 35mm ASPH ii",
+        "Lomo Square Front 35mm",
+        "Lowa 9mm",
+        "Lowa 9mm T2.9",
+        "MB0.71x+DZO35mm",
+        "MEIKE 10mm",
+        "Meike 25mm",
+        "Meike 25mm T2.2",
+        "Meike 50mm FF Cine, Canon Speedbooster",
+        "Meike 50mm FF Cine, Canon Speedbooster, 50fps, 2,4:1",
+        "Meike FF 50mm Cine, Canon Speedbooster, 40FPSi",
+        "Meike FF Cine 50mm, Canon RF Speedbooster",
+        "Meike FF Cine 50mm, Canon RF Speedbooster,",
+        "Meike Mini 10mm",
+        "Meike Mini 25mm",
+        "Meike Mini 35mm",
+        "Meike Mini 50mm",
+        "Meike Mini 65mm",
+        "Meike T2.2/10mm",
+        "Metabones Speedbooster 0,71x + DZO Film Vespid Prime 50mm T2.1",
+        "Metabones Speedbooster 0.71x + DZO Film Vespid Prime 16mm T2.8",
+        "Metabones Speedbooster 0.71x + DZO Film Vespid Prime 25mm T2.1",
+        "Metabones Speedbooster 0.71x + DZO Film Vespid Prime 35mm T2.1",
+        "Metabones Speedbooster 0.71x Ultra RF to PL + DZO Film Vespid Prime 16mm T2.8",
+        "Minolta 58F1.2withNero1.5x",
+        "Mir 20m 20mm",
+        "Mitakon Speedmaster Cine 35mm T1.0",
+        "NIKKOR 18MM VINTAGE",
+        "NIKKOR AI 28mm f/2.8",
+        "NIKKOR AI 85mm f/2",
+        "NIKKOR AIS 20mm f/3.5",
+        "NIKKOR AIS 35mm f/2",
+        "NIKKOR AIS 50mm f/1.4",
+        "NIKON NIKKOR AIS 85MM F1.4 W/ METABONES SPEED BOOSTER 0.71X",
+        "Nikkor SC 55mm f/1.2",
+        "Nikon AI 28mm f2",
+        "Nikon AI-S 18mm f3.5",
+        "Nikon AIS 20mm 2.8",
+        "Nikon AIS 35mm 1.4",
+        "Nikon AIS 50mm 1.2",
+        "Nikon AIS 85mm 1.4",
+        "Nikon F1.4 85mm",
+        "Nikon Nikkor 50mm AIS F/1.2",
+        "Nikon Nikkor 50mm F/1.2 w/ Metabones .71x Speed Booster",
+        "Nikon Nikkor AIS 85mm F/1.4",
+        "Nisi 25mm",
+        "Nisi Athena Prime 14mm",
+        "RF15-35mm F2.8 L IS USM 15.00mm",
+        "RF15-35mm F2.8 L IS USM 35.00mm",
+        "RF16mm F2.8 STM 16.00mm",
+        "RF24-105mm F4 L IS USM 24.00mm",
+        "RF24-70mm F2.8 L IS USM 24.00mm",
+        "RF24-70mm F2.8 L IS USM 35.00mm",
+        "RF24mm F1.8 MACRO IS STM 24.00mm",
+        "RF28mm F2.8 STM 28.00mm",
+        "RF35mm F1.8 MACRO IS STM 35.00mm",
+        "RF50mm F1.8 STM 50.00mm",
+        "Rokinon 24mm",
+        "Rokinon 35mm",
+        "Rokinon 50mm",
+        "Rokinon 85mm",
+        "S4 27mm",
+        "SAMYANG 35mm T1.5",
+        "SIRUI 24mm T1.2",
+        "SIRUI24mm",
+        "Samyang 10mm f2.8",
+        "Samyang 14mm f2.8",
+        "Samyang 14mm f2.8 II",
+        "Samyang 35mm T1.5 @5K",
+        "Samyang 35mm T1.5 @6K",
+        "Samyang 35mm T1.5 UMC II",
+        "Samyang EF 24mm f1.4",
+        "Schneider-Kreuznach Xenon FF-Prime 75mm T2.1",
+        "Schneider-Kreuznach Xeon FF-Prime 35mm T2.1",
+        "Sigma 135mm f/1.8 DG HSM Art Lens for Canon EF",
+        "Sigma 14mm f/1.8 DG HSM Art Lens for Canon EF",
+        "Sigma 18-35",
+        "Sigma 18-35 24.00mm",
+        "Sigma 18-35 @18.00mm",
+        "Sigma 18-35 @28.00mm",
+        "Sigma 18-35 @35.00mm",
+        "Sigma 18-35mm F1.8 DC HSM | Art 013 32.00mm",
+        "Sigma 20mm f/1.4 DG HSM Art Lens for Canon EF",
+        "Sigma 24-70 DG",
+        "Sigma 24-70 f2.8 DG",
+        "Sigma 24mm f/1.4 DG HSM Art Lens for Canon EF",
+        "Sigma 35mm F1.4 DG HSM | Art 012 35.00mm",
+        "Sigma 35mm f/1.4 DG HSM Art Lens for Canon EF",
+        "Sigma 50mm 1.4 EX",
+        "Sigma 50mm f/1.4 DG HSM Art Lens for Canon EF",
+        "Sigma 70-200 mm",
+        "Sigma 70.00-200 mm",
+        "Sigma 8mm-16mm @8mm",
+        "Sigma ARt 35mm + Canon Focal Reducer 0.71",
+        "Sigma EX 1.4 30.00mm",
+        "Sigma18-35 @ 20.00mm",
+        "Sirui 24mm",
+        "Sirui 24mm 1,33x Anamorphic",
+        "Sirui 35 mm",
+        "Sirui 35mm",
+        "Sirui 35mm Anamorphic",
+        "Sirui 50mm anamorphic",
+        "Sirui Nigfhtwalker 55mmT1.5",
+        "Sirui Nightwalker  24mm T1.2",
+        "Sirui Nightwalker 24mm",
+        "Sirui Nightwalker 55mm T1.2 S35",
+        "Sirui nightwalker 24mm",
+        "Super Takumar 35mm f/2",
+        "TAMRON SP 24-70mm F/2.8 Di VC USD G2 A032 24.00mm",
+        "TAMRON SP 24-70mm F/2.8 Di VC USD G2 A032 35.00mm",
+        "TAMRON SP 24-70mm F/2.8 Di VC USD G2 A032 50.00mm",
+        "TAMRON SP 24-70mm F/2.8 Di VC USD G2 A032 70.00mm",
+        "TAMRON SP 35mm F/1.4 Di USD F045 35.00mm",
+        "TAMRON SP 35mm F/1.8 Di VC USD F012 35.00mm",
+        "TOKINA 11-20",
+        "TOKINA 11-20 T2.9",
+        "TT ARTISAN",
+        "TT ARTISAN 35mm",
+        "TT Artisans 17mm",
+        "TTARTISAN 7.5MM FISHEYE",
+        "Tamron SP 35mm F1.4 + Canon Speedbooster",
+        "Tokina 11-20 atx-i @11",
+        "Tokina 16-28 T3",
+        "TokinaATXi  11-20 T3.1 at 20mm",
+        "VOIGTLANDER ULTRON 28mm RF Adapter",
+        "Vespid 21mm",
+        "ZEISS CP.2 25mm",
+        "ZEISS CP3 18MM",
+        "ZEISS Compact Prime CP.3 18 mm/T2.9",
+        "ZEISS Compact Prime CP.3 25 mm/T2.1",
+        "ZEISS Compact Prime CP.3 35 mm/T2.1",
+        "ZEISS SUPER SPEED MK1 18mm T5.6",
+        "ZEISS SUPER SPEEED MK1 18mm T4",
+        "ZEISS SUPERSPEED 25mm T2.8",
+        "ZEISS SUPERSPEED MK.1 18mm",
+        "ZEISS SUPERSPEED MK1 25mm T4",
+        "ZEISS ZUPERSPEED MK1 18mm T5.6",
+        "ZEISSCompact Prime CP.3 18mm/T2.9",
+        "Zeiss 1.4 35.00mm",
+        "Zeiss 15mm cp.3",
+        "Zeiss CP.2 25mm",
+        "Zeiss CP.3 XD 100mm/T2.1",
+        "Zeiss CP.3 XD 21mm/T2.9",
+        "Zeiss CP.3 XD 50mm/T2.1",
+        "Zeiss CP2 21mm 2.9",
+        "Zeiss CP2 25mm",
+        "Zeiss CP2 35mm",
+        "Zeiss Contax 50 1.4 T*",
+        "Zeiss Contax 50 1.4 T* MMJ",
+        "Zeiss Cp.2 21mm",
+        "Zeiss Distagon 18mm f3.5",
+        "Zeiss Otus 28mm",
+        "Zeiss Otus 55 with Canon 0.71x Focal Reducer",
+        "Zeiss Spuperspeedmk1 35mm",
+        "Zeiss SuperSpeed Mk.1 T4",
+        "Zeiss Superspeed 18mm T2.8",
+        "Zeiss Superspeed Mk.1 18mm T2.8",
+        "canon usm 28mm 1.8",
+        "kipon 75mm",
+        "laowa 9mm",
+        "leicaR 50 F2",
+        "roki 20",
+        "sirui 35 T1.2",
+        "tokina 11-20 T2.9at 11mm",
+        "unknown 11.00mm",
+        "unknown 14.00mm",
+        "unknown 16.00mm",
+        "unknown 20.00mm",
+        "unknown 21.00mm",
+        "unknown 24.00mm",
+        "unknown 28.00mm",
+        "unknown 35.00mm",
+        "美科35mm T2.1"
+      ],
+      "crop_factor": 1.33,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Komodo X",
+      "lenses": [
+        "CNE Prime 50mm 1.3",
+        "DZO Pictor Zoom 20-55",
+        "Venus Optics Laowa 10mm f/2.8 Zero-D",
+        "Vilrox Epic 50mm",
+        "Viltrox Epic 50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "KOMODO-X 6K S35",
+      "lenses": [
+        "11 tokina",
+        "18-35mm F1.8 DC HSM | Art 013 18.00mm",
+        "24-70mm F2.8 DG OS HSM | Art 017 24.00mm",
+        "25mm FF",
+        "7Artisans 10mm T2.1",
+        "Contax Zeiss 28mm F2.8",
+        "Contax Zeiss 28mm f2.8",
+        "Contax Zeiss 35mm f2.8",
+        "Cooke SP3 100mm",
+        "Cooke SP3 25mm T2.4",
+        "Cooke SP3 50mm",
+        "Cooke SP3 75mm",
+        "DZO Film 20-55 T2.8",
+        "DZO Film 25mm Vespid Prime",
+        "DZO GNOSIS 24MM",
+        "DZO GNOSIS 65MM",
+        "DZO Pictor Zoom 20mm 2.8",
+        "DZO Vespid 125mm",
+        "DZO Vespid 12mm",
+        "DZO Vespid 21mm",
+        "DZO Vespid 25mm",
+        "DZO Vespid 40mm",
+        "DZO Vespid 70mm",
+        "DZO Vespid 75mm",
+        "DZOFILM 16mm T2.8 VESPID Prime",
+        "DZOFILM 21mm T2.1 VESPID Prime",
+        "DZOFILM 40mm T2.1 VESPID Prime",
+        "DZOFILM Vespid Prime 25mm",
+        "DuLens",
+        "EF-S17-55mm f/2.8 IS USM 11.00mm",
+        "EF14mm f/2.8L II USM 14.00mm",
+        "EF16-35mm f/2.8L II USM 16.00mm",
+        "EF16-35mm f/2.8L II USM 34.00mm",
+        "EF16-35mm f/2.8L II USM 35.00mm",
+        "EF16-35mm f/4L IS USM 16.00mm",
+        "EF17-40mm f/4L USM 19mm",
+        "EF17-40mm f/4L USM 20mm",
+        "EF17-40mm f/4L USM 24mm",
+        "EF17-40mm f/4L USM 28mm",
+        "EF17-40mm f/4L USM 35mm",
+        "EF17-40mm f/4L USM 40mm",
+        "EF24-70mm f/2.8L II USM 24.00mm",
+        "EF24-70mm f/2.8L II USM 70.00mm",
+        "EF70-200mm f/2.8L IS II USM 70.00mm",
+        "IRIX CINE T2.6 15MM",
+        "LAOWA ARGUS 18mm T1",
+        "LAOWA Nanomorph 27mm T2.8",
+        "Laowa 10mm FF",
+        "Laowa 9mm",
+        "Laowa 9mm T2.9",
+        "Laowa Nanomorph",
+        "Laowa Nanomorph 27mm",
+        "Laowa nanomorph 50 mm",
+        "Meike 25mm t2.2 s35",
+        "NISI Athena 14mm",
+        "NISI Athena 25mm",
+        "NISI Athena 35mm",
+        "NISI Athena 50mm",
+        "NISI Athena 85mm",
+        "NiSi 14mm ATHENA PRIME",
+        "NiSi 25mm ATHENA PRIME",
+        "NiSi 35mm ATHENA PRIME",
+        "NiSi 50mm ATHENA PRIME",
+        "NiSi 85mm ATHENA PRIME",
+        "Nisi Athena 25mm",
+        "RF15-35mm F2.8 L IS USM 15.00mm",
+        "RF15-35mm F2.8 L IS USM 35.00mm",
+        "RF16mm F2.8 STM 16.00mm",
+        "RF24-105mm F4 L IS USM 24.00mm",
+        "RF24-240mm F4-6.3 IS USM 24.00mm",
+        "RF24-70mm F2.8 L IS USM 24.00mm",
+        "RF24-70mm F2.8 L IS USM 70.00mm",
+        "RF24mm F1.8 MACRO IS STM 24.00mm",
+        "RF35mm F1.4 L VCM 35.00mm",
+        "SIRUI 55MM T.15",
+        "SIRUI NIGHTWALKER 55MM",
+        "SIRUI Night Walker T1.2",
+        "SIRUI Night Walker T1.2  35mm",
+        "SIRUI Night Walker T1.2  55mm",
+        "SP29MM",
+        "Sirui nightwalker 24mm",
+        "TOKINA 11-16 ATX-i @ 11mm",
+        "TOKINA 11-16 ATX-i @ 12mm",
+        "TOKINA 11-16 ATX-i @ 16mm",
+        "TTArtisan 50mm f/0.95 Lens for Canon RF",
+        "Tokina 11-16 ATX-i @ 16mm",
+        "Tokina 11-16mm ATX-i @ 11mm",
+        "XEEN 85mm T 1.5",
+        "Zeiss B-Speed 25mm",
+        "Zeiss Macro-Planar 50.00mm f2",
+        "cooke sp3 25mm",
+        "mitakon speedmaster 35mm t1 with sirui 1.25 anamorphic adapter",
+        "sigma cine art 28mm T1.5 PL",
+        "sp29mm",
+        "supreme prime 25mm 17:9"
+      ],
+      "crop_factor": 1.33,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Raptor",
+      "lenses": [
+        "Leica R 135mm",
+        "Leica R 19",
+        "Leica R 28mm",
+        "Leica R 35mm",
+        "Leica R 50mm",
+        "Leica R 80mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "Raven",
+      "lenses": [
+        "Canon EF 100mm L f2.8",
+        "Canon EF 14mm L f2.8",
+        "Canon EF 24mm L f1.4",
+        "Canon EF 50mm L f1.2",
+        "Canon EF S 24mm STM f2.8",
+        "Canon EF-s 10-18mm f4.5-5.6 at 10mm",
+        "Canon EF-s 10-18mm f4.5-5.6 at 14mm",
+        "Canon EF-s 10-18mm f4.5-5.6 at 18mm",
+        "DZO FILM 20mm",
+        "Fish-eye-Takumar 17mm f1/4",
+        "Rokinon 10mm T3.1",
+        "Super Takumar 300mm f4",
+        "Super-Multi-Coated Takumar 135mm f2.5",
+        "Super-Multi-Coated Takumar 200mm f4",
+        "Super-Multi-Coated Takumar 35mm f2",
+        "Super-Takumar 24mm f3.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "SCARLET-W 5K",
+      "lenses": [
+        "20"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "SCARLET-X",
+      "lenses": [
+        "Sigma Art  18.00mm 18 - 35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-Raptor",
+      "lenses": [
+        "12mm",
+        "Arri Ultra Prime",
+        "LAOWA 9MM",
+        "Laowa 11mm F3.5",
+        "Laowa 12mm",
+        "Laowa 12mm Cine T2.9",
+        "Laowa 9mm",
+        "Leica 35mm f/1.4 0.8 M",
+        "Leica Elmarit-R 19mm",
+        "ZEISS CP3 35MM",
+        "ZEISS CP3 50mm",
+        "ZEISS CP3 85MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-RAPTOR 8K S35",
+      "lenses": [
+        "DZO 25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-RAPTOR 8K VV",
+      "lenses": [
+        "20mm MIR",
+        "35mm T1.5 FF | 017 35.00mm",
+        "BlackWing 27mm",
+        "Blackwing 137",
+        "Blackwing 20.7",
+        "Blackwing 37",
+        "Blackwing 47",
+        "Blackwing 57",
+        "Blackwing 77",
+        "CN-E18-80mm T4.4 L IS KAS S 18.00mm",
+        "CN-E18-80mm T4.4 L IS KAS S 24.00mm",
+        "CN-E18-80mm T4.4 L IS KAS S 25.00mm",
+        "CN-E18-80mm T4.4 L IS KAS S 35.00mm",
+        "CP3 15mm",
+        "Contax Zeiss 25mm",
+        "Contax Zeiss 25mm f2.8",
+        "Cooke SP3 100mm T2.4",
+        "Cooke SP3 25mm",
+        "Cooke SP3 32mm",
+        "Cooke SP3 50mm",
+        "Cooke SP3 75mm",
+        "DZO Vespid 12mm T2.8",
+        "DZO Vespid 21mm T2.1",
+        "DZO Vespid 35mm",
+        "DZO Vespid 40mm T2.1",
+        "DZO Vespid 75mm T2.1",
+        "EF16-35mm f/4L IS USM",
+        "EF24-70mm f/2.8L II USM -1.00mm",
+        "Laowa 10mm FF",
+        "Laowa 11mm",
+        "Laowa 12 MM",
+        "Laowa 24mm T8 35*",
+        "Laowa 35mm f/0.95 FF",
+        "Laowa 45 proteus 2x anamorphic",
+        "Laowa 45mm anamorphi",
+        "Laowa Probe 24mm",
+        "Mir 20m 20mm",
+        "RF100mm F2.8 L MACRO IS USM 100.00mm",
+        "RF14-35mm F4 L IS USM @ 14.00mm",
+        "RF14-35mm F4 L IS USM @ 18.00mm",
+        "RF14-35mm F4 L IS USM @ 35.00mm",
+        "RF15-35mm F2.8 L IS USM 19.00mm",
+        "RF24-105mm F4 L IS USM @ 24.00mm",
+        "RF24-105mm F4 L IS USM @ 35.00mm",
+        "RF24-105mm F4 L IS USM @ 50.00mm",
+        "RF24-105mm F4 L IS USM @ 70.00mm",
+        "RF24-70mm F2.8 L IS USM 24.00mm",
+        "RF24mm F1.8 MACRO IS STM 24.00mm",
+        "RF28-70mm F2 L USM 28.00mm",
+        "RF35mm F1.8 MACRO IS STM 35.00mm",
+        "RF70-200mm F2.8 L IS USM 70.00mm",
+        "RF85mm F1.2 L USM DS 85.00mm",
+        "Sigma 50mm T1.5 FF",
+        "Sigma 85mm T1.5 FF",
+        "Sigma T1.5 FF 20mm",
+        "TOKINA 11-16mm",
+        "XEEN 50mm T1.5",
+        "Zeiss CP3_100mm",
+        "Zeiss Supreme Prime 18mm",
+        "Zeiss Supreme Prime 25mm",
+        "Zeiss Supreme Prime 35mm",
+        "dzofilm vespid 21mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-RAPTOR VV",
+      "lenses": [
+        "ZEISS CP.3 100MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RED",
+      "model": "V-Raptor [X] 8K VV",
+      "lenses": [
+        "35mm V35 Athena OM",
+        "Laowa Pro2be 24mm T8 Straight"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "10c",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "12c",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "K60",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "K60 Ultra",
+      "lenses": [
+        "22mm ƒ/ 1.79"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "K70",
+      "lenses": [
+        "25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 10 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 10s",
+      "lenses": [
+        "UW@10mm",
+        "Wide @26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "note 11 pro 5G",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 12",
+      "lenses": [
+        "Ultra Wide 0,6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 12 Turbo",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 12T",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 13",
+      "lenses": [
+        "Smartphone 25 mm",
+        "ultra wide 15mm",
+        "wide 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 13 Pro 5g",
+      "lenses": [
+        "UW 16mm",
+        "W 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 8 Pro",
+      "lenses": [
+        "Middle"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "Note 9",
+      "lenses": [
+        "f/1.89\nAF, lente 6P, FOV 79,8°."
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Redmi",
+      "model": "note 9 pro max",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ricoh",
+      "model": "GR II",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "530",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "9s Plus",
+      "lenses": [
+        "2.75 mm 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "AC 625",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei (禄来)",
+      "model": "ac500",
+      "lenses": [
+        "禄来"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Rollei",
+      "model": "Actioncam 7S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "2",
+      "lenses": [
+        "STOCK",
+        "Std Weitwinkel"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "2 4K",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "3S",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "5 black",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "5 Orange",
+      "lenses": [
+        "Original"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "6",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HDZero Micro V2",
+      "lenses": [
+        "Stock"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HDZero Nano",
+      "lenses": [
+        "Stock"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HuangFeng",
+      "lenses": [
+        "wsap"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "HYBRID",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Hybrid 2",
+      "lenses": [
+        "16:9",
+        "2.1 mm",
+        "m10"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "IF Gocam",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Iflight Gocam PMGR",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Link Phoenix HD Kit",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Link Wasp",
+      "lenses": [
+        "Nano"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "LR-RUNCAM43",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Micro V2 HDZero",
+      "lenses": [
+        "Ratel 1 1.66mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "MIPI",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Nano 3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Nano2",
+      "lenses": [
+        "2.1mm(M8) FOV 155°"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Nano3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Phinex",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Phoenix",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Phoenix 2",
+      "lenses": [
+        "Analog"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "phoenix jb",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Protek25",
+      "lenses": [
+        "Fixed Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Protek25 2.7K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RC5-OR (v1.1)",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RunCam 2",
+      "lenses": [
+        "2.3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RunCam 4K Protek25 3840x2160 29.97fps",
+      "lenses": [
+        "RunCam 4K Protek25 Fixed Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "RunCam 6",
+      "lenses": [
+        "Standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Runcam Split 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Spilt",
+      "lenses": [
+        "mini2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split",
+      "lenses": [
+        "RC25G"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 2",
+      "lenses": [
+        "Ratel red lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 3 Lite",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split 3 lite caddx turtle 2",
+      "lenses": [
+        "caddx"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 3 Micro",
+      "lenses": [
+        "Runcam Split 3 Micro Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 3 Nano HD",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split HD",
+      "lenses": [
+        "MJ",
+        "XY-1440-1080",
+        "gopro",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split hd 2.7k",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split HD 43",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split lite 3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split Mini 1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split Mini 2",
+      "lenses": [
+        "130 fov"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Split Nano 3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split3",
+      "lenses": [
+        "runcam nano3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split3 lite",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "split4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb",
+      "lenses": [
+        "1.8mm caddx ant",
+        "caddx 1.8mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "thumb pro",
+      "lenses": [
+        "2.1 ratel"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb Pro w",
+      "lenses": [
+        "IMX577(12MP)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb ProW",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Thumb2",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "ThumbPro",
+      "lenses": [
+        "2.1mm",
+        "Foxeer 1.7mm",
+        "Foxeer 1.8",
+        "Foxeer 2.5mm",
+        "Goveisee 2.1mm",
+        "RC18G",
+        "RC19",
+        "caddx ratel v1",
+        "rc19g",
+        "rc25g",
+        "stock",
+        "wide",
+        "xv"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "ThumbPW",
+      "lenses": [
+        "wide",
+        "xv"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Tramp pro 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "RunCam",
+      "model": "Wasp",
+      "lenses": [
+        "DJI V2 DVR",
+        "org"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ryze",
+      "model": "Tello",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "23",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A 20 E",
+      "lenses": [
+        "CMOS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A03s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A13",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A14 ISOCELL JN1",
+      "lenses": [
+        "50mp"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A22",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A30s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A34",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A41",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A5 2017",
+      "lenses": [
+        "10"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A51",
+      "lenses": [
+        "Main Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A52 5G",
+      "lenses": [
+        "64 MP, 26mm (wide), 1/1.7X\""
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "a53 5g",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "a70",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A71",
+      "lenses": [
+        "0.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "a73",
+      "lenses": [
+        "0.5x Lens",
+        "1x Lens",
+        "2x Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A9 pro(2016)",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "A9Pro (2016)",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Fold 3",
+      "lenses": [
+        "Ultrawide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Fold 4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A30",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A51 Ultra Wide",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A52",
+      "lenses": [
+        "Ultrawide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A52s",
+      "lenses": [
+        "Ultra Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A71",
+      "lenses": [
+        "26mm F1.8",
+        "Main Cam 26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy A72",
+      "lenses": [
+        "0.5 wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy F62",
+      "lenses": [
+        "Main Rear Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy M20",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy m31",
+      "lenses": [
+        "64 mp main sensor",
+        "main sensor"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy note 10",
+      "lenses": [
+        "Main camera",
+        "ultra wide",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note 20",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note 9",
+      "lenses": [
+        "12 Мп - Samsung S5K2L3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note S20 Ultra",
+      "lenses": [
+        "0.5 Ultrawide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Note10",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S10e",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S20 FE 4G",
+      "lenses": [
+        "27mm Main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy s20 fe 5g",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S20fe",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy s20u",
+      "lenses": [
+        "5x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S21",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S21 FE 5G",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy s21 Ultra",
+      "lenses": [
+        "24 mm",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S22",
+      "lenses": [
+        "14mm",
+        "24mm",
+        "24mm F1.8",
+        "69mm",
+        "Selfie"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S22 Ultra",
+      "lenses": [
+        "0.7x",
+        "10x",
+        "14mm",
+        "1x",
+        "1x at 24mm",
+        "3x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S22 Ultra - Main (108 MP)",
+      "lenses": [
+        "1X"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S23",
+      "lenses": [
+        "14mm",
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "galaxy s23 ultra",
+      "lenses": [
+        "14mm",
+        "230mm",
+        "23mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S23 x1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S24",
+      "lenses": [
+        "14mm",
+        "24mm",
+        "69mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S24 Ultra",
+      "lenses": [
+        "14 mm",
+        "Aperture",
+        "aperture"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S24 Ultra 14mm",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S8",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy S9",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Galaxy Ultra 23S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Gear 360 (2017)",
+      "lenses": [
+        "180 Degree"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Gear360",
+      "lenses": [
+        "360"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Gran angular",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "gw1",
+      "lenses": [
+        "gw1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "ISOCELL",
+      "lenses": [
+        "(S5K)HM6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "J7 NXT",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "M30s",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "m52",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10+",
+      "lenses": [
+        "UltraWide (0.5x)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10 Lite",
+      "lenses": [
+        "1x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10 plus",
+      "lenses": [
+        "Main Camera",
+        "UltraWide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 10H",
+      "lenses": [
+        "标准"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 20",
+      "lenses": [
+        "Wide angle",
+        "sm-n981b"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 8",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Note 9 1080p",
+      "lenses": [
+        "Open Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX-30",
+      "lenses": [
+        "16-50 IOS",
+        "16-50mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX 500",
+      "lenses": [
+        "16 mm 1:2.4 F2.4",
+        "16-50 OIS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX2000",
+      "lenses": [
+        "NX 20-50"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX30",
+      "lenses": [
+        "Samsung nx 30 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX300",
+      "lenses": [
+        "18mm-55mm",
+        "30mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "NX500",
+      "lenses": [
+        "16mm",
+        "Meike Optics MK 8mm f3.5",
+        "Samsung 45mm 1.8 Prime"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S10+",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S10 5g",
+      "lenses": [
+        "Front facing"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S10e",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S20",
+      "lenses": [
+        "26mm main (1x)",
+        "Primary",
+        "normal"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S20 fe",
+      "lenses": [
+        "Main rear lens",
+        "STD"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S20FE",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S21 FE",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S21 Ultra",
+      "lenses": [
+        "Main Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22",
+      "lenses": [
+        "14mm",
+        "24mm",
+        "3X",
+        "Wide",
+        "anamorphic"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22 Base",
+      "lenses": [
+        "Wide 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22 Ultra",
+      "lenses": [
+        "108 mp",
+        "1x at 24mm",
+        "24 MM",
+        "24mm",
+        "70mm",
+        "S22 ultra 24mm",
+        "Stock 24mm camera lens",
+        "T series 58mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22 Wide",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S22u",
+      "lenses": [
+        "Front"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23",
+      "lenses": [
+        "0.6X",
+        "1.0",
+        "14mm",
+        "24mm",
+        "69mm",
+        "Wide"
+      ],
+      "crop_factor": 0.6,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23 FE",
+      "lenses": [
+        "73mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23 Plus",
+      "lenses": [
+        "14mm Crop",
+        "69mm crop"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23 Ultra",
+      "lenses": [
+        "14mm",
+        "23",
+        "23mm",
+        "70mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23U",
+      "lenses": [
+        "23mm",
+        "70mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S23ultra 23mm",
+      "lenses": [
+        "Motion cam"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S24",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S24 Plus",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S24 Ultra",
+      "lenses": [
+        "14mm",
+        "23mm",
+        "23mm (Main)",
+        "Superview",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S25 Ultra",
+      "lenses": [
+        "117mm",
+        "14mm (0-2)",
+        "14mm (2)",
+        "23mm",
+        "63mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S5K4H7",
+      "lenses": [
+        "S5K4H7"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S5KGM1",
+      "lenses": [
+        "1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "s5kgm2",
+      "lenses": [
+        "s5kgm2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S6 edge plus",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S8",
+      "lenses": [
+        "rear"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "S9+",
+      "lenses": [
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Samsung A51 Ultra Wide 9:16",
+      "lenses": [
+        "Ultra Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "WB2000",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "WB800F",
+      "lenses": [
+        "4.1-86.1mm 1:2.8-5.9"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Xcover 5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Samsung",
+      "model": "Z Flip 4",
+      "lenses": [
+        "1.76″ sensor"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SARGO",
+      "model": "A9",
+      "lenses": [
+        "IMX 386"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sargo",
+      "model": "G10+",
+      "lenses": [
+        "--",
+        "NO"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "sargo11",
+      "model": "sargo11",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SBOX",
+      "model": "actioncam",
+      "lenses": [
+        "170"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sena",
+      "model": "50C",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sencor",
+      "model": "4K20WR",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sharp",
+      "model": "aquos r6",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SHARP",
+      "model": "SH-R80",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "fp",
+      "lenses": [
+        "14mm Laowa f4 Zero D",
+        "18-50 1:2.8 DC DN 55mm",
+        "20",
+        "20-60mm  When20",
+        "24",
+        "24-1",
+        "24-70 dg dn art",
+        "24-70 f2.8 dg dn art",
+        "28 70",
+        "28mm",
+        "45-2.8(I)",
+        "45-2.8-I",
+        "45mm 2.8 dg dn c",
+        "45mm DG DN",
+        "45mm f2.8 dg dn",
+        "45mm f2.8 dg dn c",
+        "50mm",
+        "50mm F1.7",
+        "7 Artisans 35mm T2.0",
+        "7Artisans 10mm f2.8",
+        "7artisans 14mm T2.9",
+        "Asahi SMC Takumar Fish-eye 17mm F/4",
+        "AstrHori 10mm f.8 II",
+        "AstrHori 10mm f8 II",
+        "AstrHori 10mm_f8_II",
+        "CANON LTM 35mm F2",
+        "CARL ZEISS JENA FLEKTOGON 20mmF2.8",
+        "CARL_ZEISS_JENA_FLEKTOGON35mmF2.4",
+        "Canon FD 35mm F2",
+        "Canon FD 50mm 1.4mm",
+        "Canon FD 50mm F1.8",
+        "Canon nFD 50mm f/1.2",
+        "Cheecar35mm F1.4",
+        "Contax Zeiss Distagon T* 18mm f/4",
+        "HELIOS 44M 58MM",
+        "Helios - 44 - 2",
+        "Helios 44m",
+        "Helios-44-2",
+        "Helios-44м-4 2/58mm h113-a",
+        "Irix 15mm EF",
+        "Irix 15mm Firefly",
+        "LAOWA 10 MM COOKIE DC",
+        "Laowa 10mm f/4 Cookie",
+        "Laowa 11mm FF 4.5",
+        "Laowa 14mm f4 FF RL Zero-D",
+        "Laowa 9MM F5.6 FF RL",
+        "Laowa 9mm F5.6 FF RL",
+        "Laowa 9mm FF RL",
+        "Laows 9mm",
+        "Leica Elmar M 50mm",
+        "Loawa 9mm",
+        "NIKKOR NIKON 24mm F2.0 AIS",
+        "Nikkor Ai 50mm 1:1.4",
+        "Pannasonic 35 1.8",
+        "Pentax-A 645 45mm 2.8 + Kipon P645-L 0.7x",
+        "ROCKSTAR 50mm F2",
+        "SIGMA 90mm f2.8",
+        "SMC PENTAX-M 1:2 28mm",
+        "SMC Takumar 50mm f1.4",
+        "Samyang 85mm CINE",
+        "Samyang T3.1 14mm ED AS IF UMC",
+        "Sigma 28 - 70mm F2.8 DG DN C",
+        "Sigma 28 -70mm 2.8 DG DN",
+        "Sigma 35mm 1.2f",
+        "Sigma 45mm F2.8",
+        "Sigma 45mm f2.8 DG DN",
+        "Sigma20mm_f2_DN_ART",
+        "TTA-50mm",
+        "TTArtisan 21mm f1.5 ASPH",
+        "TTartisans_17mm_1.4",
+        "Tamron 35mm VC",
+        "Tokina AT-X 270 AF PRO II @ 28mm",
+        "Vivitar 135mm F2.8",
+        "Vivitar Canon FD 135mm F2.8",
+        "Voigtlander 15 4.5",
+        "Voigtlander 15mm 4.5",
+        "Voigtlander 21mm 1.4",
+        "Voigtlander 35 2.5",
+        "Voigtlander 35mm2.5",
+        "Yashika 45mm F1.7",
+        "Zeiss Flektogon 35/F2.4",
+        "Zeiss Vario-Sonnar 28-70mm f3.5-4.5",
+        "cock 50 f2",
+        "dulens 31mm",
+        "ef 20-35mm",
+        "linix 2060",
+        "pentax SMC A 28mm",
+        "契卡35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "fp L",
+      "lenses": [
+        "50mm F2",
+        "7artisans 28mm5.6",
+        "Olympus Zuiko 50mm f1.4",
+        "Panasonic Lumix S 20-60mm f/3.5-5.6",
+        "Sigma 24mm F2 DG DN",
+        "TTArtisan 50mm F2",
+        "sigma DGDN"
+      ],
+      "crop_factor": 1.24,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "FPL",
+      "lenses": [
+        "20-60MM",
+        "LUMIX 20-60"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sigma",
+      "model": "SIGMA_FPL",
+      "lenses": [
+        "32MM_F10_L"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Simulus",
+      "model": "GH-265",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sioeye",
+      "model": "Blink",
+      "lenses": [
+        "宽",
+        "最广"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sioeye",
+      "model": "v3",
+      "lenses": [
+        "none"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "sioeye",
+      "model": "v4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "sj6 legend",
+      "model": "sj6",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "11",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "200pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "4000 AIR",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "4000air",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "4000W",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "8 Pro",
+      "lenses": [
+        "Standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "8Pro",
+      "lenses": [
+        "Standart"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "C",
+      "lenses": [
+        "300",
+        "300P",
+        "300R"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "c100+",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "c100+ Horizontal",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "c100+ Vertical",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "C200",
+      "lenses": [
+        "SONY IMX335"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "c200pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "c300",
+      "lenses": [
+        "PR"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "Legend 6",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "M10+",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "M20",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ 7 STAR",
+      "lenses": [
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ 8 Pro",
+      "lenses": [
+        "Without Len correction"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ10 Pro",
+      "lenses": [
+        "standart"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "sj10pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ20",
+      "lenses": [
+        "Dual"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "sj4000",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ4000 Air",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ5000",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ5000x",
+      "lenses": [
+        "default"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "sj6 legend",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "sj6legend",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ6PRO",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ7",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ8",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ8 Plus",
+      "lenses": [
+        "90° Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ8 PRO",
+      "lenses": [
+        "Without Len Correction",
+        "Without len correction",
+        "int"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "SJCam",
+      "model": "SJ8PRO",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Skydio",
+      "model": "2+",
+      "lenses": [
+        "Skydio 2+"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Somikon",
+      "model": "action cam",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "黑鲨4",
+      "lenses": [
+        "imx582"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "5100",
+      "lenses": [
+        "16-50"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "6300",
+      "lenses": [
+        "16-50"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "7CII",
+      "lenses": [
+        "35mm ziess"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a1",
+      "lenses": [
+        "101.00mm",
+        "135.00mm",
+        "150.00mm",
+        "16-35 GM",
+        "18.00mm Samyang F2.8 FE",
+        "24mm (Sigma DG DN 24-70 f2.8)",
+        "35.00mm",
+        "50.00mm",
+        "70.00mm",
+        "87.00mm",
+        "APO Lanthar 35.00mm",
+        "Batis 25.00mm",
+        "Batis 40.00mm",
+        "Laowa 14mm f/4 Zero-D",
+        "Meike FF Cine 135mm",
+        "Nokton 40mm",
+        "Sigma 14-24mm",
+        "Sigma 28-70",
+        "Sigma 28-70 f2.8",
+        "Sigma Art Canon /w MC11 14.00mm 1.8f",
+        "Sigma DG DN 85mm F1.4",
+        "Sigma DG DN C 16-28 at 16mm",
+        "Tamron 17-28@17mm",
+        "Tamron 17-28@28mm",
+        "Voigtlander 75mm Nokton"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "A37",
+      "lenses": [
+        "SAL1855"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a5000",
+      "lenses": [
+        "SEL1650OSS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a5100",
+      "lenses": [
+        "16-50",
+        "7artisans 35mm f1.4",
+        "Sony E35 1.8",
+        "sigma 16mm f/1.4",
+        "viltrox 23mm f.14"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a58 18-55 kit",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6000",
+      "lenses": [
+        "16-35",
+        "16-50",
+        "16-50 F8 GM",
+        "16-50 at 16mm",
+        "16-50 f3.5-5.6",
+        "1650 3.5-5.6",
+        "16mm 1:1.4",
+        "16nm 1:1.4",
+        "18-55 kit",
+        "3.5-5.6/16-50 mm sony kit lens",
+        "50mm",
+        "55-210",
+        "Helios-33",
+        "Laowa 9mm F2.8 Zero-D",
+        "SELP1650",
+        "SONY 50M",
+        "Samyang 85mm t1.5 VDSLR",
+        "Sony",
+        "Sony 16-50mm",
+        "Sony 18-105 f4",
+        "Sony SEL16F28",
+        "Sony SELP1650 PZ 16-50mm f/3.5-5.6 OSS; 9 elements in 8 groups, 4 aspheric surfaces",
+        "Tamron 28-200 2.8-5.6",
+        "sony 18.108 emount f4",
+        "sony 50m",
+        "sony 55-210",
+        "stocklens@16mm",
+        "ttartisan 50mm f1.2",
+        "岩石星50 f2"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6100",
+      "lenses": [
+        "16-50",
+        "16-50s",
+        "18-105mm F4 G",
+        "30mmmacro",
+        "39mm macro",
+        "7 artisans 25mm f1.8",
+        "Lente de Zoom de 16-50 mm",
+        "NIkon 60mm macro",
+        "OSS 3.5-5.6/16mm",
+        "OSS 3.5-5.6/50mm",
+        "OSS 4.5-6.3/210mm",
+        "Samyang 12mm f2 AF Sony e",
+        "Sigma 18-50 2.8",
+        "Sigma 18-50 2.8 DC DN",
+        "Sony 18-55 Kit",
+        "Sony 85mm 1.8 FE",
+        "sony 55-210mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6300",
+      "lenses": [
+        "16 105 F4",
+        "16-35mm F4",
+        "16-50",
+        "16-50 Standard Kit",
+        "16-50.16mm",
+        "16-50mm",
+        "1650",
+        "18",
+        "18-135",
+        "18-50mm oss kit lens 16mm",
+        "3.5-5.6/16-50",
+        "30 f1.4",
+        "50mm 1.8 OSS",
+        "50mm F1.8",
+        "55210",
+        "7.52.8fish",
+        "70-200mm F4",
+        "7Artisans 25mm",
+        "7Artisans 35mm f/0.95 APS-C",
+        "7Artisans 7.5mm F2.8",
+        "7artisans 12mm 2",
+        "Canon 24-105",
+        "Laowa 10mm apc-s",
+        "Laowa 9mm f2.8",
+        "Rokinon",
+        "Rokinon 8mm Fisheye",
+        "SEL 70-200mm F4",
+        "SEL16F28",
+        "SEL16F28+VLC-ECU1",
+        "SEL2870",
+        "SIGMA 16mm f/1.4 DC DN",
+        "Samyang 12mm",
+        "Samyang 12mm f/2.0",
+        "Samyang 21mm f1.4",
+        "Samyang12mm f2",
+        "Sigma 16mm",
+        "Sigma 16mm 1.4",
+        "Sigma 16mm F1.4",
+        "Sigma 16mm f1.4",
+        "Sigma 16mm f1.4 DN",
+        "Sigma 18-50mm 2.8",
+        "Sigma 18-50mm F2.8 DC DN",
+        "Sigma 30F1.4",
+        "Sigma 30mm",
+        "Sigma 30mm 1.4",
+        "Sigma_16mm",
+        "Sony 10-18mm f4",
+        "Sony 16-50@50",
+        "Sony 18-105mm F4",
+        "Sony 20mm f2.8",
+        "Sony 3,5-5,6/16-50",
+        "Sony18-105",
+        "TAMRON18-300mm",
+        "Tamron 17-70",
+        "Tamron 28-200",
+        "Tamron 35-150",
+        "Yongnuo 50 f1.8",
+        "ZONLAI 25mm F1.8",
+        "ind",
+        "iowa 10mm",
+        "kit 16-50",
+        "rockstar 10MM F8",
+        "sigem-50/1.4",
+        "sigem50/1.4",
+        "sigma 30 f1.4",
+        "sigma 30mm F1.4",
+        "sony 35mm",
+        "sony E 16-50mm f/3.5-5.6 OSS PZ",
+        "tamron 17-70",
+        "yongnuo 50mm f1.8",
+        "索尼e50"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6400",
+      "lenses": [
+        "10-20 F4 G",
+        "11-20 11 4k",
+        "11mm",
+        "16-50",
+        "16-50GMaster(16mm端)",
+        "16-50mm",
+        "16-50mmm",
+        "16-70",
+        "17-70 35",
+        "1770 2.8 17",
+        "1770 f2.8 at 17",
+        "18-105 F4",
+        "18-105 g",
+        "18-105mm",
+        "18-50 f1:2.8s",
+        "35",
+        "35mm F1.8 OSS",
+        "4/16-70",
+        "50",
+        "55-210",
+        "7A 7.5mm Fisheye",
+        "7Artisans 50mm f0.95 Sony E-Mount",
+        "7artisans 7.5mm",
+        "7artisans 7.5mm f2.8",
+        "90mmf2.8",
+        "E 18-135mm F3.5-5.6 OSS",
+        "E 3.5-5.6/pz 16-50 oss",
+        "E16-50",
+        "EF 24-70mm F2.8 GM",
+        "Laowa 9mm F2.8 Zero-D",
+        "Laowa 9mm f/2.8 Zero-D",
+        "Laowa S35 7.5mm T2.9",
+        "Lens kit 16mm",
+        "NikonAF-24mm",
+        "Rokinon 14mm",
+        "SEL1670z",
+        "SEL18-200",
+        "SEL35mm",
+        "SELP1650 16mm",
+        "SELP18105F4G",
+        "SIGMA",
+        "SIGMA 16mm/F1.4 DC DN",
+        "SIGMA 56MM F1.4 DC DN",
+        "SIGMA 56mm",
+        "SONY 11mm F1.8",
+        "SONY SEL50F18F",
+        "Samyang 12mm 2.0",
+        "Sigma 10-20",
+        "Sigma 16 mm contemporane",
+        "Sigma 16 mm f/1.4 DC DN Sony E",
+        "Sigma 16mm Contemporane",
+        "Sigma 16mm F1.4",
+        "Sigma 16mm f1.4",
+        "Sigma 16mm f1.4 DC DN",
+        "Sigma 30 mm F1.4",
+        "Sigma 30mm F1.4",
+        "Sigma 30mm F1.4 DC DN",
+        "Sigma 30mm f1.4 dc dn",
+        "Sigma 56 1.4 art",
+        "Sigma16 1.4",
+        "Sigma16mm",
+        "Sigma30 1.4",
+        "Sigma30mm",
+        "Sigma_16_mm_f1,4_DC_DN",
+        "Sony 11mm f1.8",
+        "Sony 16-50",
+        "Sony 16-50 mm",
+        "Sony 16-50mm f/3.5-5.6 Montura E",
+        "Sony 16-55mm GM",
+        "Sony 18-135mm",
+        "Sony 35mm f1.8 SEL35F18",
+        "Sony 50",
+        "Sony E 16-50mm",
+        "Sony E 18-135mm F3.5-5.6 OSS",
+        "Sony E 35mm f1.8 OSS",
+        "Sony E1.8/11",
+        "Sony FE 28MM F2",
+        "Sony FE 50mm F1.8",
+        "Sony SEL18-200",
+        "Sony f3.5-5.6 16-50mm",
+        "Sony10-20G",
+        "TAMRON 17-70mm F/2.8",
+        "TAMRON_18-300_18mm",
+        "TTArtisans",
+        "Tamron 11-20",
+        "Tamron 17-70 2.8",
+        "Tamron 17-70mm @17mm F/2.8",
+        "Tamron 17-70mm F/2.8 @17mm",
+        "Tamron 17-70（17）",
+        "Tamron 1770",
+        "Tamron17-70 2.8 35mm",
+        "VILTORX 20MM f2.8",
+        "VILTROX 20MM  F2.8",
+        "VILTROX 20MM F2.8",
+        "VILTROX 27F1.2",
+        "VILTROX 27mmf1.2",
+        "VTX56mm",
+        "Viltrox 56mm 1.4",
+        "Ynlens YN50mm F1.8S DA DSM",
+        "e24",
+        "shima 50",
+        "sigma 10-20",
+        "sigma 18-50mm",
+        "sigma 30 F1.4",
+        "sigma 30mm",
+        "sigma 30mm F1.4",
+        "sigma 56 1.4 art",
+        "sigma 56 mm 1.4f",
+        "sigma c 16mm dn",
+        "sigma16-1.4",
+        "sigma16mm",
+        "sigma28-70",
+        "simga 18-50mm",
+        "sony 35mm f 1.8",
+        "sony 55-210mm",
+        "sony e 1.8/11",
+        "sony e 11mm f1.8",
+        "sony16mm",
+        "tamron 11-20",
+        "tamron 1770 f2.8 17",
+        "tenglong11-20",
+        "viltrox 35mm",
+        "vtx 56mm F1.7",
+        "xingyao35mmF0.95",
+        "ynlens-50mm",
+        "zenith 58f2",
+        "卫斯理25 F 1.7",
+        "唯卓仕 20mm F2.8",
+        "唯卓仕 56mm F1.7",
+        "唯卓仕23e1.4",
+        "唯卓士23 1.4",
+        "唯卓士751.2",
+        "永诺FE50",
+        "腾龙11-20",
+        "腾龙11-20 2.8",
+        "腾龙17-70",
+        "腾龙17-70 2.8",
+        "腾龙17-70 35mm",
+        "自测腾龙11-20 16mm",
+        "自测腾龙17-70 17mm 4k",
+        "适马56",
+        "适马56 1.4"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6500",
+      "lenses": [
+        "16 mm 1.4 sigma",
+        "18-50",
+        "18/135mm 3.5-5.6",
+        "28 MM 2.0",
+        "30 mm 2,8 sigma",
+        "56 f1.7",
+        "E PZ 16-50 мм F3.5-5.6 OSS",
+        "Rokinon 12mm CINE",
+        "SONY E 16-503.5-5.6F OSS",
+        "Sigma 16mm",
+        "Sigma 18-50mm",
+        "Sigma 24mm F3.5 DG DN Contemporary",
+        "Sony 10-18mm F4",
+        "Sony 4/18-105",
+        "Sony 4/18-105mm",
+        "Sony 50mm",
+        "Sony FE 28-70 f/3.5-5.6",
+        "Sony SEL35F18",
+        "Viltrox 13mm f.14",
+        "sanyang 35 1.4 af",
+        "sigma 30mm",
+        "sony 4/18-105",
+        "viltrox fe20 f2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6600",
+      "lenses": [
+        "10-18",
+        "10-18mm",
+        "18-105mm f4",
+        "24mm",
+        "3.5-5.6 / 18-135 OSS",
+        "SELP18105G",
+        "Sigma 16-28mm F2.8",
+        "Sigma 56mm F1.4",
+        "Sigma30 1.4",
+        "pz10-20",
+        "sony 3.5-5.6 / 18-135"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a6700",
+      "lenses": [
+        "16.00mm",
+        "17.00mm",
+        "18-105mm F4 OSS",
+        "18-105mmf4 105.00mm",
+        "18-35mm Sigma Art 1.8",
+        "18.00mm",
+        "18.00mm-50.00mm",
+        "18135/18",
+        "20.30mm",
+        "27.00mm",
+        "30.00mm",
+        "35.00mm",
+        "50.00mm",
+        "56.00mm",
+        "70.00mm",
+        "BRIGHTSTAR 12mm",
+        "LAOWA",
+        "Laowa 9mm",
+        "Meike 35mm f1.4",
+        "Rokinon 12mm F2.8 ED AS NCS Fish-eye",
+        "SELP1020G",
+        "SIGMA 18-50:2.8 DGDN",
+        "SIGMA 18-50mm F2.8  DC DN",
+        "SIGMA 30 F1.4 DC DN",
+        "SONY 15.00mm F1.4",
+        "Samyang Rokinon 12.00mm F2 AF",
+        "Samyang Rokinon 12.00mm F2 AF APS-C",
+        "Samyang24.00mm f1.8",
+        "Sigm 18-50 2.8",
+        "Sigma 18-35 1.8 ART",
+        "Sigma 18-35mm 1.8 ART",
+        "Sigma 18-50",
+        "Sigma 18-50 18.00mm",
+        "Sigma 18-50 50.00mm",
+        "Sigma 18-50 F2.8 DC DN",
+        "Sigma 18-50 f2.8 36.30mm",
+        "Sigma 18-50mm F2.8 24.0mm",
+        "Sigma 18-50mm F2.8 35.0mm",
+        "Sigma 18.50 F2.8 DC DN",
+        "Sigma 30mm F1.4 DC Art APS-C",
+        "Sigma 30mm f 1.4",
+        "Sigma 56.00mm",
+        "Sigma 56mm 1.4",
+        "Sigma 56mm f1.4",
+        "Sirui Sniper 23mm F1.2",
+        "Sony 15.00mm",
+        "Sony 18-135mm f5.6 135.00mm",
+        "Sony 50-210.00mm",
+        "Sony 50mm F1.8",
+        "Sony 70-350",
+        "TAMRON 18.00mm",
+        "TAMRON_17-70_17.00mm",
+        "TARMRON 18-300",
+        "TTArtisan AF 27mm f/2.8",
+        "Tamron 17-70mm",
+        "Tamron 17-70mm @ 35mm",
+        "Tamron 18-300 (18.00mm)",
+        "Tamron 28-75 F2.8 Di III RXD",
+        "VILTROX 27.00mm",
+        "Viltrox 27mm",
+        "Yashinon-DS 50mm f1.2",
+        "Yongnuo 11mm F/1.8S DA",
+        "Yongnuo 16.00mm",
+        "e 18-70 f2.6",
+        "laowa 9mm",
+        "sanyang12mmF2.0",
+        "sigma 16-28mmF2.8(16.00mm)",
+        "sigma 18-50 24mm",
+        "sigma 18-50 28mm",
+        "sigma 18-50 35mm",
+        "sigma 18-50 50mm",
+        "sigma 18-50 F2.8 18.00mm",
+        "sigma 18-50@18.00mm",
+        "sigma 18-50mm",
+        "sigma 23.00 mm",
+        "sigma 23.00mm f1.4",
+        "sigma 30 F1.4 DC DN",
+        "sigma 30.00mm",
+        "sigma 30f1.4",
+        "sigma 56.00mm F1.4",
+        "sigma(18 50)-18mm",
+        "sigma(18 50)-35mm",
+        "sigma18-50 18.00mm",
+        "sigma18-50mm F2.8 50.00mm",
+        "sony 18-105mm F4 G",
+        "tamron 17-70 2.8",
+        "viltrox唯卓仕 27.00 1.2pro",
+        "viltrox唯卓仕 27.00 1.2promm",
+        "yongnuo 11.00mm f1.8",
+        "铭匠光学50mm 0.98"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7",
+      "lenses": [
+        "16mm+0.75",
+        "7Artians",
+        "CHINON-AUTO f35",
+        "HELIOS 44-2",
+        "SEL50F18F",
+        "VILTROX AF 20MM F2.8 FE",
+        "VILTROX AF 20mm F2.8 FE 56A11",
+        "VILTROX AF 85MM F1.8 FE",
+        "tamton 28-75mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "A7 IV",
+      "lenses": [
+        "Sigma 28-70mm 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a77",
+      "lenses": [
+        "16"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7C",
+      "lenses": [
+        "10",
+        "10-24",
+        "10mm",
+        "11baea79",
+        "12mm (Apsc)",
+        "16-35 f4 OSS",
+        "18a19563",
+        "19f7ecbf",
+        "20-40 @ 20mm",
+        "20-70 G",
+        "20-70G@70MM",
+        "20b5c305",
+        "20d9ac3d",
+        "20f67252",
+        "20mm 1.8",
+        "21a16994",
+        "24 fe",
+        "24-105.24",
+        "24-105mm",
+        "24-240",
+        "24-240 f3.5-6.3",
+        "24e23644",
+        "24f78111",
+        "24mm",
+        "27c49f08",
+        "28-60mm@60mm",
+        "28-70 c522b64f",
+        "28-75",
+        "2875",
+        "2875G2",
+        "351.8",
+        "48e423ad",
+        "50mm 1.8",
+        "50mm f1,7 meike",
+        "50mm f2.5",
+        "55",
+        "55mm f/1.8",
+        "55mm f1.8 zeiss",
+        "7 artisans 25mm f1.8 e mount (APSC)",
+        "7.5mm Fisheye APSC",
+        "70-180",
+        "70-300",
+        "7Artisans 10mm 1:2.8 Fisheye ED",
+        "7abb6735",
+        "7artisans 10mm fisheye",
+        "85mm 1.8",
+        "932993f",
+        "95216789",
+        "AF 85mm F1.4 FE",
+        "Contax Planar 1,4/50",
+        "EF 24-70mm F2.8 GM",
+        "EF 28-60mm F4-5.6",
+        "EF 35mm F1.8",
+        "FE 1.2/50 GM",
+        "FE 1.8/50",
+        "FE 16-35mm F4 ZA OSS",
+        "FE 28-60 @28",
+        "FE 4-5.6/28-60",
+        "FE 4/20-70 G",
+        "FE 4/24-105 G OSS",
+        "FE1.8/20G",
+        "FE16-35F4za",
+        "FE24-70F4za",
+        "FE2470F4za",
+        "FE55/1.8",
+        "Helios 44-2",
+        "Kit 28-70mm",
+        "LAOWA 15mm F.4 MACRO",
+        "LAOWA 15mm f/4 MAcro",
+        "Laowa 9mm f/5.6 FF RL",
+        "MINolta55mm",
+        "Minolta MC Rokkor 28mm f2.5",
+        "Nisi 15mm f4",
+        "RockStar 10mm MKII",
+        "RoclStar 10mm F8 MKII",
+        "RoclStar 10mm F8 MKii",
+        "SEL1018",
+        "SEL1224GM",
+        "SEL2070G",
+        "SEL20F18G",
+        "SEL24105G",
+        "SEL24105G@24mm",
+        "SEL2470GM2",
+        "SEL28F20",
+        "SEL40F25G",
+        "SIGMA 24-70mm F2,8 DG DN | Art",
+        "SIGMA 28-70 2.8 dgdn",
+        "SLR Magic 25mm f1.4",
+        "SONY 20-70 F4G 20mm",
+        "Samyang 12mm f/2.0 CS E",
+        "Samyang 18 2.8",
+        "Samyang 24 mm f/1.8",
+        "Samyang 24-70mm",
+        "Samyang 24mm 2.8",
+        "Samyang 35mm f1.8",
+        "Samyang 50mm f1.2",
+        "Samyang 50mm f1.4",
+        "Samyang 75mm f1.8",
+        "Samyang 85mm f1.4 v1",
+        "Samyang AF 35mm F3.8 FE",
+        "Samyang FE 18mm 2.8",
+        "Samyang FE 35 2.8",
+        "Samyang FE 35MM 1.8",
+        "Sigma 16-28mm 1:2.8 DG DN",
+        "Sigma 20 F2",
+        "Sigma 24 mm 1.4",
+        "Sigma 24-70",
+        "Sigma 24-70mm",
+        "Sigma 24-70mm F2,8 DG DN | Art",
+        "Sigma 24-70mm f/2.8 DG DN Art",
+        "Sigma 28-70 F2.8 DG DN",
+        "Sigma 28-70 f2.8",
+        "Sigma 28-70mm",
+        "Sigma 35 F2",
+        "Sigma 35mm f2",
+        "Sigma 65 F2 DG DN 20",
+        "Sigma art 24-70",
+        "Sigma2470",
+        "Sigma28-70",
+        "Sigma28-70/2.8",
+        "Sigma_35mm_F2_DGDN",
+        "Sirui Anamorphic 50mmF1.8 1.33",
+        "Sony 20mm f1.8 G",
+        "Sony 24mm 1.4 GM",
+        "Sony 24mm F/2.8 G",
+        "Sony 28-60(@28)",
+        "Sony 35mm F/1.4 GM",
+        "Sony 50mm F/2.5 G",
+        "Sony 85mm F/1.4 GM",
+        "Sony FE 35mm f1.8",
+        "Sony FE 4-5.6 / 28-60",
+        "Sony FE 4-5.6 /28-60",
+        "Sony FE 85mm 1.8",
+        "Sony SEL11F18",
+        "Sony SEL20F18G",
+        "Sony SEL28F2",
+        "Sony SEL28FE20",
+        "Sony SEL35F18F",
+        "Sony28-60",
+        "Sony_A7C_SuperTakumar_55mm_F1_8_3840x2140_30fps",
+        "TAMRON 17-28@17MM",
+        "TAMRON 70-180 F2.8",
+        "TTArtisans 11mm f2.8",
+        "Tamron 17-28 A046",
+        "Tamron 17-28 f 2.8 Di III RXD",
+        "Tamron 17-50F4 Di III VXD",
+        "Tamron 17-50F4 Di III VXD 17mm",
+        "Tamron 17-50F4 Di III VXD 20mm",
+        "Tamron 17-50F4 Di III VXD 24mm",
+        "Tamron 17-50F4 Di III VXD 28mm",
+        "Tamron 1728",
+        "Tamron 20-40",
+        "Tamron 20-40 f/2.8",
+        "Tamron 20F2.8",
+        "Tamron 20mm 2.8",
+        "Tamron 24mmn F/28 Di III OSD",
+        "Tamron 28-200 @ 100",
+        "Tamron 28-200 @ 135",
+        "Tamron 28-200 @ 200",
+        "Tamron 28-200 @ 28",
+        "Tamron 28-200 @ 35",
+        "Tamron 28-200 @ 50",
+        "Tamron 28-200 @ 70",
+        "Tamron 28-200mm f/2.8-5.6",
+        "Tamron 28-75",
+        "Tamron 28-75 Di VXD G2",
+        "Tamron 28-75 F2.8 G2",
+        "Tamron 35mm FE/2.8 Di III OSD",
+        "Tamron FE 20-40 @20mm",
+        "Tamron FE 20-40 @20mm 1.2x 30fps",
+        "Tamron FE 20-40 @28mm",
+        "Tamron FE 20-40 @28mm 30fps 1.2x",
+        "Tamron FE 20-40 @40 1.5x Crop + Zoom 1.5x",
+        "Tamron FE 20-40 @40mm",
+        "Tamron FE 20-40 @40mm + Zoom 1.5x",
+        "Tamron FE 20-40 @40mm 30fps 1.2x",
+        "Tamron FE 20-40 @40mm 30fps 1.2x + 1.5x Zoom",
+        "Tamron FE 20-40 @40mm Crop 1.5 + Zoom 1.5",
+        "Tamron FE 28-200 @100mm",
+        "Tamron FE 28-200 @40mm",
+        "Tamron FE 28-200mm 2.8",
+        "Tamron-28-75-2g",
+        "Tamron70-300",
+        "Topcor 57mm",
+        "VILTROX 16mm 1.8f",
+        "Viltrox 20mm/2.8 FE",
+        "Viltrox 40mm f.5",
+        "YN85MM F1.8",
+        "Zeiss Batis 2/25",
+        "Zeiss Loxia 21mm f2.8",
+        "Zeiss Loxia 35mm",
+        "a3a23ffd",
+        "aps-c   18mm",
+        "aps-c  35mm",
+        "betis 18mm 2.8",
+        "betis18mm",
+        "e7403f4a",
+        "eca95ab9",
+        "fe20-70f4",
+        "meike 35mm 1.7",
+        "samyang 18mm f2.8",
+        "samyang 24",
+        "samyang14mmt3.1",
+        "sel20f18g",
+        "sel24240 @ 240mm",
+        "sel24240 @240mm",
+        "sel2860",
+        "sigma",
+        "sigma 24-70 24mm",
+        "sigma 28-70 DG DN",
+        "sony fe2870",
+        "sony20F1.8",
+        "tamron 28-75 di 3 f/2.8",
+        "viltrol 20.00mm f2.8",
+        "viltrox 20.00mm f2.8",
+        "yongnuo50",
+        "zeiss Batis 18",
+        "zeiss Batis 40",
+        "zeiss Batis 85",
+        "zeiss batis 85",
+        "唯卓仕AF85/1.8 II",
+        "腾龙24mmF2.8 Di III",
+        "腾龙28-75"
+      ],
+      "crop_factor": 1.2,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7CII",
+      "lenses": [
+        "102.00mm",
+        "14.00mm  samyang",
+        "16-28 2.8",
+        "16-50 20MM",
+        "16-50 apsc",
+        "18.00mm",
+        "20.00mm",
+        "2875G2",
+        "2875g2_75mm",
+        "35mm APSC Mode",
+        "50.00mm",
+        "75.00mm",
+        "75.00mm F1.8 SAMYANG",
+        "FE 20-70g f4",
+        "FE 20-70mm",
+        "FE 20-70mm F4",
+        "FE 24-105G",
+        "FE85/F1.8",
+        "Kodak 30mm F10 Disposal Lens",
+        "Kodak 30mm f10",
+        "SONY 20-70 F4G 20-70mm",
+        "SONY 20-70 F4G 20mm",
+        "Samyang 35.00mm",
+        "Samyang V-AF T1.9 75mm",
+        "Sig28-70/F2.8",
+        "Sig28-70/f2.8",
+        "Sigma 24-70 DG DN Art II",
+        "Sony FE 35 f1.8",
+        "Sony FE 55 f1.8",
+        "TL2875 75.00mm",
+        "TTartisan 11mm F2.8",
+        "Tam17-28/f2.8",
+        "Tam20/F2.8",
+        "Tam20/f2.8",
+        "Tam20mm",
+        "Tam70-300/f4.5-6.3",
+        "Tamron 17-28mm f2.8",
+        "Tamron 20-40mm F/2.8 DiIII VXD",
+        "Tamron 24.00mm f2.8",
+        "Tamron 24mm f2.8",
+        "Tamron 28-200 @ 28.00mm",
+        "Tamron 28-200-28.00mm",
+        "Tamron17-28",
+        "Tokina Firin 20.00mm",
+        "VILTROX  27.00mm",
+        "VILTROX 16.00mm",
+        "Viltrox 20 2.8",
+        "Viltrox 20 f2.8",
+        "Viltrox 20mm f2.8",
+        "Viltrox 50mm F1.8",
+        "Viltrox AF 20mm F2.8 FE",
+        "Viltrox AF 20mm f/2.8 FE",
+        "Voigtlander\nAPO-LANTHAR 50mm F2 Aspherical",
+        "YN 85.00mm 1.8",
+        "YN50.00mm f/1.8 DF DSM",
+        "YnLens-35mm-F2",
+        "kit FE 3.5-5.6 28-70mm",
+        "samyang 35.00mm f2.8",
+        "sigma 28 70 2.8 28.00mm",
+        "sigma 28 70 28.00mm",
+        "sigma 28-70=28.00mm",
+        "sigma28-70 28.00mm",
+        "sigma85.00mm1.4",
+        "sumyang75.00mm",
+        "tamron 28-200 @ 134.00mm",
+        "tamron 28-200 @ 158.00mm",
+        "tamron 28-200 @ 28.00mm",
+        "tamron 28-200 @ 35.00mm",
+        "tamron 28-200 @ 49.00mm",
+        "tamron 28-200 @ 69.00mm",
+        "tamron 28-200 @ 98.00mm",
+        "ttartisan 10mm"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7Cr",
+      "lenses": [
+        "21.00mm NOKTON 21 mm F1.4 Aspherical",
+        "Sony 20-70mm f4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7II",
+      "lenses": [
+        "28-70mm",
+        "50mm",
+        "85mm F1.8",
+        "Batis 85",
+        "FE 3.5-5.6 28-70 OSS",
+        "FE 85mm F1.8",
+        "Pentax 40mm",
+        "Sony FE 1.8/50",
+        "Viltrox  viltrox 85 F1.8 STM ED IF",
+        "leica R 35 f2",
+        "sony 50mm",
+        "viltrox 20mm 2.8 fe"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7III",
+      "lenses": [
+        "16-35",
+        "16-35 f4",
+        "16-35mm f/2.8",
+        "16c",
+        "16mm 1:1.4 DC DN",
+        "17",
+        "24-105",
+        "24-105 gss stds",
+        "24-70",
+        "24-70 F2.8",
+        "24-70mm F2.8",
+        "2470F4",
+        "24mm",
+        "28-70",
+        "28-70 F3.5-5.6",
+        "28-70/3.5-5.6",
+        "28-75",
+        "28-75@28",
+        "3.5-5.6/28-70",
+        "35c",
+        "35mm F1.8",
+        "35mm f/2.8 Di III OSD M 1:2",
+        "35mm sigma",
+        "35mmF1.4",
+        "4/18-105 stock",
+        "50",
+        "50MM 1.8",
+        "50mm",
+        "50mm 1.8 FE",
+        "55 1.8",
+        "55 1.8 ZA",
+        "55f1.8",
+        "55mm F1.8 ZA",
+        "55mm f1.8",
+        "70mm",
+        "85mm",
+        "A047",
+        "AstrHori 50 F2",
+        "Astrhori50f2",
+        "Canon 16-35mm f4 L",
+        "Canon FD 28mm",
+        "Canon L 16-35mm f.4",
+        "Cine 21mm IRIX",
+        "FE 1.4/35 GM",
+        "FE 1.8/35",
+        "FE 24-105 mm F4 G OSS",
+        "FE 4 / 24-105 G OSS",
+        "FE 4/ 25-105 G OOS",
+        "FE 4/12-24 G",
+        "FE 4/24-105 G OSS",
+        "FE 50mm 1.8",
+        "FE4 /24-105 G OSS",
+        "GM 16-35",
+        "GM 16-35mm 2.8",
+        "GMaster FE 2.8/24-70",
+        "Helios 44-6",
+        "Laowa",
+        "Laowa 15mm",
+        "Pergear 10mm f2.8",
+        "ROKINON 14 MM",
+        "Rokinion-12mm-APSC",
+        "Rokinon 12mm",
+        "Rokinon 14mm T3.1",
+        "SAMYANG 14MM F2.8",
+        "SAMYANG 24mm F2.8 AF - SONY FE",
+        "SEL 70-200/f4.0 @200mm",
+        "SEL2470Z",
+        "SELP18105G",
+        "SHIMA 35mm F1.4",
+        "SIGMA 14-24 F2.8",
+        "SIGMA 14MM",
+        "SIGMA 14MM PRIME",
+        "SIGMA 24-70mm",
+        "SIGMA ART 18-35MM 1.8",
+        "SONY FE 4/16-35",
+        "Samyang 14 F2.8",
+        "Sigma 16mm 1.4 DC",
+        "Sigma 24-70",
+        "Sigma 24-70mm",
+        "Sigma 24-70mm f/2.8",
+        "Sigma 24-70mm f2.8 DG DN",
+        "Sigma 28-70 mm",
+        "Sigma 35 mm 1.4 ART DN",
+        "Sigma 35mm 1.4 DG Art",
+        "Sigma 35mm 1:1.4 DG",
+        "Sigma 35mm f/1.4",
+        "Sigma 40mm 1.4",
+        "Sigma Art 24mm 1.4",
+        "Snoy 28mm F2",
+        "Sonnar T* FE 55mm F1.8 ZA",
+        "Sony 24-105",
+        "Sony 24-70",
+        "Sony 28mm F2",
+        "Sony 35mm F1.8",
+        "Sony 35mm f1.8",
+        "Sony 50 mm 1.8",
+        "Sony 50mm f1.8",
+        "Sony 85mm 1.8",
+        "Sony FE 1.8/85",
+        "Sony FE 2.8/24 G",
+        "Sony Prime 35mm f1.8",
+        "Sony SEL 24-240mm 1:3,5-6,3 FE OSS",
+        "Sony Sigma 18-105",
+        "Sony Zeizz 4/24-70",
+        "TAMRON 28-200 F2.8",
+        "TAMRON 28-75",
+        "TAMRON 28-75 F/2.8 Di III VXD G2",
+        "TAMRON-28-75mm F/2.8",
+        "TAMRON28-75II",
+        "TAMROW 28-75mm F/2.8 Di III VXD G2",
+        "Tamron 17-28 F2.8 -- 17mm",
+        "Tamron 17-28mm f2.8",
+        "Tamron 28 - 75mm F/2.8 Di III RXD",
+        "Tamron 28-200 @28 Di III RDX",
+        "Tamron 28-200 @28 Di III RXD",
+        "Tamron 28-74",
+        "Tamron 28-75",
+        "Tamron 28-75mm F/2.8[28mm]",
+        "Tamron 28-75mm F/2.8[50mm]",
+        "Tamron 28-75（28mm）",
+        "Tamron 28-75（28端）",
+        "Tamron 28-75（28）",
+        "Tamron 28-75（75mm）",
+        "Tamron DI III RXD",
+        "Tamron20/2.8",
+        "Tamron28-75/2.8Di III",
+        "Viltrox 20mm 2,8",
+        "Viltrox 20mm/f2.8",
+        "Vivitar 28mm f2.8",
+        "Vivtar 28mm f2.8",
+        "ZEISS FE 1.8/55mm",
+        "Zeiss Contax 25mmF2.8",
+        "batis25",
+        "canon 24-70@24mm",
+        "canon EF 50 F1.4",
+        "fe 1.8/20 G",
+        "fe 3.5 -5.6 28-70MM",
+        "fe 4/24-105 g oss",
+        "g-master",
+        "kit 28-70",
+        "kit 3.5-5.6 28-70 28mm",
+        "kit 3.5-5.6/28-70",
+        "kit 3.5-5.6/28-70mm",
+        "kit FE 3.5/5.6 28-70 55",
+        "kit fe 3.5-5.6-28-70mm",
+        "laowa 9mm f/2.8",
+        "samjang af 35/1.8FE",
+        "samyang",
+        "samyang 18 f2.8",
+        "samyang 35mm 1.4",
+        "samyang 45mm",
+        "sigma 14-24mm",
+        "sigma 24 - 70 mm",
+        "sigma 28mm f28",
+        "sigma 35mm",
+        "sigma art 85mm 1.4 dg dn",
+        "sony 28-70mm",
+        "sony 85mm 1.8",
+        "sony Gseries 20mm f1.8",
+        "sony20-70",
+        "tamrom 28 75 mm f/2.8",
+        "tamron 17-28",
+        "tamron 35 mm",
+        "viltrox 20mm",
+        "腾龙20 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7IV",
+      "lenses": [
+        "12 - 24mm F2.8 GM",
+        "13.00mm",
+        "14.00 f1.8 GM",
+        "14.00mm",
+        "16-35",
+        "16.00mm",
+        "17.00mm Tamron AF 17-28mm f/2,8 Di III RXD",
+        "20.00mm Tamron AF 17-28mm f/2,8 Di III RXD",
+        "24-70mm F2.8 DG DN | Art",
+        "24.00-70mm sigma art",
+        "24.00mm Tamron AF 17-28mm f/2,8 Di III RXD",
+        "28-75",
+        "28-75mm",
+        "28.00-75.00mm",
+        "28.00mm",
+        "28.00mm -75mm",
+        "28.00mm Tamron AF 17-28mm f/2,8 Di III RXD",
+        "28.00mm-70mm",
+        "28.90mm",
+        "28mm with 1,5x Crop",
+        "34.80mm",
+        "35.00mm",
+        "35.00mm Tamron 28-75mm f/2,8 Di III VXD G2",
+        "40.50mm",
+        "41.90mm",
+        "42.30mm",
+        "44M-6",
+        "49.90mm",
+        "50.00mm Tamron 28-75mm f/2,8 Di III VXD G2",
+        "50.20mm",
+        "58.80mm",
+        "59.20mm",
+        "70.00mm",
+        "75.00mm",
+        "7ARTISANS 35MM F/1.4 II",
+        "7Artisans 10mm fisheyes",
+        "7Artisans 50mm F0.95",
+        "7Artisans 7.5mm",
+        "7artisans 10mm f2.8",
+        "7artisans 10mm f2.8 APS-C",
+        "7artisans 10mm2.8",
+        "85.00mm",
+        "AstrHori50mmF2.0",
+        "CANON FL 35 2.5",
+        "CHINON 28mm",
+        "CHINON 35mm",
+        "CHINON 50mm",
+        "Canon 100mm",
+        "Canon 10mm",
+        "Canon 50mm",
+        "Canon EF 24 1.4 L II",
+        "E 3.5-5.6/PZ 16-50 OSS SELP1650",
+        "FE PZ 16-35mm F4 G",
+        "FE Sony 4/ 24-105 G OSS",
+        "FE4/24-105MM",
+        "Helios 44-3",
+        "Helios 44M-6",
+        "Helios44-2",
+        "IRIX Cine 30mm",
+        "Irix 45mm",
+        "Irix cine 45mm",
+        "Laowa 12mm",
+        "Laowa 15mm F4",
+        "Laowa 1mm",
+        "Laowa 35mm F0.95",
+        "Laowa 35mm f0.95",
+        "Laowa 9mm",
+        "Laowa 9mm f5,6",
+        "Laowa 9mm f5.6",
+        "Laowa_11_4.5",
+        "Laowa_11_no_Crop",
+        "Minolta 50mm f2",
+        "Minolta_35mm",
+        "Nikon 35mm 2.8",
+        "Pentax 28mm F2.8",
+        "RockStar 12mm F2.0",
+        "Rokinon CAF35 T1.9",
+        "SAMYANG 14mm",
+        "SAMYANG 24mm",
+        "SAMYANG 35.00mmF2.8",
+        "SAMYANG 35mm",
+        "SAMYANG 75.00mm F1.8",
+        "SAMYANG 85mm",
+        "SAMYANG 8mm",
+        "SAMYANG AF 50mm F1,4 II FE für Sony E",
+        "SELP1635G",
+        "SIGMA 16-28mm@42mm",
+        "SIGMA 2470mm f2.8",
+        "SIGMA16-28@24mm",
+        "SIGMA2470:24.00mm",
+        "SIGMA40.00mmF1.4",
+        "SLR Magic 35mm",
+        "SLR Magic Micro Prime",
+        "SLR Magic MicroPrime CINE 35mm T1.3",
+        "Samyang 12",
+        "Samyang 12mm F2.0",
+        "Samyang 14mm",
+        "Samyang 14mm F2.8 EF manual lens",
+        "Samyang 24.-70 mm f2.8",
+        "Samyang 24.00mm f2.8",
+        "Samyang 35-150",
+        "Samyang 35.00mm f1.4",
+        "Samyang 35mm 1.8",
+        "Samyang 45.00mm",
+        "Samyang 45.00mm F1.8",
+        "Samyang 75.00mm f1.8",
+        "Samyang 85mm T1.5",
+        "Samyang AF 12mm F2.0",
+        "Samyang_12",
+        "Sigma 14-24 @ 14",
+        "Sigma 14-24 @14",
+        "Sigma 14-24 @24",
+        "Sigma 14-24.00mm f2.8 @24mm",
+        "Sigma 14-24mm f2.8 @24mm",
+        "Sigma 16-28 F2.8",
+        "Sigma 16-28 F2_8",
+        "Sigma 16-28mm f/2.8",
+        "Sigma 16-28mm f2.8",
+        "Sigma 16.00mm",
+        "Sigma 16_28 F2_8",
+        "Sigma 24-70 @24",
+        "Sigma 24-70 DG DN at 24.00mm",
+        "Sigma 24-70 DG-DN Art",
+        "Sigma 24-70mm",
+        "Sigma 24-70mm 2.8 DG DN ART",
+        "Sigma 24-70mm DG DN",
+        "Sigma 24-70mm f/2.8 DG DN",
+        "Sigma 28-70 (only for 28mm)",
+        "Sigma 28-70mm",
+        "Sigma 35.00mm",
+        "Sigma 35mm f1.4",
+        "Sigma 85.00mm",
+        "Sigma art 18-35 (35.00mm)",
+        "Sigma art 18-35mm F1.8 (18.00mm)",
+        "Sigma1424.00mm",
+        "Sigma24-70@35.00mm",
+        "Sony 16-35mm G",
+        "Sony 16-50mm",
+        "Sony ESLP 18mm 3.5-6.3/18-200",
+        "Sony FE 35 mm F1.4 GM",
+        "Sony FE35 SEL35F18F 35.00mm",
+        "Super Takumar 35mm F2",
+        "TAMRON 20-40 F2.8 20.00mm",
+        "TAMRON 20-40mm F2.8 20.00mm",
+        "TAMRON 200.00mm",
+        "TAMRON 28-75.00mm",
+        "TAMRON E 17-28 f2.8",
+        "TAMRON E 35-150 f2-2.8",
+        "TAMRON FE 28-75mm",
+        "TAMRON20-40mm F2.8 40.00mm",
+        "TAMRON2875G2 @ 51.00mm",
+        "TOMRON28-75A6350mm",
+        "TOMRON28-75A6375mm",
+        "TTArtisan 50mm f0.95",
+        "Tamron 17-28 @17.00mm",
+        "Tamron 17-28 mm f2.8",
+        "Tamron 17-28mm F2.8 @ 17mm",
+        "Tamron 17-28配置文件",
+        "Tamron 20-40mm @20mm",
+        "Tamron 20-40mm F2.8",
+        "Tamron 20mm 2.8",
+        "Tamron 28-200",
+        "Tamron 28-200mm",
+        "Tamron 28-75",
+        "Tamron 28-75 50.00mm",
+        "Tamron 28-75 @ 28.00mm",
+        "Tamron 28-75 G2 @28.00mm",
+        "Tamron 28-75 f/2.8 G2",
+        "Tamron 28-75 f/2.8 ff28.00mm",
+        "Tamron 28-75 f2.8 Di III RXD",
+        "Tamron 28-75 f2.8 G2",
+        "Tamron 28-75-28.00mm",
+        "Tamron 28-75mm F2.8",
+        "Tamron 28-75mm F2.8 @28.00mm",
+        "Tamron 28-75mm G1 23.976fps @28.00mm",
+        "Tamron 28-75mm G1 75.00mm",
+        "Tamron 28-75mm f/2.8 Di III VXD G2",
+        "Tamron 28-75mm f/2.8 g2",
+        "Tamron 28-75mm f2.8 @50.00mm",
+        "Tamron 28-75mm f2.8 @75.00mm",
+        "Tamron 28-75mm f2.8 G2",
+        "Tamron 28.00mm",
+        "Tamron 35-150",
+        "Tamron 35-150 f/2-2.8 50mm",
+        "Tamron 35-150 f/2-2.8 85.00mm",
+        "Tamron 35-150mm Di III VXD",
+        "Tamron 35-150mm f/2-2.8 Di III VXD 35.00mm",
+        "Tamron 50-400mm F4.5-6.3 VC VXD (A067) 200mm",
+        "Tamron 50-400mm F4.5-6.3 VC VXD (A067) 400.00mm",
+        "Tamron 50-400mm f4.5-6.3",
+        "Tamron 70-300 (300mm)",
+        "Tamron_17-28mm_F2.8",
+        "Venus Optics Laowa 10.00mm",
+        "Venus Optics Laowa 10.00mm F2.8",
+        "Venus Optics laowa 10.00mm",
+        "Viltrox 20.00mm f2.8",
+        "Vivitar 28mm f2",
+        "Voigtlander_10.00mm",
+        "YONGNUO1.8 @ 50.00mm",
+        "Zeiss 24-70mm",
+        "Zeiss 55.00mm",
+        "Zeiss Batis 135mm F2.8",
+        "Zeiss Batis 18.00mm",
+        "Zeiss Praktikar 50mm",
+        "irix 45mm cine",
+        "laowa 12mm",
+        "pz1635f4-16.00mm",
+        "samyang35.00mmf2.8",
+        "sigma 28-70 28.00mm",
+        "sigma 28-70 f2.8",
+        "sirui 35mm saturn t2.9",
+        "tamron 28-75mm",
+        "vvd",
+        "yongnuo50.00mm",
+        "zeiss 16-35mm",
+        "美能达Auto.Rokkor- PF 58/1.4"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7r",
+      "lenses": [
+        "50",
+        "Sony FE 1.8/50mm",
+        "Voigtlander Nokton 35mm f1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7RII",
+      "lenses": [
+        "24-70",
+        "28F2",
+        "35-2.8",
+        "50MMF1.8",
+        "50f2",
+        "7.5mm",
+        "7.5mm f2",
+        "Canon FD 50mm f/1.4",
+        "EF-E 35MM F1.4",
+        "Laowa 9mm f4.5",
+        "MEIKE 85 1.8",
+        "SAMYANG 12MM T3.1",
+        "SONY 10-20 f4",
+        "Samyang 14mm f2.8",
+        "Samyang FE AF 35mm F2.8",
+        "Sigma 24-70mm",
+        "Sigma 24-70mm F2.8 DG DN Art for Sony E Lens",
+        "Sony 24-240mm",
+        "TTArtisan  7.5mm F2",
+        "Tamron 28-200 F/2.8-5.6 Di III RXD",
+        "e 18-200 f3.5",
+        "f2.8 35mm",
+        "yongnou 35 f2",
+        "zeiss batis",
+        "岩石星50F2",
+        "岩石星50MMF2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7RIII",
+      "lenses": [
+        "16-35 F2.8",
+        "16-35mm F2.8",
+        "24MM  F1.8",
+        "28 tamron",
+        "28-200",
+        "28-200mm 28mm",
+        "35150",
+        "50mm",
+        "55-300NIKON",
+        "90macro",
+        "FE 24-70mm F4",
+        "FE 28-70 F3.5",
+        "FE 3.5 28-70",
+        "FE 4/24-105 G 0SS",
+        "FE 4/24-105 G OSS",
+        "FE4、24-70",
+        "PLANAR 50MM",
+        "Pentax 16-85",
+        "SEL2470GM",
+        "SEL3514GM",
+        "Sigma",
+        "Sigma-247-",
+        "Sony 14mm",
+        "Sony 24-240",
+        "Sony FE 1.4/35 GM",
+        "Sony FE 16-35mm f2.8 GM",
+        "TAMRON 28-200mm 28mm",
+        "Tamron 17-28",
+        "Tamron 18300",
+        "Tamron 28-75",
+        "Tamron 28-75mm 28mm",
+        "ZEISS FE 2.8 / 35",
+        "sel50f18f",
+        "sigma dg dn 28-70 f2.8",
+        "tamron 28-200 28mm",
+        "zeiss 18",
+        "森养-20mmT1.9",
+        "森养20mm T1.9"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rIIIA",
+      "lenses": [
+        "Sigma 16mm F1.4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rIV",
+      "lenses": [
+        "20mm",
+        "24-105",
+        "FE 2.8/24-7 GM",
+        "FE 2.8/24-70 GM",
+        "FE4_12_24G",
+        "SEL35F18F",
+        "Sigma 20mm 1:1.4 DG",
+        "Sigma 20mm1:1.4 DG",
+        "Sony 20-70 F4 G",
+        "Sony 85F14GM",
+        "Temron 24 2.8 Di III OSD Tamron"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rIVa",
+      "lenses": [
+        "FE24-105 G OSS",
+        "GM 24-70",
+        "Laowa 12mm F2.8 Zero D",
+        "Sigma 24mm F1.4 ART",
+        "Sigma 35 F1.4",
+        "Sony 24-70mm G mk2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7rV",
+      "lenses": [
+        "7Artisans 7.5mm f2.8",
+        "BATIS 2/25",
+        "Carl Zeiss Distagon 18mm F3.5 ZF with Metabones Speedbooster Ultra",
+        "FE 24-70mm f2.8 GM",
+        "Laowa 35mm Nanomorph",
+        "SIGMA 28-70mm F2.8 DG DN | Contemporary @28mm",
+        "SIGMA 28-70mm F2.8 DG DN | Contemporary @35mm",
+        "SIGMA 28-70mm F2.8 DG DN | Contemporary @70mm",
+        "SIGMA16.00mm",
+        "SONY 50mm F1.4",
+        "Sigma 16-28",
+        "Sigma ART 35mm 1.4",
+        "Tamron 20-40mm F2.8 @ 20mm",
+        "seagull50mm",
+        "sigma 14-24, 14mm",
+        "sigma 1424",
+        "sigma 1424, 24mm",
+        "tamron 20mm-40mm f2,8@20.00mm",
+        "tamron 35-150",
+        "tamron 35-150mm",
+        "tamron 35MM-150.00mm"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7S",
+      "lenses": [
+        "28-70",
+        "2860",
+        "35mm f1.8",
+        "85mm f1.8",
+        "@16mm",
+        "FE 28-70mm F3.5 - 5.6 OSS",
+        "Samyang T1.5 24mm",
+        "Walimexpro 35 mm",
+        "liguan 50",
+        "samyang 35mm f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7sII",
+      "lenses": [
+        "16-35",
+        "24-70 Sony OSS",
+        "Canon 16-35mm",
+        "FE 1.8",
+        "LAOWA14MM",
+        "LAOWA14MM F4.0",
+        "LaoWa14mm",
+        "ROKINON 14MM 2.8",
+        "ROKINON 14MM F2.8",
+        "Rokinon",
+        "Rokinon Cine DS T.5 24mm ED ASIF UMC",
+        "SEL2470Z",
+        "Samyang 18mm / 2.8 FE",
+        "Sony 12-24mm",
+        "Sony 14m f1.8 GM",
+        "Sony 24 - 70 f4",
+        "Sony E35mm f2.8",
+        "samyang 24 T1.5",
+        "samyang cine 35 mm t 1.5"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a7sIII",
+      "lenses": [
+        "105.00mm",
+        "16.00mm",
+        "16.00mm F1.8 Youngnuo on Sony FF",
+        "17.00mm",
+        "19.00mm",
+        "24- 105mm 68.00mm",
+        "24-70mmF2.4 24mm",
+        "24mm",
+        "28.00mm",
+        "35.00mm",
+        "7Artisans 35mm T2.0",
+        "90.00mm",
+        "ANGENIEUX 28",
+        "ATHENA 25 T1.9",
+        "Angenieux 28",
+        "CP3 25mm",
+        "CP3 35mm",
+        "Canon 16-35mm @16mm",
+        "Canon 16-35mm @20mm",
+        "Canon 16-35mm @24mm",
+        "Canon 16-35mm @28mm",
+        "Canon 16-35mm @35mm",
+        "Canon 24-70mm @24m",
+        "Canon 24-70mm @28m",
+        "Canon 24-70mm @35m",
+        "Canon FD 50mm 1.4 S.S.C",
+        "Carl Zeiss Jena Biometar 80mm f2.8",
+        "Carl Zeiss Jena Flektogon 20mm f4",
+        "Carl Zeiss Jena Flektogon 25mm f4",
+        "Carl Zeiss Jena Flektogon 35mm f2.8",
+        "Carl Zeiss Jena Pancolar 50mm f1.8",
+        "FE 2.8/24-70 GM",
+        "Great Joy 35mm x1.8",
+        "Great Joy 85mm 1.8x",
+        "Helios 44-2",
+        "Helios 44m",
+        "LEICA SUMMICRON 25",
+        "Laowa 11",
+        "Laowa 15mm F2",
+        "Laowa 15mm f2 Zero-D",
+        "Laowa 15mm f2 zero-D",
+        "Laowa 35mm 0.95",
+        "Laowa 9mm",
+        "Laowa periprobe 24mm",
+        "Leica 90 anamorphic 2x",
+        "Leica Elmarit-R 24mm f/2.8 v2",
+        "Leica Summicron-R 50mm f/2 v2",
+        "Leica Summicron-R 90mm f/2 v2",
+        "Micro-Nikkor 55mm F2.8",
+        "Mini-Nikkor 55mm F2.8",
+        "NISI Athena 35mm",
+        "Nero1.5xKonica57f1.4",
+        "Nikkor 35mm f1.4",
+        "Nikon 50mm 1.4D",
+        "Nisi 35mm T1.9",
+        "Pentax Super-Multi-Coated Takumar 24mm F3.5",
+        "Pentax Super-Takumar 55mm",
+        "SIGMA 24-70 @24mm 4k 60fps",
+        "SLR MAGIC 50MM 1.1",
+        "SLR MAGIC 50mm f1.1",
+        "SLR magic 35mm f1.2 CINE",
+        "Samyang 12mm 2.0",
+        "Samyang 14/2.8",
+        "Samyang 24",
+        "Samyang 24-70 AF 24.00mm",
+        "Samyang 35-150mm",
+        "Samyang AF FE 85.00mm f1.4",
+        "Samyang Cine V-AF 45.00mm",
+        "Samyang Cine V-AF 75.00mm",
+        "Samyang cine V-AF 75.00mm",
+        "Samyang v-af 24mm",
+        "Sigma",
+        "Sigma 14-24",
+        "Sigma 14-24mm DG DN",
+        "Sigma 16 - 28 - 16.00mm",
+        "Sigma 24-70",
+        "Sigma 24-70 - 24.00mm",
+        "Sigma 24-70mm",
+        "Sigma 24-70mm (24mm) f/2.8 DG DN Art",
+        "Sigma 24-70mm (35mm) f/2.8 DG DN Art",
+        "Sigma 24-70mm (50mm) f/2.8 DG DN Art",
+        "Sigma 24-70mm (70mm) f/2.8 DG DN Art",
+        "Sigma 24-70mm 2.8 Art",
+        "Sigma 24-70mm @24mm",
+        "Sigma 24-70mm @30mm",
+        "Sigma 24-70mm @35mm",
+        "Sigma 24.00mm f/3.5 C",
+        "Sigma Art 24-70mm f/2.8 DG",
+        "Sigma FF Cine Prime 20mm",
+        "Sigma FF Cine Prime 24mm",
+        "Sigma FF Cine Prime 35mm",
+        "Sirui 35mm Anamorphic",
+        "Sirui 50mm T2.9 1.6x",
+        "Sirui 50mm T2.9 FF Anamorphic",
+        "Sirui Saturn 35mm anamorphic",
+        "Sirui Saturn 75mm anamorphic",
+        "Sirui anamorphic 50mm",
+        "Sonnar FE 35mm F2.8 ZA",
+        "Sony 24-70 f2.8 G",
+        "Sony 24-70mm f2.8 G",
+        "Sony FE 1.8/20G",
+        "Sony Vario-Tessar T FE 24-70mm f4 ZA OSS @ 24.00mm",
+        "Sony-Zeiss Planar T* FE 50mm F1.4 ZA",
+        "TL35.00mm",
+        "Tamoron 28-75 @28",
+        "Tamron 17-28 @17.00mm",
+        "Tamron 25-75mm",
+        "Tamron 28-75",
+        "Tamron 28-75 2.8 G2",
+        "Tamron 28-75 G2 RAW@28.00mm",
+        "Tamron 28-75 G2 RAW@28mm",
+        "Tamron 28-75 G2 RAW@35.00mm",
+        "Tamron 28-75 G2 RAW@35mm",
+        "Tamron 28-75 G2 RAW@50.00mm",
+        "Tamron 28-75 G2 RAW@75.00mm",
+        "Tamron 28-75 f2.8 @ 28mm",
+        "Tamron 2875G2",
+        "Viltrox 16.00mm",
+        "Viltrox 35.00mm 1.8",
+        "Viltrox AF 16mm f1.8 Sony FE",
+        "Viltrox AF 35mm F1.8 FE",
+        "Vivitar 25mm 2.5",
+        "Zeiss 16.00mm",
+        "Zeiss @16mm 16.00mm-35",
+        "Zeiss Batis 18mm",
+        "Zeiss superspeed 25mm",
+        "Ziess Kowa 16H slr rangefinder v 1",
+        "helios 44-2 aivascope",
+        "laowa12mm",
+        "sigma 24-70 f/2.8 DG DN",
+        "sony f2.8 24-70mm G",
+        "tamron 2875g2",
+        "ttartisan 11m f2.8"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "A99 II",
+      "lenses": [
+        "vario-sonnar 2,8/24-70 ZA"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "a9III",
+      "lenses": [
+        "50.00mm",
+        "Blazar Remus 65mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "blackshark4",
+      "lenses": [
+        "imx582"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-HX300",
+      "lenses": [
+        "24MM_F2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX0",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX0M2",
+      "lenses": [
+        "9fab2ee1",
+        "dd4199c6"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC-RX10M4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC WX 50",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "DSC WX50",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX30",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX43",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX53",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-AX700",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR X1000V",
+      "lenses": [
+        "ZEISS® Tessar® Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FDR-X3000",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "fs5",
+      "lenses": [
+        "10.-18"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FS7",
+      "lenses": [
+        "Canon EF24-105 with 1.7x Metabones Speedbooster"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX3",
+      "lenses": [
+        "119.00mm",
+        "11mm Fisheye",
+        "14.00mm f1.8 Sigma prime",
+        "150.00mm",
+        "16-35 GM II",
+        "16-35 GM2",
+        "25mm_sp3cooke",
+        "35.00mm",
+        "35MM+OPTEX+1+3",
+        "50.00mm",
+        "55mm",
+        "70.00mm",
+        "7artisans",
+        "85.00mm",
+        "90.00mm G Macro",
+        "BRIGHTIN STAR 9MM",
+        "Blazar Remus 35mm 1.5X",
+        "Blazar Remus 45mm 1.5X",
+        "Blazar Remus 65mm 1.5X",
+        "Blazar Remus Anamorphic 45 mm",
+        "Canon FD 24mm F2.8",
+        "Canon FD 24mm f2.8",
+        "Canon FD 50mm f1.4 S.S.C",
+        "Canon FD 85mm f1.8 S.S.C",
+        "Canon nFD 28mm 2.8",
+        "Carl Zeiss Compact Prime 21mm",
+        "Cooke 18mm T2.1",
+        "DZO Vespid Prime 40mm",
+        "DZOFILM 35MM T2.1",
+        "DZOfilm-vespid-prime-50mmt2.1",
+        "FE 2.8/16-35 GM",
+        "FE2.8/24-70GM2 24.00mm",
+        "G-Master 24mm",
+        "HELIOS 44-2",
+        "HELIOS-44-2",
+        "Helios 44M-4",
+        "LAOWA10.00mm",
+        "Laowa 11mm",
+        "Laowa 12mm Zero-D",
+        "Laowa 12mm Zero-D T2.9",
+        "Laowa 14mm F4 zero-d",
+        "Laowa FF 11mm F4.5 C-Dreamer",
+        "Leica R 50mm",
+        "MIR-1B 37MM",
+        "NISI 50mm",
+        "Nisi",
+        "Nisi 50mm T1.9",
+        "Rokinon 50.00mm 1.4 FE",
+        "SAMYANG 14MM",
+        "SAMYANG V-AF 24mm T1.9",
+        "SAMYANG_V-AF 75mm T1.9",
+        "SEL1018",
+        "SEL35F18F",
+        "SEL55F18Z 55mm",
+        "SIIRUI 75mm Anamorphic",
+        "SIRUI 1.33x 24mm",
+        "SIRUI 100mm Anamorphic",
+        "SIRUI 135mm 60fps 1/125",
+        "SIRUI 135mm Anamorphc",
+        "SIRUI 135mm Anamorphic",
+        "SIRUI 35mm",
+        "SIRUI 35mm Anamorphic",
+        "SIRUI 35mm Anamorphic x 1.65",
+        "SIRUI 50mm 1.33 MFT",
+        "SIRUI 50mm Anamorphic",
+        "SIRUI 50mm MFT",
+        "SIRUI 75mm Anamorphic",
+        "SIRUI Saturn 35mm Full-frame Carbon Fiber Anamorphic",
+        "Samyang 135mm t2.2",
+        "Samyang 14mm f2.8",
+        "Samyang 16mm T 2.6",
+        "Samyang Cine V-AF 24mm T1.9 FE Lens",
+        "Sigma 16.00mm",
+        "Sigma 24-70",
+        "Sigma 24-70 f/2.8 @ 35mm",
+        "Sigma 24-70mm",
+        "Sigma 24-70mm DG DN ART",
+        "Sigma 24-70mm DG DN | A",
+        "Sigma 24-70mm f/2.8 DG DN | A",
+        "Sigma 28-70mm F2.8 DG DN Contemporary",
+        "Sirui 1.6X Anamorphic_50mm",
+        "Sirui 33mm sniper AF",
+        "Sirui Saturn 35mm 1.6",
+        "Sirui Saturn 50mm Anamorphic 1.6x T2.9",
+        "Sony 70-200 f4G2 @ 200",
+        "Sony FE 70-200 Macro G II @70mm",
+        "TAMRON28.00mm",
+        "TT Artisan 50mm 1.4",
+        "TTArtisan 50mm 1.4",
+        "Tamron 17-28",
+        "Tamron 20-40 @22.00mm",
+        "Tamron 20-40mm",
+        "Tamron 28-75 G2 28.00mm",
+        "Tamron 28-75 G2 35.00mm",
+        "Tamron 28-75 G2 41.00mm",
+        "Tamron 28-75 G2 50.00mm",
+        "Tamron 28-75 G2 64.00mm",
+        "Tamron 28-75 G2 75.00mm",
+        "Tamron 28-75 f2.8 @28.00mm",
+        "Tamron 35-150mm",
+        "VILTROX 20MM T2.0",
+        "Venus Optics Laowa 12mm f/2.8 Zero-D",
+        "Viltrox 20.00mm F/2.8",
+        "Viltrox 20T2.0",
+        "XEEN CF 16mm",
+        "XEEN CF 24mm",
+        "XEEN CF 35mm",
+        "XEEN CF 50mm",
+        "XEEN CF 85mm",
+        "Zeiss 15mm 2.9T CP.3",
+        "Zeiss 21.00mm",
+        "ganguang80mm",
+        "helios 44-2 58mm",
+        "laowa 100mm F2.8 macro FE",
+        "laowa 11mm",
+        "laowa 15mm F2",
+        "laowa 7.5mm F2,0",
+        "laowa 9mm F5.6",
+        "laowa11 f4.5",
+        "laowa11mm F4.5",
+        "minolta MC Rokkor 28mm f2.8",
+        "nisi 35mm T1.9",
+        "nisi 50mm",
+        "nisi 50mm T1.9",
+        "samyang75.00mm",
+        "sirui FF 55"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX30",
+      "lenses": [
+        "12.00mm",
+        "134/4 jupiter",
+        "150.00mm",
+        "18-105 G 18mm",
+        "18-105mm",
+        "18.00mm",
+        "18.00mm SIGMA",
+        "18mm-105mm",
+        "20.00mm",
+        "24mm Samyang",
+        "7.5mm f2.8 7Artisans",
+        "7Artisans 35mm 0.95",
+        "7Artisans 35mm T1.05",
+        "7Artisans 35mm Vision",
+        "7artisans 12mm F2.8",
+        "7artisans Hope 85mm",
+        "85mm Samyang",
+        "AstrHori 85.00mm",
+        "Blazar Remus 45mm w/Metabones Speed Booster Ultra",
+        "Brightin Star 10mm",
+        "Canon 10 - 22mm (10mm)",
+        "Canon EF 70-200.00mm F4L",
+        "Canon FD 1.4 50mm",
+        "Canon FD 17mm f4",
+        "Canon FD 28mm Speed Booster",
+        "Canon FD 50 1.4",
+        "Canon FD 50MM 1.4 Speedboosted",
+        "Canon FD 50mm Speed Boosted 1.4",
+        "Canon FD 50mm Speed Booster 10_3_23",
+        "Carl Zeiss Sonnar T* E 24mm f1.8 ZA",
+        "DZO Vespid Prime 50mm T2.1",
+        "EF 24-70mm f/2.8 GM II @35mm",
+        "EF 24-70mm f/2.8 GM II @50mm",
+        "EF 24-70mm f/2.8 GM II @70mm",
+        "Fujinon MK 18-55 T2.9",
+        "Helios 28mm f2.8",
+        "Helios 44-2 58mm",
+        "Helios 44M-4",
+        "Helios 44M-4 58mm",
+        "Helios 58mm F2",
+        "Helios-44 2M",
+        "LAOWA 25mmF0.95",
+        "LAOWA 9 mm",
+        "LAOWA 9mm",
+        "LAOWA 9mm zeroD",
+        "Laowa 9mm",
+        "Laowa 9mm ZeroD",
+        "Mamiya 80mm 1.9 sekor c",
+        "Mike 12mm f2.8",
+        "Nightwalker 24mm",
+        "Nightwalker 35mm",
+        "Nightwalker 55mm",
+        "PENTAX 50mm + speedbooster",
+        "ROKINON 12MM",
+        "Rokinon 24mm T1.5",
+        "Rokinon CINE ED AS UMC",
+        "SIGMA 30.00mm 1.4",
+        "SIGMA 30.00mm 1:1.4 DC DN",
+        "SIGMA 50.00mm 1;1.4 DG DN",
+        "SIRUI 35mm",
+        "SIRUI 35mm T1.2",
+        "SIRUI Sniper 23.00mm",
+        "SIRUI35MM",
+        "SLR MAgic 12mm",
+        "SLR MAgic 21mm",
+        "SLR Magic  21mm",
+        "SLR Magic 35mm",
+        "SLR Magic 50mm",
+        "SLR Magic Micro Prime 35mm",
+        "Samyang 14mm T3.1",
+        "Samyang 24-70mm 2.8 (24mm)",
+        "Samyang 45.00mm F1.8",
+        "Samyang 85",
+        "Samyang 85mm",
+        "Sigma 1.4 30.00mm",
+        "Sigma 16.00mm",
+        "Sigma 16.00mm  1.4",
+        "Sigma 16.00mm f1.4",
+        "Sigma 18-35 (18mm)vitrox 0.70",
+        "Sigma 18-35 (25) + Viltrox 0.70",
+        "Sigma 18-35 (viltrox 18mm)",
+        "Sigma 18-35 (viltrox 30mm)",
+        "Sigma 18-50 @ 24.00mm",
+        "Sigma 18-50 @ 28mm",
+        "Sigma 18-50 @ 35mm",
+        "Sigma 18-50mm",
+        "Sigma 24-70 DG DN (@ 24mm)",
+        "Sigma 30.00mm",
+        "Sigma 30.00mm 1.4 DC DN",
+        "Sigma 30mm F1.4 DC DN",
+        "Sigma ART 18-35 1.8",
+        "Sigma Art 35mm F1.4 DG DN",
+        "Sigma16.00mm 1:1.4",
+        "Sigma18-50F2.8",
+        "Sirui",
+        "Sirui 150mm Anamorphic T2.6",
+        "Sirui 35mm F1.8",
+        "Sirui 75mm",
+        "Sirui Anamorphic 50mm f1.8",
+        "Sirui Night Walker T1.2 35mm",
+        "Sirui Nightwalker 24mm",
+        "Sirui Nightwalker 75mm",
+        "Sirui Nightwalker T1.2 24mm",
+        "Sirui Nightwalker T1.2 55mm",
+        "Sirui Saturn 35 mm T2.9",
+        "Siuri Night Walker 35mm",
+        "Sony 15.00mm G",
+        "Sony 24-105 G at 105mm",
+        "Sony 24-105 f4 @ 50mm",
+        "Sony 24-105 f4 G at 35mm",
+        "Sony 24-105mm f4 G at 24mm",
+        "Sony SEL 1.8/11.00mm",
+        "Sony16-55mm G",
+        "TAMRON17-70mm F/2.8",
+        "TTartisan 50mm f1.2",
+        "TTartisan 7.5mm",
+        "Tamron 11-20mm - 11.00mm",
+        "Tamron 11-20mm - 20.00mm",
+        "Tamron 17-70mm",
+        "Tamron SP 17-50mm F/2.8 XR Di-II VC LD",
+        "Tamron11.00mm",
+        "Tokina 11-20mm (viltrox 11mm)",
+        "Tokina 11-20mm (viltrox 20mm)",
+        "Tokina ATX-m 23mm F1.4",
+        "Viltrox 13.00mm",
+        "Viltrox 23.00mm",
+        "Viltrox 35mm f1.8",
+        "Viltrox 50mm f1.8",
+        "Viltrox 75.00mm",
+        "Viltrox 85mm f1.8",
+        "Voigtlander Nokton 42.5mm f/0.95",
+        "Voigtlander Nokton 42.5mm f/0.95 MFT",
+        "Zalupasigm 30mm",
+        "laowa 33 0.95",
+        "mir-1",
+        "nightwalker 35mm",
+        "nikkor 50 f1.4 ais",
+        "nikon 50 1.8d",
+        "sigma 16.00mm f1.4",
+        "sigma 18-50 @ 18mm",
+        "sigma 50.00mm 1.4 art",
+        "sigma-2-56.00mm",
+        "sigma56.00mm",
+        "sirui 24mm",
+        "sirui 35mm",
+        "sony 16-50",
+        "sony16-70mm",
+        "tamron11.00mm",
+        "viltrox 23.00mm 1.4"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX6",
+      "lenses": [
+        "35MM MAMIYA+OPTEX",
+        "50.00mm Sigma ART",
+        "50mm",
+        "Blazar Remus 65mm - V1",
+        "CANON FD 24MM",
+        "CANON FD 28mm f2.0 SSC",
+        "Canon 16-35mm @16mm",
+        "Canon 16-35mm @20mm",
+        "Canon 16-35mm @24mm",
+        "Canon 16-35mm @28mm",
+        "Canon 16-35mm @35mm",
+        "Canon 24-70mm @24mm",
+        "Canon 24-70mm @30mm",
+        "Canon 24-70mm @35mm",
+        "Canon FD 100mm f2.8 SSC",
+        "Canon FD 17mm f/4",
+        "Canon FD 20-35 F3.5 L",
+        "Canon FD 20mm",
+        "Canon FD 20mm F2.8 SSC",
+        "Canon FD 24",
+        "Canon FD 24mm F2.0",
+        "Canon FD 28mm f/2.8",
+        "Canon FD 35mm F2.0 SSC",
+        "Canon FD 35mm f2.0 SSC",
+        "Canon FD 50mm F1.4 SSC",
+        "Canon FD 50mm f1.4 SSC",
+        "Canon FD 85mm f1.8 SSC",
+        "Canon FDn 20mm f2.8",
+        "Canon FDn 24mm f2.8",
+        "Canon nFD 17mm f4",
+        "Canon nFD 20mm f2.8",
+        "Canon nFD 24mm f2.8",
+        "Canon nFD 35mm f2",
+        "Canon nFD 50mm f1.4",
+        "Carl Zeiss Jenna f1.8 50mm",
+        "Contax Zeiss 50mm 1.7 AEJ",
+        "DZOFILM Vespid Prime FF 125 mm T2.1",
+        "DZOFILM Vespid Prime FF 16 mm T2.8",
+        "DZOFILM Vespid Prime FF 35 mm T2.1",
+        "DZOFILM Vespid Prime FF 50 mm T2.1",
+        "DZOFILM Vespid Prime FF 90 mm Macro T2.8",
+        "DZOFilm Catta Ace 35-80 T2.9",
+        "DZOFilm Catta Zoom 35-80mm",
+        "DZOFilm Vespid Prime FF 25mm T2.1",
+        "FE 12-24mm F4 G @14mm",
+        "FE 12-24mm F4 G @16mm",
+        "FE 12-24mm F4 G @18mm",
+        "FE 12-24mm F4 G @21mm",
+        "Helios",
+        "LAOWA 10.00mm FF",
+        "LAOWA 12mm",
+        "LAOWA 14 mm",
+        "LEICA R 19mm f2.8",
+        "Laowa 10.00mm",
+        "Laowa 12mm  EF f2.8",
+        "Laowa FE 12mm F/2.8",
+        "Laowa FF 14mm f4.0 C&D Dreamer",
+        "Laowa FF 14mm f4.0 Dreamer",
+        "Leica Elmarit R 28mm",
+        "Leica M0.8 21mm",
+        "Leica M0.8 24mm F1.4",
+        "Leica M0.8 28mm F1.4",
+        "Leica M0.8 35mm F1.4",
+        "Leica M0.8 Summilux 21mm F1.4",
+        "Leica M0.8 Summilux 24mm F1.4",
+        "Leica M0.8 Summilux 35mm F1.4",
+        "Leica M0.8 Summilux 50mm F1.4",
+        "Leica R 19mm f2.8 v2",
+        "Leica R 24mm f2.8",
+        "Leica R 35mm f2.0",
+        "Leica R 50mm f2.0",
+        "Leica R 90mm F2",
+        "Meyer-Optik Gorlitz f2.8 135mm",
+        "Nikkor 24-70 f2.8",
+        "Nisi Athena 14mm",
+        "Nisi Athena 25mm",
+        "Nisi Athena 35mm",
+        "Nisi Athena 50mm",
+        "Nisi Athena 85mm",
+        "Pentax 15mm f3.5",
+        "Pentax Takumar 20mm F4.5",
+        "Rokinon 14.00mm 2.8",
+        "Rokinon 16mm cine",
+        "Rokinon 24.00mm",
+        "Rokinon 85 mm Cine",
+        "Rokinon 85mm",
+        "Rokinon Cine 35mm",
+        "Ronkinon Cine DS 50mm",
+        "SEL2870 28-70mm",
+        "SEL70200GM2",
+        "SIRUI 35MM FF1.6X",
+        "SONY (SIGMA 24mm F1.4 DG DN)",
+        "SONY (Sony FE 55mm F1.8 ZA)",
+        "Samyang 35mm",
+        "Sigma 14-24",
+        "Sigma 17.00mm f4",
+        "Sigma 24-70mm",
+        "Sigma 24-70mm @30mm",
+        "Sigma 24-70mm @35mm",
+        "Sigma FF Cine Prime 20mm",
+        "Sigma FF Cine Prime 24mm",
+        "Sigma FF Cine Prime 35mm",
+        "Sirui Venus 35mm 1.66x anamorphic",
+        "Sirui Venus 75mm 1.66x anamorphic",
+        "Sony 24-105 G f4 at 105mm",
+        "Sony 24-105 G f4 at 50mm",
+        "Sony 24-105 G f4 at 70mm",
+        "Sony 24-105 f4 G at 24mm",
+        "Sony 24-105mm f/4 G",
+        "Sony GM 14.00mm",
+        "Sony GM 20.00mm",
+        "Sony GM 24-27 F2.8 Mk II",
+        "Sony GM 24.00mm",
+        "Sony GM 35.00mm",
+        "Takumar 135mm f3.5",
+        "Takumar 20mm f4.5",
+        "Takumar 24mm f3.5",
+        "Takumar 28mm f3.5",
+        "Takumar 35mm f2.0",
+        "Takumar 50mm f1.4",
+        "Takumar 85mm f1.8",
+        "Takumar f3.5 28mm",
+        "Tamron 17-28 @20.00mm",
+        "Tamron 17-28 f2.8 @17.00mm",
+        "Tamron 17-28 f2.8 @24.00mm",
+        "Tamron 17-28 f2.8 @28.00mm",
+        "Viltrox 35mm f1.8",
+        "Viltrox 50mm 1.8 Sony E",
+        "Viltrox 85mm f1.8",
+        "Viltrox AF 16mm F1.8 FE",
+        "XEEN CF 35mm T1.5",
+        "XEEN CF 50mm T1.5",
+        "Zeiss 55mm",
+        "Zeiss16-35 20mm",
+        "Zeiss16-35 24mm",
+        "Zeiss16-35 35mm",
+        "sigma28-70 35mm",
+        "sigma28-70 70mm",
+        "tamron35.00mm-150mm_35mm",
+        "tokina 11-16 DX",
+        "ziess milvus 35.00mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX6V",
+      "lenses": [
+        "16.00mm",
+        "16.00mm on FE C 16-35mm",
+        "Batis 135.00mm",
+        "Canon nFD 35mm f2.8",
+        "DZOFILM Vespid Prime 25mm",
+        "DZOFILM Vespid Prime 75mm",
+        "Helios 44-2 58mm",
+        "Leica Elmarit- R 35mm",
+        "Leica M0.8 21mm F1.4 Summilux",
+        "Leica M0.8 24mm F1.4 Summilux",
+        "Leica M0.8 35mm F1.4 Summilux",
+        "Leica M0.8 50mm F1.4 Summilux",
+        "Leica R_35MM",
+        "Pentax Super Takumar 50mm 59 fps",
+        "SEL24-70GM2",
+        "SELP28135G OSS",
+        "SLR Magic Microprime 35mm T1.3",
+        "SLR Magic microprime 35mm",
+        "SONY 24.00mm - 70.00mm GM II 24mm",
+        "Sirui 35mm Saturn",
+        "Tokina SD11-16 2,8",
+        "Zeiss 35mm f2",
+        "Zeiss Distagon 25.00mm",
+        "Zeiss16-35 16mm",
+        "sigma 28.00mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "FX9",
+      "lenses": [
+        "28.00mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR AS 15",
+      "lenses": [
+        "170"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS100V",
+      "lenses": [
+        "ZEISS® Tessar®"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS15",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS200V",
+      "lenses": [
+        "ZEISS® Tessar®"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS30V Action Cam",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AS50",
+      "lenses": [
+        "N"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-AZ1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-CX625",
+      "lenses": [
+        "Sony Lines G 1.8/1.9-57"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-CX900E",
+      "lenses": [
+        "Build-in lens Zeiss",
+        "Built-in lens Zeiss"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HDR-mv1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HX200V",
+      "lenses": [
+        "Carl Zeiss Vario-Tessar 2,8-5,64,8-144 T"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HX60",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HXR MC2500",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HXR-NX100",
+      "lenses": [
+        "moren"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "HXR-NX80",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILME-FX3",
+      "lenses": [
+        "14.00mm",
+        "35.00mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILME-FX6V",
+      "lenses": [
+        "SIRUI ANAMORPHIC x1.6 35mm T2.9",
+        "SIRUI ANAMORPHIC x1.6 50mm T2.9",
+        "SIRUI ANAMORPHIC x1.6 75mm T2.9"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ILX-LR1",
+      "lenses": [
+        "18.00mm",
+        "40.00mm",
+        "Laowa 11mm F4.5 C-Dreamer",
+        "Sony FE 24mm F2.8 G",
+        "Sony FE 40mm F2.8 G",
+        "Sony FE 85mm F1.8"
+      ],
+      "crop_factor": 1.24,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "M3",
+      "lenses": [
+        "1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "mini dv",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX 5",
+      "lenses": [
+        "fuji 55mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Nex 5N",
+      "lenses": [
+        "16-50",
+        "7artisans 7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-5R",
+      "lenses": [
+        "16-50 Kit lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Nex 6",
+      "lenses": [
+        "Sony 16-50"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "NEX-7",
+      "lenses": [
+        "18-200"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "nex3n",
+      "lenses": [
+        "1650"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PMW-400",
+      "lenses": [
+        "Canon HDGC"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "potensic",
+      "lenses": [
+        "1/3"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Potensic Atom SE",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PXW-FS7M2",
+      "lenses": [
+        "Laowa Argus 33mm F0.95"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PXW-FX9V",
+      "lenses": [
+        "28.00mm",
+        "Nikon AF Nikkor 20mm f2.8 DAF",
+        "Nikon Nikkor AF 20mm 2.8 D",
+        "Zeiss Super Speed MkIII 18mm T1.3",
+        "Zeiss Super Speed MkIII 25mm T1.3",
+        "Zeiss Super Speed MkIII 35mm t1.4",
+        "Zeiss Super Speed MkIII 50mm t1.3",
+        "Zeiss Super Speed MkIII 85mm t1.3",
+        "sigma 28.00mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "PXW-Z280V",
+      "lenses": [
+        "0.00mm",
+        "5.63mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "R100III",
+      "lenses": [
+        "24-70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0",
+      "lenses": [
+        "0.6X wide lens",
+        "35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0 II",
+      "lenses": [
+        "0.6x",
+        "0.6x Adapter"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0II",
+      "lenses": [
+        "24mm with 0.6x ZOMEI",
+        "BEASTGRIP 0.6X",
+        "BeastGrip 0.6X Wide Angle",
+        "LH0811-12MP",
+        "Moondog Anamorpgic 1.33x",
+        "Sirui 1.33x Anamorph",
+        "Sirui 18mm",
+        "Zeiss Tesar T* 7,9mm F4 (24mm FF)",
+        "ZumLain_8mm_LH0811-12MP",
+        "ZumLian LH0811 8mm F2",
+        "ZumLian LH0811 8mm F2 V2",
+        "b3b1bf80",
+        "f4c0498c"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0II_C-Mount-MOD",
+      "lenses": [
+        "LH0811-12MP"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0II_Custom-C-Mount-MOD",
+      "lenses": [
+        "LH0811-12MP"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX0M2",
+      "lenses": [
+        "0.45x lens",
+        "37mm UV& 0.45 lens adapter",
+        "Ulanzi wl-1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100II",
+      "lenses": [
+        "carl zeiss"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100III",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100IV",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100M4",
+      "lenses": [
+        "zeiss 24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100M5A",
+      "lenses": [
+        "T* 24-70mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100V",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX100VI",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10II",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10III",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10IV",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10M2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RX10M4",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "RXO II",
+      "lenses": [
+        "Moondog Labs Anamorphic 1.33"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "SO-02K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Venice",
+      "lenses": [
+        "Canon K35 50mm",
+        "SIGMA 18mm to 35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "XA75",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1",
+      "lenses": [
+        "24",
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1 III",
+      "lenses": [
+        "24",
+        "25mm",
+        "74mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1 iv",
+      "lenses": [
+        "24mm",
+        "85mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 1 V",
+      "lenses": [
+        "16mm",
+        "24mm",
+        "24mm f1.9",
+        "92MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5",
+      "lenses": [
+        "16mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 II",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "xperia 5 iii",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 iii Cinema pro",
+      "lenses": [
+        "Cinema pro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 IV",
+      "lenses": [
+        "16",
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5 V",
+      "lenses": [
+        "48mm f/1.9"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia 5ii",
+      "lenses": [
+        "16mm",
+        "26mm",
+        "60mm",
+        "ultra wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia IV",
+      "lenses": [
+        "13",
+        "16mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia PRO-I",
+      "lenses": [
+        "16mm Ultrawide (Exmos RS IMX363)",
+        "24mm Wide (Exmos RS IMX478)",
+        "50mm Telephoto (Exmos RS IMX663)",
+        "50mm Telephoto (Exmos RS IMX664)",
+        "Main 25mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia V 2",
+      "lenses": [
+        "Medium"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia XA2 Ultra",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "Xperia XZ1 Compact SO-02K",
+      "lenses": [
+        "normal"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "XZ1 Compact",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-1F",
+      "lenses": [
+        "20mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E1",
+      "lenses": [
+        "10-20f4",
+        "10mm f4.0 apsc cookie",
+        "136.00mm-Sony50-210mm",
+        "138.00mmTamron70-300mm",
+        "1635GMIIF2.816.00mm",
+        "18.00mmSamyang2.8",
+        "24-105mm   g-master",
+        "24.00mmSamyang2.8",
+        "40.00mmVoigtlander1.2",
+        "50mm",
+        "50mmtessar2.8",
+        "70200gm2 70.00mm",
+        "7Artisans 10mm",
+        "7artisans 10mm F2.8",
+        "85.00mm F1.8",
+        "BRIGHTIN STAR 9mm F5.6",
+        "CAYE 10mm F8",
+        "Canon EF 50mm 1.8 STM",
+        "Contax 25mm F2.8",
+        "Contax 50mm F1.4",
+        "EF 24-70/2.8L USM",
+        "EF 24-70mm 2.8L USM",
+        "EF 4-5.6/28-60:35.00mm",
+        "FE 20-70mm F4",
+        "FE 24-240mm",
+        "FE 35mm F1.4 GM",
+        "FE20-70F4G",
+        "HELIOS 44-2",
+        "LAOWA 100㎜ F2.8 CA-Dreamer Macro 2X",
+        "LAOWA 14MM F4 FF RL ZERO-DaAS",
+        "Laowa 14mm F4 Dreamer",
+        "Laowa 45mm F0.95",
+        "Laowa 9mm f2.8",
+        "Laowa Nanomorph 27 f2.8 (1.5x Anamorphic)",
+        "Milnolta 200mm 2.8 2X Tele",
+        "PZ 16-35 G FE4",
+        "PZ1635G",
+        "SAMYANG 35.00mm 2.8",
+        "SAmyang 35.00mm 2.8",
+        "SEL24105G 49.00mm",
+        "SEL24105G 68.00mm",
+        "SEL24105G-105.00mm",
+        "SIGMA  24-70F2.8 DG DN 2",
+        "SIGMA 14-24mm",
+        "SIGMA 14.00mm F1.4",
+        "SIGMA 16-28mm F2.8 DG DN",
+        "Samyang 18.00mm F2.8",
+        "Sigma  28-70  35.00mm",
+        "Sigma 24-70mm@24",
+        "Sigma 24-70mm@24mm",
+        "Sigma 24-70mm@35mm",
+        "Sigma 24-70mm@50",
+        "Sigma 24-70mm@50mm",
+        "Sigma 24-70mm@70mm",
+        "Sigma 28-70  70.00mm",
+        "Sigma 28-70 50mm",
+        "Sigma DG DN 3.5 24mm",
+        "Sigma16.00mm  1.4",
+        "Sigma28-70 28mm",
+        "Sigma30.00mm 1.4",
+        "Sirui 35mm T2.9 Anamorhipc Carbon Fiber",
+        "Sonnar FE 55mm F1.8 ZA SEL55F18Z@1.8",
+        "Sony 16-35mm G F4",
+        "Sony 24-70mm 2.8 GM",
+        "Sony28.00mmF2.0",
+        "Sonyt 35mm F1.8",
+        "Tamron 20-40",
+        "Tamron 20-40.00",
+        "Tamron 20.00mm 2.8",
+        "VILTROX 20.00mm F2.8",
+        "VM 75.00mm",
+        "Vazen85 2.8",
+        "Viltrox 16.00mm",
+        "Viltrox 16mm",
+        "Viltrox 20 1.8",
+        "Viltrox 85.00mm",
+        "ZF100/2",
+        "ZF25/2.8",
+        "Zeiss Batis 25.00mm 2.0@2.0",
+        "Zeiss Batis 40.00mm 2.0@2.0",
+        "Zeiss Contax 28mm",
+        "Zeiss Contax 35mm",
+        "cangye-10mm-f8",
+        "gmii-16-35-16.00mm",
+        "kodak",
+        "laowa 35 0.95",
+        "laowa 9mm aps-c",
+        "nour triplet 64mm",
+        "sigma 2870 35mm",
+        "sigma 30 f/1.4",
+        "sigma dn dg 85mm f1.4",
+        "sigma16-28 F2.8 16.00mm",
+        "sigma16-28 F2.8 18.00mm",
+        "sigma16-28 F2.8 20.00mm",
+        "sigma16-28 F2.8 22.00mm",
+        "sigma16-28 F2.8 24.00mm",
+        "sigma16-28 F2.8 28.00mm",
+        "sigma35mmF1.4",
+        "sirui sniper F1.2 APS-C AF 23.00mm",
+        "sony gm 14mm",
+        "tamron28-200",
+        "tamronTamron  17-28 f2.8  24.00mm",
+        "tamronTamron 17-28 f2.8",
+        "yongnuo 50 1.8",
+        "zeiss 25/2.8"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10",
+      "lenses": [
+        "10-20mm F4 G",
+        "10F5.6",
+        "10MM",
+        "11f1.8",
+        "16-50",
+        "16-50 Kit Lens",
+        "16-50 f3.5-5.6",
+        "16-50MM",
+        "16mm",
+        "18 mm",
+        "18-105",
+        "18-135mm@70mm",
+        "18-200le 18mm",
+        "18-200le70mm",
+        "20mm 1.8",
+        "20mm f2.8 tamron",
+        "27 1.2",
+        "35 F1.7",
+        "50fangdou",
+        "50mm T2.0",
+        "6c5f7ee5",
+        "70-180",
+        "72 1.2",
+        "7ARTISANS 12 F2.8",
+        "7ARTISANS 16:9 24mm F1.4",
+        "7Artisan 25mm f1.8",
+        "7Artisans 25mm crop",
+        "7Artisans 35MM F0.95",
+        "7Artisans 35mm 1.4f",
+        "7Artisans 35mm f1.2 Mark II",
+        "7Artisans 35mm f1.8 (crop)",
+        "7Artisans 55m/1.4",
+        "7artisan 25m",
+        "7artisan 25mm",
+        "7artisans",
+        "7artisans 35mm T1.05 Vision Cine Lens",
+        "7artisans 60mm f/2.8 Macro",
+        "9MM",
+        "9mm",
+        "Asahi SMC Pentax-M 1:1.4 50mm",
+        "AstrHori岩石星10mmF8一代",
+        "Auto Chinon f=35",
+        "B070 Tamron 17-70 mm",
+        "BrightStar 10mm",
+        "Brighten Stars 55mm FE",
+        "Brightin Star 35mm f0.95",
+        "Brightin Star 7.5mm f2.8",
+        "Brightin star 10mm",
+        "CANON 16-35 F2.8",
+        "CANON 16-35 F2.8 (35MM)",
+        "CANON 16-35 F2.8 I",
+        "CANON 16-35 F2.8 I (24MM)",
+        "CANON16-35 F2.8( 16MM)",
+        "CF10mm",
+        "Canon 18-135mm",
+        "Canon 50/1.4 FD SSC with MB SpeedBooster Ultra",
+        "Canon 50mm. f1.4 scc",
+        "Canon 55-250mm with viltrox speedbooster",
+        "Canon fd 28mm (32mm)",
+        "Canon fd 28mm (42mm)",
+        "Canon16-35 F2.8 (16MM)",
+        "Carl Zeiss Sonnar T* E 24mm F1.8 ZA",
+        "Carl Zeiss Sonnar T* E 24mm f/1.8 ZA",
+        "E 16-50 f 3.5-5.6",
+        "E 18-135mm@18mm",
+        "E 18-135mm@24mm",
+        "E 24mm F1.8 ZA",
+        "E 3.5-5.6/PZ 16-50 OSS",
+        "E 35/1.8",
+        "E PZ 16-50mm",
+        "E1.4 15mmG",
+        "E3.5-5.6/PZ 16-50 OSS",
+        "E50MM",
+        "E50mm1.8",
+        "EYE",
+        "Eye",
+        "FE 50mm F1.8",
+        "Fujian 25mm",
+        "G15mm 1.4",
+        "Helios 44 M 58mm",
+        "Helios 44-2 Focal Reducer",
+        "Helios 44-2 w/focal reducer",
+        "Helios 44M (KMZ)",
+        "Helios 44M 2/58",
+        "Jupiter 8 f2 50mm",
+        "Jupiter-8 50mm f2",
+        "Kamlan 28mm F1.4",
+        "LAOWA CF10mm",
+        "LAOWA Cookie 10mm",
+        "LW10",
+        "LW9 2.8",
+        "Laowa 10 mm f4",
+        "Laowa 10 mm f4 cookie",
+        "Laowa 10mm Cookie",
+        "Laowa 10mm f4 Cookie",
+        "Laowa 9mm f/2.8 Zero-D",
+        "MEIKE 7.5mm F2.8",
+        "MEIKE 7.5mm FishEye F2.8",
+        "Meike 12 2.8",
+        "Meike 35MM F1.4",
+        "Meike 35mm",
+        "Meike 35mm f1.7",
+        "Minolta AF 50 (85 crop) 1.4",
+        "Minolta AF 50mm (75mm crop) f1.4",
+        "Minolta AF 50mm f1.4 (crop)",
+        "PZ 16-50 f3,5-5,6",
+        "Pentax 55mm f1.8",
+        "SAMYANG 12 mm 2.0",
+        "SAMYANG 12MM F2.0",
+        "SAMYANG AF 12MM F2.0",
+        "SAMYANG AF 12mm F2.0",
+        "SAMYANG af 12mm f2",
+        "SAMYANG_7.5mm_MFT_fisheye",
+        "SEL35F1",
+        "SEL35F18",
+        "SELP1650 6729825C",
+        "SIGMA 16F1.4",
+        "SIGMA 18-50mm F2.8 DC DN",
+        "SIGMA 30MM F1.4 ND",
+        "SIGMA 50端",
+        "SIGMA-23mm-1.4",
+        "SIGMA18端",
+        "Samayng 12mm f2.0",
+        "Samyang 12 F2 AF",
+        "Samyang 12mm F2",
+        "Samyang 18mm f2.8",
+        "Samyang 21mm f1/4",
+        "Samyang 85mm t1.5",
+        "Samyang 8mm f/2.8 II",
+        "Samyang AF 24mm F2.8 FE",
+        "Samyang12mm2.0",
+        "Sigma 10-18mm F2.8",
+        "Sigma 10-20mm",
+        "Sigma 16mm 1.4",
+        "Sigma 16mm 1.4 x1.5",
+        "Sigma 16mm 1.4x1.5 Digital Zoom",
+        "Sigma 16mm F1.4",
+        "Sigma 16mm F1.4 DC DN",
+        "Sigma 16mm f 1.4",
+        "Sigma 16mm f/1.4",
+        "Sigma 16mm f1.4",
+        "Sigma 16mm f1.4 268ca01e",
+        "Sigma 16mm f1.4 zoom 2x v1",
+        "Sigma 18-50",
+        "Sigma 18-50 2.8",
+        "Sigma 18-50 2.8 DC DN",
+        "Sigma 18-50 2;8",
+        "Sigma 18-50 F2.8 DC DN",
+        "Sigma 18-50 F2.8@18mm.",
+        "Sigma 18-50, 2.8f",
+        "Sigma 18-50mm",
+        "Sigma 18-50mm 1:2.8 DC DN @18mm",
+        "Sigma 18-50mm 2.8",
+        "Sigma 18-50mm f 2.8 DC DN",
+        "Sigma 18-50mm f/2.8",
+        "Sigma 18-50mm f/2.8 DC DN",
+        "Sigma 18_50 F2.8 @50mm",
+        "Sigma 30 1.4mm",
+        "Sigma 30 f1.4",
+        "Sigma 30 mm 1:2.8 DN 46",
+        "Sigma 30mm 1.4",
+        "Sigma 30mm 1.4 DC DN",
+        "Sigma 30mm DC DN",
+        "Sigma 30mm f1.4",
+        "Sigma 30mm f1.4 DC DN",
+        "Sigma 56mm DC DN f/1.4",
+        "Sigma 56mm F1.4 DC DN",
+        "Sigma 56mm f/1.4",
+        "Sigma 70-300 1.4-5,6",
+        "Sigma 70-300mm f1.4-5.6 (crop)",
+        "Sigma DC DN E 30mm",
+        "Sigma, 16mm F1,4 DC DN | Contemporary",
+        "Sigma16f1.4",
+        "Sigma18-50",
+        "Sigma18-50mm",
+        "Sigma1850",
+        "Sigma23f1.4",
+        "Sigma501.4",
+        "Sirui 23 mm f1.2",
+        "Sirui 35mm anamorphic 1.33",
+        "Sirui Sniper 23mm",
+        "Sony 18-105 f4",
+        "Sony E 16mm w/UWA (12mm)",
+        "Sony E24mm f1.8",
+        "Sony FE 28-70mm",
+        "Super-Tarkumar 35mm f3.5 & Metabones Speedbooster x0.71",
+        "TAMRON 17-28mm f/2.8 Di III RXD",
+        "TAMRON 17-70",
+        "TAMRON 17-70 17",
+        "TAMRON 1770",
+        "TT Artian 35mm F1.4",
+        "TT Artisan 35mm F1.4",
+        "TTArtisan",
+        "TTArtisan 17/1.4",
+        "TTArtisan 50mm f0.95",
+        "TTArtisan 50mm f1.8",
+        "TTArtisan50f1.2",
+        "TTartisan 50mm F0.95",
+        "TTartisan 50mm f0.95",
+        "TTartisan 50mm f1.2",
+        "TTartisan 7.5mm F2.0",
+        "TTartisan 7.5mm f2",
+        "TTartisans 35mm f/1.8 APS-C",
+        "Tamron 17-70",
+        "Tamron 17-70 70mm f2.8",
+        "Tamron 17-70 F2.8 B070",
+        "Tamron 17-70 f2.8 17mm",
+        "Tamron 17-70mm F/2.8",
+        "Tamron 17-70mm F2.8",
+        "Tamron 18",
+        "Tamron 18-200 3.5-6.3 Di III VC",
+        "Tamron 18-300",
+        "Tamron 28-75 Di III XVD G2",
+        "Tamron 35mm",
+        "Tamron 70-300 4.5-6.3 Di III RXD",
+        "Tamron 75mm 1.2",
+        "Tamron17-70/f2.8",
+        "Tokina 11-16",
+        "Tokina ATX-m 23mm F1.4 Sony E",
+        "Tokina ATX-m 56mm F1.4 Sony E",
+        "Tokina atx-m 23mm AF F1.4 E - 30p 1.2x",
+        "Tokina atx-m 23mm AF F1.4 E - 4k24p 1.0x",
+        "VCL-ECF2",
+        "VILTROX AF 20/2.8 FE",
+        "VILTROX AF 35/1.8 FE",
+        "Viltrox 20 2.8",
+        "Viltrox 20F2.8",
+        "Viltrox 23mm 1.4 - 5884045",
+        "Viltrox 23mm f1.4",
+        "Viltrox 33",
+        "Viltrox 85 F1.8",
+        "Viltrox 85mm 1.8 II FE",
+        "Viltrox AF 23/1.4 E",
+        "Viltrox AF 56/1.4 E",
+        "Vivitar 28-85mm",
+        "Vivitar 90mm 2.5 Macro",
+        "Voigtlander 35mm f1.4",
+        "Vtro 13mm",
+        "YN-50 1.8",
+        "YN-50.8 E",
+        "YN-50mm",
+        "YN-E 50mm",
+        "YN11mm_F1.8S_DA_DSM_WL_240607",
+        "YN16mm F1.8S DA DSM",
+        "YN50 f1.8s",
+        "YN50MM1.8S",
+        "YONGNUO 50MM 1.8",
+        "Yongnuo 50MM",
+        "Yongnuo 50f1.8",
+        "Yongnuo 50mm1.8",
+        "Yongnuo YN11mm F1.8S DA DSM WL",
+        "Yongnuo YN16 16mm 1.8",
+        "Yonguno 50mm f1.8",
+        "Yonguo 50mm",
+        "Youngnuo 50mm 1.8",
+        "Zeiss Portrait F1.8",
+        "artisan 55mm f1.4",
+        "brightin star AF 50mm 1.4",
+        "brightingstar 12mmf2",
+        "cf10mm",
+        "ePZ19105",
+        "laowa",
+        "laowa9mm",
+        "lw10",
+        "nikon18105-105mm",
+        "sigma 16mm f1.4",
+        "sigma 18-50",
+        "sigma 19mm f2.8",
+        "sigma 30mm f1.4 dc",
+        "sigma 30mm f1.4 dc dn contemporary",
+        "sigma 30mm f2.8",
+        "sigma 35mm",
+        "sigma 70-300mm  f1.4-5.6 (crop)",
+        "sigma art 24 1.4 DG",
+        "sirui 23 1.2",
+        "sony 35mm f1.8",
+        "sony1650",
+        "stm50 1.8",
+        "tamron a009 70-200 200",
+        "viltrox-23mm-f1.4",
+        "yong nuo 50",
+        "岩石星10mmF8",
+        "星耀10mm  f5.6",
+        "星耀50 F1.4",
+        "维卓仕20 2.8"
+      ],
+      "crop_factor": 1.5,
+      "sensor_size": "APS-C",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10 II",
+      "lenses": [
+        "Laowa 9mm f2.8",
+        "Sony E 11mm F1.8 (SEL11F18)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10II",
+      "lenses": [
+        "SIRUI 35mm 1.8 anamorphic 1.33"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sony",
+      "model": "ZV-E10M2",
+      "lenses": [
+        "Laowa 9mm 2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "soocoo",
+      "model": "c100",
+      "lenses": [
+        "soocoo 70"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Sooyi",
+      "model": "S3",
+      "lenses": [
+        "Sony"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "supremo",
+      "model": "premere",
+      "lenses": [
+        "OEM",
+        "yudiputa ka"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "supremo",
+      "model": "premere 4K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "surfola",
+      "model": "530",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Techno spark",
+      "model": "Spark",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Tecno",
+      "model": "pova 5",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Thieye",
+      "model": "dash cam",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Thieye",
+      "model": "t5",
+      "lenses": [
+        "Stock"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "TOMATE",
+      "model": "MT-1081",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "TomTom",
+      "model": "Bandit",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Tracer",
+      "model": "SJ 4000LE",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ulefone",
+      "model": "Armor 12g",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Ulefone",
+      "model": "Armor 7 Rear IMX586",
+      "lenses": [],
+      "crop_factor": 5.41,
+      "sensor_size": "1/2.3-inch",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "UMIDIGI",
+      "model": "F3 5G MP13",
+      "lenses": [
+        "Sony 48MP Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vaquita",
+      "model": "Paralenz Gen 1",
+      "lenses": [
+        "FOV (1/1.8\") D135 / H110 / V57 lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "visi",
+      "model": "orion_819L",
+      "lenses": [
+        "sony"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Visuo",
+      "model": "Zen K1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "VIVITAR",
+      "model": "DVR923-KIT-BLK",
+      "lenses": [
+        "N/A (Built in)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "A119 V3",
+      "lenses": [
+        "original"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "VIVO",
+      "model": "IQOO 9",
+      "lenses": [
+        "26MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "iQOO Z1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "IQOO3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "S15pro",
+      "lenses": [
+        "IMX766"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "V2145A",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "VIVO",
+      "model": "V23 5G",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "V2309",
+      "lenses": [
+        "16",
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "VIVO",
+      "model": "v27e",
+      "lenses": [
+        "Custom"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "Vivo x90 Pro+",
+      "lenses": [
+        "24 mm"
+      ],
+      "crop_factor": 3.0,
+      "sensor_size": "1-inch",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X100 Pro",
+      "lenses": [
+        "104mm",
+        "23mm Main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "x100pro",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X50",
+      "lenses": [
+        "main_camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "x50 pro+",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X50ProPlus",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "X70 Pro Plus",
+      "lenses": [
+        "Main 23mm",
+        "Tele",
+        "Ultra Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "VIVO",
+      "model": "x90 Pro+",
+      "lenses": [
+        "1x",
+        "24 mm main",
+        "Main 24 mm (35 mm full frame equivalent)",
+        "主摄"
+      ],
+      "crop_factor": 3.0,
+      "sensor_size": "1-inch",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Vivo",
+      "model": "x90pro+",
+      "lenses": [
+        "Main Camera",
+        "imx989",
+        "main lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Volla",
+      "model": "Vollaphone X",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "1s lite",
+      "lenses": [
+        "1s lite"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "1s little",
+      "lenses": [
+        "1s lite"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar",
+      "lenses": [
+        "Moonlight",
+        "Moonlight kit"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar HD",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar HD Mini 1s Lite",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Micro",
+      "lenses": [
+        "Micro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Micro V1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Mini",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar mini 1s kit nano",
+      "lenses": [
+        "2.1mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Moonlight",
+      "lenses": [
+        "AvatarMoonlight__1080p_4by3_4K-60.00fps",
+        "AvatarMoonlight___2.7k_16by9_2704x1520-60.00fps",
+        "AvatarMoonlight___4k_16by9_3840x2160-60.00fps"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Moonlight kit",
+      "lenses": [
+        "lens imu"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro",
+      "lenses": [
+        "60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro Camera",
+      "lenses": [
+        "Walksnail_Avatar_Pro_Camera_1080p_16by9_60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro HD",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Pro Wide",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar V2",
+      "lenses": [
+        "60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar V2 Camera",
+      "lenses": [
+        "Walksnail_Avatar_V2_Camera_1080p_16by9_60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Avatar Wide",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "fpv cam",
+      "lenses": [
+        "Walksnail_Avatar_Pro_Camera_1080p_16by9_60fps wide",
+        "Walksnail_Avatar_V2_Camera_1080p_16by9_60fps wide",
+        "Walksnail_Avatar_V2_Camera_1080p_4by3_60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "HD Pro kit",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Micro",
+      "lenses": [
+        "Standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "mini vtx",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Moonlight",
+      "lenses": [
+        "AvatarMoonlight__1080p_16by9_1920x1080-60.00fps",
+        "AvatarMoonlight___2.7k_16by9_2704x1520-60.00fps",
+        "AvatarMoonlight___4k_16by9_3840x2160-60.00fps"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Moonlight 4K",
+      "lenses": [
+        "AvatarMoonlight___4k_16by9_3840x2160-60.00fps"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Moonlight 4K 30fps",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "Nano",
+      "lenses": [
+        "RunCam Phoenix 2 Nano"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "ProV2",
+      "lenses": [
+        "2.2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "V2",
+      "lenses": [
+        "Walksnail_Avatar_V2_Camera_1080p_4by3_60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail",
+      "model": "walksnail cinlog35",
+      "lenses": [
+        "walksnail cinlog35"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail Avatar V2",
+      "model": "FPVcam V2",
+      "lenses": [
+        "Walksnail_Avatar_V2_Camera_1080p_16by9_60fps wide",
+        "Walksnail_Avatar_V2_Camera_1080p_4by3_60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Walksnail Avatar V2 Pro",
+      "model": "fpv cam",
+      "lenses": [
+        "Walksnail_Avatar_Pro_Camera_1080p_16by9_60fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Wolfang",
+      "model": "GA300",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Wolfang",
+      "model": "GA320",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "wolfang",
+      "model": "ga400",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "WOLFANG",
+      "model": "GA420",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "WOLFGANG",
+      "model": "GA420",
+      "lenses": [
+        "Ultra wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "X-TRY",
+      "model": "XTC 263",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XDV",
+      "model": "Action Sport Camera",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "小蚁相机",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10",
+      "lenses": [
+        "25MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10 Ultra",
+      "lenses": [
+        "MainCam 25mm F1.85"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10pro Ultra wide",
+      "lenses": [
+        "2.35mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10S",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10T Lite",
+      "lenses": [
+        "26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "10u",
+      "lenses": [
+        "15mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11 Lite 5G NE",
+      "lenses": [
+        "Back 1.0 focal"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11 Ultra",
+      "lenses": [
+        "24mm",
+        "xiaomi 11 ultra"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11 Ultra 4:3 RAW",
+      "lenses": [
+        "24 mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11T",
+      "lenses": [
+        "Standard"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "11Tpro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 5G",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 Lite",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 pro",
+      "lenses": [
+        "Ultra wide",
+        "tele-zoom x2",
+        "wide angle"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12 SU",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12S Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12s ultra",
+      "lenses": [
+        "14mm",
+        "main 23mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12SU",
+      "lenses": [
+        "4K"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12T pro",
+      "lenses": [
+        "1/1.22\" 200mp 23mm f/1.69"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "12x",
+      "lenses": [
+        "Motion cam",
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13",
+      "lenses": [
+        "(75mm - 66mm tele lens)",
+        "15mm",
+        "24m",
+        "24mm",
+        "66mm",
+        "Wide 23mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13 24mm",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13 Ultra",
+      "lenses": [
+        "13 mm UW",
+        "1X main",
+        "23mm",
+        "24mm",
+        "62mm",
+        "Rear Wide Camera",
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13pro",
+      "lenses": [
+        "23mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13pro main",
+      "lenses": [
+        "23mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13pro wide",
+      "lenses": [
+        "14mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13T",
+      "lenses": [
+        "24MM Wide (Main Back) Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13T Pro",
+      "lenses": [
+        "15mm",
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13u广角",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13U 23mm 小米",
+      "lenses": [
+        "主摄像头"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "13ultra",
+      "lenses": [
+        "x1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14",
+      "lenses": [
+        "24mm",
+        "25mm",
+        "Ultrawide 15mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14 3.2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14 Main",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14 Ultra",
+      "lenses": [
+        "24mm",
+        "24mm No OIS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14PRO",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14Pro main camera",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14u",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "14ultra",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "22081212C",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "2210132G",
+      "lenses": [
+        "21mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "2304FPN6DG",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "24030PN60G",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "cc9pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "fimi x8 mini",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "K30PRO1X",
+      "lenses": [
+        "1X"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "k60",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "K70至尊",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mİ 10T",
+      "lenses": [
+        "26MM"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "M2012K11AC",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "M2101K7BNY",
+      "lenses": [
+        "26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10",
+      "lenses": [
+        "26mm",
+        "Main Camera",
+        "Main Rear Camera",
+        "Ultrawide Rear Camera",
+        "Wide lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10 Pro",
+      "lenses": [
+        "14mm ultrawide",
+        "Main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10 Ultra",
+      "lenses": [
+        "Ultra Wide Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10T",
+      "lenses": [
+        "26mm",
+        "26mm wide",
+        "uw"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10T lite",
+      "lenses": [
+        "Sony IMX682"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 10T PRO",
+      "lenses": [
+        "108MP 1080p Main",
+        "Samsung Bright S5KHMX"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11",
+      "lenses": [
+        "Samsung ISOCELL Bright HMX"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 Lite",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 lite 5g",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 Lite 5G NE",
+      "lenses": [
+        "26mm f/1.8",
+        "Main sensor f1.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "MI 11 Ultra",
+      "lenses": [
+        "Main 50 MP, f/2.0, 24mm (wide)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11 Ultra 24mm",
+      "lenses": [
+        "24mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi 11t",
+      "lenses": [
+        "none"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11x",
+      "lenses": [
+        "Ultra wide angle"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 11X M2012K11AI",
+      "lenses": [
+        "Main f/1.79 4.71mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "MI 11x / Poco F3",
+      "lenses": [
+        "Sony IMX582"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 12 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 13",
+      "lenses": [
+        "Wide 23mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 14",
+      "lenses": [
+        "15mm",
+        "24mm",
+        "62mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 8 Lite",
+      "lenses": [
+        "Sony IMX 363"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 9",
+      "lenses": [
+        "Filmic pro Main",
+        "Primary camera Wide",
+        "Wide (1x)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "MI 9 Lite",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 9 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 9T Pro",
+      "lenses": [
+        "16mm",
+        "Ultra Wide (0.6x)",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi 9T Pro / K20 Pro",
+      "lenses": [
+        "Main 27mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi A3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi Action 4K",
+      "lenses": [
+        "SONY FDR X3000"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi Action Camera 4K",
+      "lenses": [
+        "16:9",
+        "9:16"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi MIX 1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi Note 10 Pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi10",
+      "lenses": [
+        "uw"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi10tpro",
+      "lenses": [
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "mi14",
+      "lenses": [
+        "Ultrawide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mi8",
+      "lenses": [
+        "Sony IMX363 Exmor RS"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mijia 4K",
+      "lenses": [
+        "3.2mm f/2.8",
+        "FOV 145 f/2.8",
+        "fov 145 f/2.8"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mix 2s",
+      "lenses": [
+        "Wide/Main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Mix3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Nico",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Note 10",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco F2 Pro",
+      "lenses": [
+        "IMX686"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco f3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "POCO F5",
+      "lenses": [
+        "Main Camera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco X3",
+      "lenses": [
+        "Sony IMX682"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco X3 NFC",
+      "lenses": [
+        "1x",
+        "Wide Lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Poco X3 pro",
+      "lenses": [
+        "padrão"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Pocophone NFC X3",
+      "lenses": [
+        "1x"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 10s",
+      "lenses": [
+        "redmi 10 s"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 11",
+      "lenses": [
+        "29"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 8",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 9",
+      "lenses": [
+        "13MP",
+        "29mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 9s pro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Horizontal",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi 红米K30pro",
+      "lenses": [
+        "主摄横屏",
+        "红米K30pro主摄横屏",
+        "红米K30pro广角"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi K50 广角",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi k50i",
+      "lenses": [
+        "wide/main  lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 10",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 10 pro",
+      "lenses": [
+        "main 26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11",
+      "lenses": [
+        "main"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "REDMI NOTE 11 4G",
+      "lenses": [
+        "29mm",
+        "MotionCamPro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11 pro 4G",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11 Pro+ 5G",
+      "lenses": [
+        "OpenCamera Sensors"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 11Pro+ 5G",
+      "lenses": [
+        "OpenCamera Sensors"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 11t pro +ultra wide",
+      "lenses": [
+        "120°"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 12 + 5G",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 12 pro + 5g",
+      "lenses": [
+        "f/1.88, IMX766"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 4X",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 4X Samsung S5K3L8",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 7",
+      "lenses": [
+        "Main",
+        "Main lens"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 8",
+      "lenses": [
+        "Ultra wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 8 Pro",
+      "lenses": [
+        "Camara Trasera"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 9 Pro",
+      "lenses": [
+        "MotionCam Pro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 9 pro maxr",
+      "lenses": [
+        "26mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi note 9Filmic pro",
+      "lenses": [
+        "ACC 23"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note 9S",
+      "lenses": [
+        "1080p 60fps"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Note12Tubro",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi Pro 10",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Redmi S2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "RN8 Ginkgo",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Ultra 14",
+      "lenses": [
+        "24mm -wide-"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Xiaomi 13 Ultra",
+      "lenses": [
+        "24mm主摄"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi",
+      "lenses": [
+        "170\"",
+        "F/2.8",
+        "GoProHero4",
+        "Std",
+        "Stock",
+        "Superview",
+        "Z22L",
+        "xiaomi yi"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 1080p Action camera",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 22l",
+      "lenses": [
+        "action cam"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 2K",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 4K",
+      "lenses": [
+        "Stock",
+        "Wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi 4K action camera",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi Action",
+      "lenses": [
+        "120"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi action cam",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi action caméra",
+      "lenses": [
+        "Capteur Sony IMX317"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi action caméra 4K",
+      "lenses": [
+        "Capteur Sony IMX317"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yi Discovery",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Xiaomi",
+      "model": "Yio",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX2",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX2 CAM",
+      "lenses": [
+        "Wide",
+        "XTU/XTU_MAX2_LDC_2.7k25_2.7k_4by3_2720x2040-25fps wide",
+        "XTU/XTU_MAX2_LDC_4k25_4k_16by9_3840x2160-25fps wide",
+        "XTU/XTU_MAX2_NO-LDC_4k25_4k_16by9_3840x2160-25fps wide",
+        "XTU/XTU_MAX2_NO-LDC_4k60_4k_16by9_3840x2160-59.94fps wide",
+        "XTU/XTU_MAX2_NO-LDC_6k30_6k_16by9_5376x3024-29.97fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAX3 CAM",
+      "lenses": [
+        "XTU/XTU_MAX3_NO-LDC_1080P120_1080p_16by9_1920x1080-120fps wide",
+        "XTU/XTU_MAX3_NO-LDC_1080P30_1080p_16by9_1920x1080-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_1080P30full_1080p_16by9_1920x1080-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_1080P60_1080p_16by9_1920x1080-59.94fps wide",
+        "XTU/XTU_MAX3_NO-LDC_1080P60full_1080p_16by9_1920x1080-59.94fps wide",
+        "XTU/XTU_MAX3_NO-LDC_1440P30_1440p_4by3_1920x1440-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_1440P60_1440p_4by3_1920x1440-59.94fps wide",
+        "XTU/XTU_MAX3_NO-LDC_2.7k30_2.7k_16by9_2720x1530-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_2.7k30_2.7k_4by3_2720x2040-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_2.7k60_2.7k_16by9_2720x1530-59.94fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k30_12M_4k_4by3_4000x3000-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k30_4k_16by9_3840x2160-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k30full_4k_16by9_3840x2160-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k60_4k_16by9_3840x2160-59.94fps wide",
+        "XTU/XTU_MAX3_NO-LDC_6k30_6k_16by9_5376x3024-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_720P120_720p_16by9_1280x720-120fps wide",
+        "XTU/XTU_MAX3_NO-LDC_720P30_720p_16by9_1280x720-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_720P60_720p_16by9_1280x720-59.94fps wide",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MAXPRO CAM",
+      "lenses": [
+        "XTU/XTU_MaxPro_LDC_2.7k60_2.7k_16by9_2720x1530-59.94fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_2.7k60_2.7k_16by9_2720x1530-59.94fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "MINI1",
+      "lenses": [
+        "GK319"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S2",
+      "lenses": [
+        "XTU/XTU_XTUS2_XTU_2.7k30_2.7k_16by9_2704x1520-30fps wide",
+        "标准"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S2 PRO",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S2PRO",
+      "lenses": [
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S3",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S3pro",
+      "lenses": [
+        "GK554"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S3PRO CAM",
+      "lenses": [
+        "MaxPro_LDC_1440P60",
+        "MaxPro_NO-LDC_2.7k30",
+        "Wide",
+        "XTU/XTU_MaxPro_NO-LDC_1080P30_1080p_16by9_1920x1080-29.97fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S5K",
+      "lenses": [
+        "GK811",
+        "JK88",
+        "XTU/XTU_XTUS5K_XTU_2.7k30_2.7k_16by9_2704x1520-30fps wide",
+        "XTU/XTU_XTUS5K_XTU_4k30_4k_16by9_3840x2160-30fps wide",
+        "XTU/XTU_XTUS5K_XTU_5k30_5k_16by9_4068x2592-30fps wide",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S6",
+      "lenses": [
+        "1080p30",
+        "1080p60",
+        "170°广角-2.8",
+        "SONY IMX386",
+        "f2.8-170°广角"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "S6 CAM",
+      "lenses": [
+        "XTU S6 1080P30 SuperView 1920x1080-30.00fps Wide",
+        "XTU/XTU_MaxPro_LDC_1440P30_1440p_4by3_1920x1440-29.97fps wide",
+        "XTU/XTU_MaxPro_LDC_1440P60_1440p_4by3_1920x1440-59.94fps wide",
+        "XTU/XTU_MaxPro_LDC_4k30_4k_16by9_3840x2160-29.97fps wide",
+        "XTU/XTU_MaxPro_LDC_4k30full_4k_16by9_3840x2160-29.97fps wide",
+        "XTU/XTU_MaxPro_LDC_720P30_720p_16by9_1280x720-29.97fps wide",
+        "XTU/XTU_MaxPro_NO-LDC",
+        "XTU/XTU_MaxPro_NO-LDC_1080P30_1080p_16by9_1920x1080-29.97fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_1080P60_1080p_16by9_1920x1080-59.94fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_1080P60full_1080p_16by9_1920x1080-59.94fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_1440P30_1440p_4by3_1920x1440-29.97fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_1440P60_1440p_4by3_1920x1440-59.94fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_2.7k30_2.7k_16by9_2720x1530-29.97fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_4k30_4k_16by9_3840x2160-29.97fps wide",
+        "XTU/XTU_MaxPro_NO-LDC_4k30full_4k_16by9_3840x2160-29.97fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X1",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X2",
+      "lenses": [
+        "2.7K30P",
+        "2.7K4/3",
+        "4K30P"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X3",
+      "lenses": [
+        "1",
+        "F05",
+        "wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "X3 CAM",
+      "lenses": [
+        "XTU-X3_LDC_4K30_16:9_3840x2160_29.97fps",
+        "XTU/XTU_MAX3_NO-LDC_4k25_4k_16by9_3840x2160-25fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k30_12M_4k_4by3_4000x3000-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k30full_4k_16by9_3840x2160-29.97fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k50_4k_16by9_3840x2160-50fps wide",
+        "XTU/XTU_MAX3_NO-LDC_4k60_4k_16by9_3840x2160-59.94fps wide",
+        "XTU/XTU_MAX3_NO-LDC_6k30_6k_16by9_5376x3024-25fps wide",
+        "XTU/XTU_MAX3_NO-LDC_6k30_6k_16by9_5376x3024-29.97fps wide"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "XTUMAX2",
+      "lenses": [
+        "GK766"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "XTU",
+      "model": "XTUS5K (v1.2)",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "YiCam",
+      "model": "Yicam",
+      "lenses": [
+        "Superview"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Yolansin",
+      "model": "C16",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E1",
+      "lenses": [
+        "10mm",
+        "LUMIX 14-45mm @ 14mm",
+        "Olympus 14-42mm 1:3.5-5.6 EZ",
+        "PANASONIC LUMIX 25MM F1.7",
+        "Rokinon 7.5mm f3.5 fish",
+        "SLR MAGIC 8 MM"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2",
+      "lenses": [
+        "0?95",
+        "10-24MM",
+        "16mm f1.4",
+        "7.5MM F2.8",
+        "Canon EF 17-40 f/4 @20mm_Equiv 24mm",
+        "HIKVISION 16mm f1.4",
+        "LAOWA 7.5mm F2",
+        "LOWO 7.5",
+        "Laowa 10mm",
+        "Laowa 12mm SB0.64",
+        "Laowa 17mm F1.8",
+        "Laowa 6mm 2.1T",
+        "Laowa 6mm T2.1",
+        "Laowa 7.5 f2",
+        "Laowa 7.5F2",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm F2",
+        "Laowa 7.5mm F2.0 MFT UL",
+        "Laowa 7.5mm T2 M43",
+        "Laowa 7.5mm f2.0",
+        "Laowa 9mm F2.8",
+        "Loawa 7.5mm f2",
+        "Lumix 12-35 f2.8 DG",
+        "Lumix 15mm f1,7",
+        "Lumix 15mm f1.7",
+        "Lumix 35-100 f2.8 G II",
+        "Meke 16mm T2.2",
+        "Olympus 12-40 f2.8 at 12mm",
+        "Olympus 12mm",
+        "Olympus 45 f1.8",
+        "Olympus 45mm f1.8",
+        "SIRUI 24MM T1.2",
+        "Samyang 20mm 1.9",
+        "Samyang 7.5mm FISH EYE T3.1",
+        "ZHONGYI 25mm f0.95",
+        "laowa 7.5mm",
+        "loawa 7.5mm f2",
+        "slr 8mm f4"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-F6",
+      "lenses": [
+        "Canon 24-70mm L 2.8 @24mm",
+        "Canon 24-70mm L 2.8 @35mm",
+        "Canon 24-70mm L 2.8 @50mm",
+        "Canon 24-70mm L 2.8 @70mm",
+        "Canon 50mm Prime",
+        "Canon EF24mm f/2.8 is USM Lens",
+        "Chiopt Xtreme 28-85 t3.2",
+        "DZOFILM VESPID 35MM",
+        "Irix 15mm",
+        "Laowa",
+        "Laowa 11mm",
+        "NIKKOR 18mm f3.5 AiS",
+        "NIKKOR 28mm f2.8 AiS",
+        "NIKKOR 85mm f2.0 Ai 2X Anamorphic",
+        "Sigma Art 24mm",
+        "laowa 14mmf4",
+        "tamron"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-M4",
+      "lenses": [
+        "10mm Meike",
+        "10mm Meike Mini Prime",
+        "10mm Meike Miniprime",
+        "16mm Meike",
+        "16mm Meike MFT",
+        "18-35 1.8",
+        "35MMcine",
+        "7.5 F2",
+        "7.5mm F2",
+        "7Artisans 7.5mm",
+        "7Artisans 7.5mm Fish Eye 2.8",
+        "7artisans 7.5mm",
+        "9mm",
+        "Canon 24-105mm f/4 Viltox Speed Booster 0.71x @ 24mm",
+        "DJI 15mm f1.7 Asph MFT",
+        "DZOFILM 20-70",
+        "Helios-44-2",
+        "IRIX 45MMT1.5 CINEMA CANON-EF",
+        "LUMIX G 14-42",
+        "Laowa",
+        "Laowa 10MM COOKIE",
+        "Laowa 17mm",
+        "Laowa 27mm Nanomorph",
+        "Laowa 6.0 T2.1 CINE LENS",
+        "Laowa 7,5",
+        "Laowa 7.5 F2",
+        "Laowa 7.5 MFT F2",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm F2",
+        "Laowa 7.5mm F2 Blue Ring",
+        "Laowa 7.5mm F2.0",
+        "Laowa 9mm",
+        "Laowa 9mm f2.8 Zero-D MFT",
+        "Laowa-7.5mm",
+        "M43-17mm",
+        "MFT Laowa 7.5mm",
+        "MZUIKO 9-18",
+        "Meike 12mm",
+        "Meike 25mm",
+        "Olympus 12mm  12-40 Pro",
+        "Olympus 12mm 12-40Pro",
+        "Olympus 17mm",
+        "Olympus 17mm f1.8",
+        "Olympus 9-18",
+        "Olympus M.Zuiko 12mm f2.0 MFT",
+        "Panasonic Leica DG Vario-Elmarit 8-18mm",
+        "SIRUI Nightwalker 35mm T1.2",
+        "Samyang fish eye 7,5",
+        "Sigma 10-20mm f/4-5.6 Vilrox Speed Booster 0.71x @ 12mm",
+        "Sigma 16mm 1.4",
+        "Sigma 18-35 1.8",
+        "Sigma 18-35 1.8 Viltrox EF-E II 0.71 speedbooster",
+        "Sigma 18-35 w/ Viltrox EF-E II 0.71x speedbooster",
+        "Sigma 8-16mm 4.5-5.6 Viltrox Ef-E II 0.71 speedbooster",
+        "Sigma 8-16mm 4.5-5.6 w/ Viltrox EF-E II 0.71x speedbooster",
+        "Sony SEL35F18 35mm 1.8",
+        "Tamron 17 50",
+        "Tamron 17-50",
+        "laowa 6mm t2.0",
+        "laowa 6mm t2.1",
+        "laowa 7.5mm",
+        "laowa7.5",
+        "samyang 12mm",
+        "tokina 12-24 f4 if dx pro"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-S6",
+      "lenses": [
+        "18-35mm F1.8 DC HSM | Art 013 18mm",
+        "25mm Meike",
+        "35mm Meike S35",
+        "Canon L 17-40",
+        "HELIOS 44M",
+        "Laowa 10mm",
+        "Laowa 10mm f2",
+        "Laowa 12mm",
+        "Laowa 14mm EF",
+        "Laowa 7.5",
+        "Laowa 7.5mm",
+        "Laowa 7.5mm MFT",
+        "Laowa 9mm f/2.8 Zero-D Sony E",
+        "Mitakon 17mm f0.95",
+        "Rokinon 8mm f/2.8",
+        "Samyang 14mm T3.1",
+        "Samyang 24mm",
+        "Sigma 18-35",
+        "TTArtisan 7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2-S6G",
+      "lenses": [
+        "24MM XEEN CF + VILTROX 0.71",
+        "Laowa 14mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2c",
+      "lenses": [
+        "8mm",
+        "Laowa 7.5",
+        "Laowa 7.5mm",
+        "Samyang 7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2F6",
+      "lenses": [
+        "Tamron 24-70mm F2.8 Di VC USD G2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2M4",
+      "lenses": [
+        "LAOWA 17MM F1.8",
+        "LOAWA 10mm",
+        "Olympus 12-40 f2.8",
+        "T2.2",
+        "laowa7.5",
+        "meike S35 12mm T2.2",
+        "思锐35mmT1.2"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "E2S6",
+      "lenses": [
+        "Meike 24mm T2.1"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "F6",
+      "lenses": [
+        "Biotar 58mm + Aivascope 1.5x (Veritcal)"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "laowa",
+      "lenses": [
+        "MFT7.5mm"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Z CAM",
+      "model": "S6",
+      "lenses": [
+        "Canon 35 F/2",
+        "Laowa 9mm",
+        "Taikuma",
+        "Taikuma 24mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "Zoom",
+      "model": "Q2n",
+      "lenses": [],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "Axon",
+      "lenses": [
+        "60"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "AXON40ULTRA",
+      "lenses": [
+        "Wideangle"
+      ],
+      "crop_factor": null,
+      "sensor_size": null,
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "Nubia z50 ultra",
+      "lenses": [
+        "15mm",
+        "35mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    },
+    {
+      "brand": "ZTE",
+      "model": "nubia z60 Ultra 35mm",
+      "lenses": [
+        "35mm"
+      ],
+      "crop_factor": 1.0,
+      "sensor_size": "Full frame",
+      "source": [
+        "gyroflow"
+      ]
+    }
+  ]
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -99,6 +99,14 @@ pub struct Controller {
     all_profiles_loaded: qt_signal!(),
     search_lens_profile_finished: qt_signal!(profiles: QVariantList),
     search_lens_profile: qt_method!(fn(&self, text: QString, favorites: QVariantList, aspect_ratio: i32, aspect_ratio_swapped: i32)),
+    search_lens_profile_for_camera: qt_method!(fn(&self, brand: QString, model: QString, lens: QString, text: QString, hidden_profiles: QVariantList, favorites: QVariantList, aspect_ratio: i32, aspect_ratio_swapped: i32)),
+    camera_registry_brands: qt_method!(fn(&self) -> QStringList),
+    camera_registry_models: qt_method!(fn(&self, brand: QString) -> QStringList),
+    camera_registry_lenses: qt_method!(fn(&self, brand: QString, model: QString) -> QStringList),
+    camera_registry_compatible_models: qt_method!(fn(&self, brand: QString, model: QString) -> QStringList),
+    camera_registry_resolve_camera: qt_method!(fn(&self, brand: QString, model: QString) -> QJsonObject),
+    camera_registry_resolve_model: qt_method!(fn(&self, brand: QString, model: QString) -> QString),
+    camera_registry_info: qt_method!(fn(&self, brand: QString, model: QString) -> QJsonObject),
     fetch_profiles_from_github: qt_method!(fn(&self)),
     lens_profiles_updated: qt_signal!(reload_from_disk: bool),
 
@@ -307,6 +315,7 @@ pub struct Controller {
     ongoing_computations: BTreeSet<u64>,
 
     pub stabilizer: Arc<StabilizationManager>,
+    camera_registry: Arc<parking_lot::RwLock<core::camera_registry::CameraRegistry>>,
 }
 
 impl Controller {
@@ -1876,6 +1885,7 @@ impl Controller {
             this.all_profiles_loaded();
         });
         let db = self.stabilizer.lens_profile_db.clone();
+        let camera_registry = self.camera_registry.clone();
         core::run_threaded(move || {
             if reload_from_disk {
                 let mut new_db = core::lens_profile_database::LensProfileDatabase::default();
@@ -1887,10 +1897,64 @@ impl Controller {
                 db.write().set_from_db(new_db);
             }
 
-            db.write().prepare_list_for_ui();
+            let new_camera_registry = {
+                let mut db = db.write();
+                db.prepare_list_for_ui();
+                core::camera_registry::CameraRegistry::from_lens_profile_database(&db)
+            };
+            *camera_registry.write() = new_camera_registry;
 
             loaded(());
         });
+    }
+
+    fn camera_registry_brands(&self) -> QStringList {
+        QStringList::from_iter(self.camera_registry.read().brands().into_iter())
+    }
+
+    fn camera_registry_models(&self, brand: QString) -> QStringList {
+        QStringList::from_iter(self.camera_registry.read().models(&brand.to_string()).into_iter())
+    }
+
+    fn camera_registry_lenses(&self, brand: QString, model: QString) -> QStringList {
+        QStringList::from_iter(self.camera_registry.read().lenses(&brand.to_string(), &model.to_string()).into_iter())
+    }
+
+    fn camera_registry_compatible_models(&self, brand: QString, model: QString) -> QStringList {
+        QStringList::from_iter(self.camera_registry.read().compatible_models(&brand.to_string(), &model.to_string()).into_iter())
+    }
+
+    fn camera_registry_resolve_camera(&self, brand: QString, model: QString) -> QJsonObject {
+        let resolved = self.camera_registry.read()
+            .resolve_camera(&brand.to_string(), &model.to_string())
+            .map(|(brand, model)| serde_json::json!({
+                "brand": brand,
+                "model": model,
+            }));
+        util::serde_json_to_qt_object(&resolved.unwrap_or_default())
+    }
+
+    fn camera_registry_resolve_model(&self, brand: QString, model: QString) -> QString {
+        QString::from(self.camera_registry.read().resolve_model(&brand.to_string(), &model.to_string()).unwrap_or_default())
+    }
+
+    fn camera_registry_info(&self, brand: QString, model: QString) -> QJsonObject {
+        let info = self.camera_registry.read().camera_info(&brand.to_string(), &model.to_string());
+        util::serde_json_to_qt_object(&serde_json::to_value(info).unwrap_or_default())
+    }
+
+    fn lens_profile_results_to_qvariant(profiles: Vec<core::lens_profile_database::LensProfileUiItem>) -> QVariantList {
+        profiles.into_iter().map(|(name, file, crc, official, rating, aspect_ratio, _author)| {
+            let mut list = QVariantList::from_iter([
+                QString::from(name),
+                QString::from(file),
+                QString::from(crc)
+            ].into_iter());
+            list.push(official.into());
+            list.push(rating.into());
+            list.push(aspect_ratio.into());
+            list
+        }).collect()
     }
 
     fn search_lens_profile(&self, text: QString, favorites: QVariantList, aspect_ratio: i32, aspect_ratio_swapped: i32) {
@@ -1901,17 +1965,44 @@ impl Controller {
         let text = text.to_string();
         let favorites = HashSet::<String>::from_iter(favorites.into_iter().map(|x| x.to_qbytearray().to_string()));
         core::run_threaded(move || {
-            let profiles = db.read().search(&text, &favorites, aspect_ratio, aspect_ratio_swapped).into_iter().map(|(name, file, crc, official, rating, aspect_ratio, _author)| {
-                let mut list = QVariantList::from_iter([
-                    QString::from(name),
-                    QString::from(file),
-                    QString::from(crc)
-                ].into_iter());
-                list.push(official.into());
-                list.push(rating.into());
-                list.push(aspect_ratio.into());
-                list
-            }).collect();
+            let profiles = Self::lens_profile_results_to_qvariant(db.read().search(&text, &favorites, aspect_ratio, aspect_ratio_swapped));
+
+            finished(profiles);
+        });
+    }
+
+    fn search_lens_profile_for_camera(&self, brand: QString, model: QString, lens: QString, text: QString, hidden_profiles: QVariantList, favorites: QVariantList, aspect_ratio: i32, aspect_ratio_swapped: i32) {
+        let finished = util::qt_queued_callback_mut(QPointer::from(self as &Self), |this, profiles: QVariantList| {
+            this.search_lens_profile_finished(profiles);
+        });
+        let db = self.stabilizer.lens_profile_db.clone();
+        let brand = brand.to_string();
+        let model = model.to_string();
+        let lens = lens.to_string();
+        let text = text.to_string();
+        let hidden_profiles = HashSet::<String>::from_iter(hidden_profiles.into_iter().map(|x| x.to_qbytearray().to_string()).filter(|x| !x.is_empty()));
+        let favorites = HashSet::<String>::from_iter(favorites.into_iter().map(|x| x.to_qbytearray().to_string()));
+        let (selected_camera_keys, compatible_camera_keys) = {
+            let camera_registry = self.camera_registry.read();
+            (
+                HashSet::<(String, String)>::from_iter(camera_registry.selected_camera_keys(&brand, &model).into_iter()),
+                HashSet::<(String, String)>::from_iter(camera_registry.compatible_camera_keys(&brand, &model).into_iter())
+            )
+        };
+
+        core::run_threaded(move || {
+            let profiles = Self::lens_profile_results_to_qvariant(db.read().search_by_camera(
+                &brand,
+                &model,
+                &lens,
+                &text,
+                &selected_camera_keys,
+                &compatible_camera_keys,
+                &hidden_profiles,
+                &favorites,
+                aspect_ratio,
+                aspect_ratio_swapped
+            ));
 
             finished(profiles);
         });
@@ -1933,6 +2024,7 @@ impl Controller {
         let current_version = self.stabilizer.lens_profile_db.read().version;
 
         let db_path = LensProfileDatabase::get_path().join("profiles.cbor.gz");
+        let registry_path = gyroflow_core::settings::data_dir().join("lens_profiles").join("camera_registry.json");
         if db_path.exists() || gyroflow_core::settings::data_dir().join("lens_profiles").exists() {
             core::run_threaded(move || {
                 if let Ok(Ok(body)) = ureq::get("https://api.github.com/repos/gyroflow/lens_profiles/releases").call().map(|x| x.into_body().read_to_string()) {
@@ -1943,24 +2035,37 @@ impl Controller {
                             if let Ok(tag) = obj.get("tag_name")?.as_str()?.trim_start_matches("v").parse::<u32>() {
                                 if tag > current_version {
                                     ::log::info!("Updating lens profile database from v{current_version} to v{tag}.");
-                                    if let Some(download_url) = obj["assets"][0]["browser_download_url"].as_str() {
-                                        if let Ok(mut content) = ureq::get(download_url).call().map(|x| x.into_body().into_reader()) {
-                                            let mut updated = false;
-                                            if db_path.exists() {
-                                                if let Ok(mut file) = std::fs::File::create(&db_path) {
-                                                    if std::io::copy(&mut content, &mut file).is_ok() {
-                                                        updated = true;
-                                                        update(());
-                                                    }
-                                                }
+                                    let assets = obj.get("assets")?.as_array()?;
+                                    let asset_url = |name: &str| {
+                                        assets.iter()
+                                            .find(|asset| asset.get("name").and_then(|x| x.as_str()) == Some(name))
+                                            .and_then(|asset| asset.get("browser_download_url").and_then(|x| x.as_str()))
+                                    };
+                                    let download_to = |url: &str, path: &std::path::Path| -> bool {
+                                        if let Some(parent) = path.parent() {
+                                            let _ = std::fs::create_dir_all(parent);
+                                        }
+                                        if let Ok(mut content) = ureq::get(url).call().map(|x| x.into_body().into_reader()) {
+                                            if let Ok(mut file) = std::fs::File::create(path) {
+                                                return std::io::copy(&mut content, &mut file).is_ok();
                                             }
-                                            if !updated {
-                                                if let Ok(mut file) = std::fs::File::create(gyroflow_core::settings::data_dir().join("lens_profiles").join("profiles.cbor.gz")) {
-                                                    if std::io::copy(&mut content, &mut file).is_ok() {
-                                                        update(());
-                                                    }
-                                                }
-                                            }
+                                        }
+                                        false
+                                    };
+
+                                    if let Some(download_url) = asset_url("profiles.cbor.gz") {
+                                        let mut updated = false;
+                                        if db_path.exists() && download_to(download_url, &db_path) {
+                                            updated = true;
+                                            update(());
+                                        }
+                                        if !updated && download_to(download_url, &gyroflow_core::settings::data_dir().join("lens_profiles").join("profiles.cbor.gz")) {
+                                            update(());
+                                        }
+                                    }
+                                    if let Some(download_url) = asset_url("camera_registry.json") {
+                                        if download_to(download_url, &registry_path) {
+                                            update(());
                                         }
                                     }
                                 }

--- a/src/core/camera_registry.rs
+++ b/src/core/camera_registry.rs
@@ -1,0 +1,509 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::Path;
+
+use crate::{LensProfile, lens_profile_database::LensProfileDatabase};
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CameraRegistryFile {
+    pub version: u32,
+    pub cameras: Vec<CameraRegistryEntry>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
+pub struct CameraRegistryEntry {
+    pub brand: String,
+    pub model: String,
+    pub lenses: Vec<String>,
+    pub crop_factor: Option<f64>,
+    pub sensor_size: Option<String>,
+    pub source: Vec<String>,
+}
+
+#[derive(Clone, Debug, Default, serde::Serialize)]
+pub struct CameraRegistryInfo {
+    pub brand: String,
+    pub model: String,
+    pub lenses: Vec<String>,
+    pub crop_factor: Option<f64>,
+    pub sensor_size: Option<String>,
+    pub source: Vec<String>,
+    pub known_lens_count: usize,
+}
+
+#[derive(Clone, Debug, Default)]
+struct CameraEntry {
+    brand: String,
+    model: String,
+    lenses: BTreeSet<String>,
+    crop_factor: Option<f64>,
+    sensor_size: Option<String>,
+    source: BTreeSet<String>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CameraRegistry {
+    cameras: BTreeMap<(String, String), CameraEntry>,
+    brands: Vec<String>,
+    models: BTreeMap<String, Vec<String>>,
+    lenses: BTreeMap<(String, String), Vec<String>>,
+}
+
+impl CameraRegistry {
+    pub fn from_lens_profile_database(profiles: &LensProfileDatabase) -> Self {
+        Self::from_lens_profile_database_with_catalogs(profiles, true)
+    }
+
+    fn from_lens_profile_database_with_catalogs(
+        profiles: &LensProfileDatabase,
+        load_catalogs: bool,
+    ) -> Self {
+        let mut registry = Self::default();
+        if load_catalogs {
+            registry.merge_catalog_path(
+                &crate::settings::data_dir()
+                    .join("lens_profiles")
+                    .join("camera_registry.json"),
+            );
+            registry.merge_catalog_str(include_str!(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/../../resources/camera_registry.json"
+            )));
+        }
+
+        for profile in profiles.iter_profiles() {
+            registry.merge_profile(profile);
+        }
+
+        registry.rebuild_indexes();
+        registry
+    }
+
+    pub fn brands(&self) -> Vec<String> {
+        self.brands.clone()
+    }
+
+    pub fn models(&self, brand: &str) -> Vec<String> {
+        self.models
+            .get(&Self::key(brand))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn lenses(&self, brand: &str, model: &str) -> Vec<String> {
+        self.lenses
+            .get(&Self::camera_key(brand, model))
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    pub fn compatible_models(&self, brand: &str, model: &str) -> Vec<String> {
+        let Some(selected) = self.find_camera(brand, model) else {
+            return Vec::new();
+        };
+
+        let selected_brand = Self::key(&selected.brand);
+        self.cameras
+            .values()
+            .filter(|candidate| {
+                Self::key(&candidate.brand) == selected_brand
+                    && Self::camera_key(&candidate.brand, &candidate.model)
+                        != Self::camera_key(&selected.brand, &selected.model)
+                    && Self::sensor_compatible(selected, candidate)
+            })
+            .map(|candidate| format!("{} {}", candidate.brand, candidate.model))
+            .collect()
+    }
+
+    pub fn selected_camera_keys(&self, brand: &str, model: &str) -> BTreeSet<(String, String)> {
+        self.find_camera(brand, model)
+            .map(|camera| BTreeSet::from([Self::camera_key(&camera.brand, &camera.model)]))
+            .unwrap_or_else(|| {
+                let key = Self::camera_key(brand, model);
+                if key.0.is_empty() || key.1.is_empty() {
+                    BTreeSet::new()
+                } else {
+                    BTreeSet::from([key])
+                }
+            })
+    }
+
+    pub fn compatible_camera_keys(&self, brand: &str, model: &str) -> BTreeSet<(String, String)> {
+        let Some(selected) = self.find_camera(brand, model) else {
+            return BTreeSet::new();
+        };
+
+        let selected_brand = Self::key(&selected.brand);
+        self.cameras
+            .values()
+            .filter(|candidate| {
+                Self::key(&candidate.brand) == selected_brand
+                    && Self::camera_key(&candidate.brand, &candidate.model)
+                        != Self::camera_key(&selected.brand, &selected.model)
+                    && Self::sensor_compatible(selected, candidate)
+            })
+            .map(|camera| Self::camera_key(&camera.brand, &camera.model))
+            .collect()
+    }
+
+    pub fn resolve_camera(&self, brand: &str, model: &str) -> Option<(String, String)> {
+        if let Some(camera) = self.find_camera(brand, model) {
+            return Some((camera.brand.clone(), camera.model.clone()));
+        }
+
+        let brand = self.resolve_brand(brand)?;
+        Some((brand, Self::model_name(model)))
+    }
+
+    pub fn resolve_model(&self, brand: &str, model: &str) -> Option<String> {
+        self.find_camera(brand, model)
+            .map(|camera| camera.model.clone())
+    }
+
+    pub fn camera_info(&self, brand: &str, model: &str) -> Option<CameraRegistryInfo> {
+        self.find_camera(brand, model)
+            .map(|camera| CameraRegistryInfo {
+                brand: camera.brand.clone(),
+                model: camera.model.clone(),
+                lenses: camera.lenses.iter().cloned().collect(),
+                crop_factor: camera.crop_factor,
+                sensor_size: camera.sensor_size.clone(),
+                source: camera.source.iter().cloned().collect(),
+                known_lens_count: camera.lenses.len(),
+            })
+    }
+
+    pub fn to_catalog(&self) -> CameraRegistryFile {
+        CameraRegistryFile {
+            version: 1,
+            cameras: self
+                .cameras
+                .values()
+                .map(|camera| CameraRegistryEntry {
+                    brand: camera.brand.clone(),
+                    model: camera.model.clone(),
+                    lenses: camera.lenses.iter().cloned().collect(),
+                    crop_factor: camera.crop_factor,
+                    sensor_size: camera.sensor_size.clone(),
+                    source: camera.source.iter().cloned().collect(),
+                })
+                .collect(),
+        }
+    }
+
+    fn merge_catalog_path(&mut self, path: &Path) {
+        if let Ok(data) = std::fs::read_to_string(path) {
+            self.merge_catalog_str(&data);
+        }
+    }
+
+    fn merge_catalog_str(&mut self, data: &str) {
+        if let Ok(file) = serde_json::from_str::<CameraRegistryFile>(data) {
+            for camera in file.cameras {
+                self.merge_catalog_camera(camera);
+            }
+        }
+    }
+
+    fn merge_catalog_camera(&mut self, camera: CameraRegistryEntry) {
+        if camera.brand.trim().is_empty() || camera.model.trim().is_empty() {
+            return;
+        }
+
+        let key = Self::camera_key(&camera.brand, &camera.model);
+        let entry = self.cameras.entry(key).or_insert_with(|| CameraEntry {
+            brand: Self::brand_name(&camera.brand),
+            model: Self::model_name(&camera.model),
+            ..Default::default()
+        });
+
+        entry.lenses.extend(
+            camera
+                .lenses
+                .into_iter()
+                .filter(|lens| !lens.trim().is_empty())
+                .map(|lens| lens.trim().to_owned()),
+        );
+        if entry.crop_factor.is_none() {
+            entry.crop_factor = camera.crop_factor;
+        }
+        if entry.sensor_size.is_none() {
+            entry.sensor_size = camera
+                .sensor_size
+                .or_else(|| Self::sensor_size(entry.crop_factor).map(str::to_owned));
+        }
+        entry.source.extend(
+            camera
+                .source
+                .into_iter()
+                .filter(|source| !source.trim().is_empty()),
+        );
+    }
+
+    fn merge_profile(&mut self, profile: &LensProfile) {
+        if profile.is_copy
+            || profile.camera_brand.trim().is_empty()
+            || profile.camera_model.trim().is_empty()
+        {
+            return;
+        }
+
+        let key = Self::camera_key(&profile.camera_brand, &profile.camera_model);
+        let entry = self.cameras.entry(key).or_insert_with(|| CameraEntry {
+            brand: Self::brand_name(&profile.camera_brand),
+            model: Self::model_name(&profile.camera_model),
+            ..Default::default()
+        });
+
+        if !profile.lens_model.trim().is_empty() {
+            entry.lenses.insert(profile.lens_model.trim().to_owned());
+        }
+        if entry.crop_factor.is_none() {
+            entry.crop_factor = profile.crop_factor;
+        }
+        if entry.sensor_size.is_none() {
+            entry.sensor_size = Self::sensor_size(entry.crop_factor).map(str::to_owned);
+        }
+        entry.source.insert("gyroflow".to_owned());
+    }
+
+    fn rebuild_indexes(&mut self) {
+        let mut brands = BTreeSet::new();
+        let mut models: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+        let mut lenses: BTreeMap<(String, String), BTreeSet<String>> = BTreeMap::new();
+
+        for ((brand_key, model_key), camera) in &self.cameras {
+            brands.insert(camera.brand.clone());
+            models
+                .entry(brand_key.clone())
+                .or_default()
+                .insert(camera.model.clone());
+            lenses
+                .entry((brand_key.clone(), model_key.clone()))
+                .or_default()
+                .extend(camera.lenses.iter().cloned());
+        }
+
+        self.brands = brands.into_iter().collect();
+        self.models = models
+            .into_iter()
+            .map(|(brand, models)| (brand, models.into_iter().collect()))
+            .collect();
+        self.lenses = lenses
+            .into_iter()
+            .map(|(camera, lenses)| (camera, lenses.into_iter().collect()))
+            .collect();
+    }
+
+    fn find_camera(&self, brand: &str, model: &str) -> Option<&CameraEntry> {
+        self.cameras.get(&Self::camera_key(brand, model))
+    }
+
+    fn resolve_brand(&self, brand: &str) -> Option<String> {
+        let brand_key = Self::key(brand);
+        if brand_key.is_empty() {
+            return None;
+        }
+        self.brands
+            .iter()
+            .find(|candidate| Self::key(candidate) == brand_key)
+            .cloned()
+            .or_else(|| {
+                let name = Self::brand_name(brand);
+                self.brands
+                    .iter()
+                    .find(|candidate| Self::key(candidate) == Self::key(&name))
+                    .cloned()
+            })
+    }
+
+    fn sensor_compatible(selected: &CameraEntry, candidate: &CameraEntry) -> bool {
+        match (&selected.sensor_size, &candidate.sensor_size) {
+            (Some(a), Some(b)) => Self::key(a) == Self::key(b),
+            _ => match (selected.crop_factor, candidate.crop_factor) {
+                (Some(a), Some(b)) => (a - b).abs() <= 0.15,
+                _ => false,
+            },
+        }
+    }
+
+    pub fn camera_key(brand: &str, model: &str) -> (String, String) {
+        (
+            Self::key(&Self::brand_name(brand)),
+            Self::key(&Self::model_name(model)),
+        )
+    }
+
+    pub fn key(value: &str) -> String {
+        value
+            .chars()
+            .map(|c| {
+                if c.is_ascii_alphanumeric() {
+                    c.to_ascii_lowercase()
+                } else {
+                    ' '
+                }
+            })
+            .collect::<String>()
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    fn brand_name(value: &str) -> String {
+        match Self::key(value).as_str() {
+            "akaso" => "AKASO".to_owned(),
+            "arri" => "ARRI".to_owned(),
+            "blackmagic design" => "Blackmagic".to_owned(),
+            "casio computer co ltd" => "Casio".to_owned(),
+            "dji" => "DJI".to_owned(),
+            "fujifilm" | "fufifilm" => "Fujifilm".to_owned(),
+            "gopro" | "go pro" => "GoPro".to_owned(),
+            "lg mobile" | "lge" => "LG".to_owned(),
+            "nikon corporation" => "Nikon".to_owned(),
+            "olympus corporation" | "olympus imaging corp" | "olympus optical co ltd" => {
+                "Olympus".to_owned()
+            }
+            "panasonic corporation" => "Panasonic".to_owned(),
+            "pentax corporation" | "asahi optical co ltd" => "Pentax".to_owned(),
+            "red digital cinema" => "RED".to_owned(),
+            "runcam" => "RunCam".to_owned(),
+            "sjcam" => "SJCam".to_owned(),
+            "xiaomi communications co ltd" | "mi" => "Xiaomi".to_owned(),
+            _ => value.split_whitespace().collect::<Vec<_>>().join(" "),
+        }
+    }
+
+    fn model_name(value: &str) -> String {
+        value
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .replace("CInema", "Cinema")
+            .replace("4k", "4K")
+            .replace("6k", "6K")
+    }
+
+    fn sensor_size(crop_factor: Option<f64>) -> Option<&'static str> {
+        let crop = crop_factor?;
+        let size = if crop <= 1.1 {
+            "Full frame"
+        } else if crop <= 1.7 {
+            "APS-C"
+        } else if crop <= 2.2 {
+            "Micro Four Thirds"
+        } else if crop <= 3.0 {
+            "1-inch"
+        } else if crop <= 6.2 {
+            "1/2.3-inch"
+        } else {
+            "Small sensor"
+        };
+        Some(size)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(brand: &str, model: &str, lens: &str, crop: Option<f64>) -> LensProfile {
+        let mut profile = LensProfile::default();
+        profile.camera_brand = brand.to_owned();
+        profile.camera_model = model.to_owned();
+        profile.lens_model = lens.to_owned();
+        profile.crop_factor = crop;
+        profile
+    }
+
+    fn registry_for_test(db: &LensProfileDatabase) -> CameraRegistry {
+        CameraRegistry::from_lens_profile_database_with_catalogs(db, false)
+    }
+
+    #[test]
+    fn builds_sorted_camera_and_lens_selectors() {
+        let mut db = LensProfileDatabase::default();
+        db.insert_for_test(
+            "sony-a7iv.json",
+            profile("Sony", "A7 IV", "Sony FE 24mm", Some(1.0)),
+        );
+        db.insert_for_test(
+            "sony-a7iv-2.json",
+            profile("Sony", "A7 IV", "Sony FE 24mm", Some(1.0)),
+        );
+        db.insert_for_test("gopro.json", profile("GoPro", "HERO12 Black", "Wide", None));
+
+        let registry = registry_for_test(&db);
+
+        assert_eq!(registry.brands(), vec!["GoPro", "Sony"]);
+        assert_eq!(registry.models("Sony"), vec!["A7 IV"]);
+        assert_eq!(registry.lenses("Sony", "A7 IV"), vec!["Sony FE 24mm"]);
+    }
+
+    #[test]
+    fn canonicalizes_common_metadata_brand_names() {
+        let mut db = LensProfileDatabase::default();
+        db.insert_for_test(
+            "olympus.json",
+            profile("Olympus Imaging Corp.", "E-M1", "12mm", Some(2.0)),
+        );
+
+        let registry = registry_for_test(&db);
+
+        assert_eq!(
+            registry.resolve_camera("Olympus Imaging Corp.", "E-M1"),
+            Some(("Olympus".to_owned(), "E-M1".to_owned()))
+        );
+        assert_eq!(registry.models("Olympus"), vec!["E-M1"]);
+    }
+
+    #[test]
+    fn compatible_models_stay_in_same_brand_and_sensor_class() {
+        let mut db = LensProfileDatabase::default();
+        db.insert_for_test(
+            "sony-a7iv.json",
+            profile("Sony", "A7 IV", "24mm", Some(1.0)),
+        );
+        db.insert_for_test("sony-fx3.json", profile("Sony", "FX3", "35mm", Some(1.01)));
+        db.insert_for_test(
+            "sony-a6700.json",
+            profile("Sony", "A6700", "35mm", Some(1.5)),
+        );
+        db.insert_for_test("canon-r5.json", profile("Canon", "R5", "35mm", Some(1.0)));
+
+        let registry = registry_for_test(&db);
+
+        assert_eq!(
+            registry.compatible_models("Sony", "A7 IV"),
+            vec!["Sony FX3"]
+        );
+        assert!(
+            registry
+                .compatible_camera_keys("Sony", "A7 IV")
+                .contains(&CameraRegistry::camera_key("Sony", "FX3"))
+        );
+    }
+
+    #[test]
+    fn exports_registry_catalog_in_stable_order() {
+        let mut db = LensProfileDatabase::default();
+        db.insert_for_test(
+            "sony-a7iv.json",
+            profile("Sony", "A7 IV", "Sony FE 24mm", Some(1.0)),
+        );
+
+        let catalog = registry_for_test(&db).to_catalog();
+
+        assert_eq!(catalog.version, 1);
+        assert_eq!(catalog.cameras.len(), 1);
+        assert_eq!(catalog.cameras[0].brand, "Sony");
+        assert_eq!(catalog.cameras[0].model, "A7 IV");
+        assert_eq!(catalog.cameras[0].lenses, vec!["Sony FE 24mm"]);
+        assert_eq!(catalog.cameras[0].sensor_size.as_deref(), Some("Full frame"));
+        assert_eq!(catalog.cameras[0].source, vec!["gyroflow"]);
+    }
+}

--- a/src/core/examples/export_camera_registry.rs
+++ b/src/core/examples/export_camera_registry.rs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Gyroflow contributors
+
+use std::path::PathBuf;
+
+use gyroflow_core::{
+    camera_registry::CameraRegistry,
+    lens_profile_database::LensProfileDatabase,
+};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let output = std::env::args()
+        .nth(1)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../resources/camera_registry.json")
+        });
+
+    let mut profiles = LensProfileDatabase::default();
+    profiles.load_all();
+
+    let registry = CameraRegistry::from_lens_profile_database(&profiles);
+    let data = serde_json::to_string_pretty(&registry.to_catalog())?;
+
+    std::fs::write(&output, format!("{data}\n"))?;
+    eprintln!("Wrote {}", output.display());
+
+    Ok(())
+}

--- a/src/core/lens_profile_database.rs
+++ b/src/core/lens_profile_database.rs
@@ -16,18 +16,69 @@ enum DataSource {
     SerdeValue(serde_json::Value)
 }
 
+pub type LensProfileUiItem = (String, String, String, bool, f64, i32, String);
+
 #[derive(Default)]
 pub struct LensProfileDatabase {
     preset_map: HashMap<String, String>,
     map: HashMap<String, LensProfile>,
     loaded_callbacks: Vec<Box<dyn FnOnce(&Self) + Send + Sync + 'static>>,
-    list_for_ui: Vec<(String, String, String, bool, f64, i32, String)>,
+    list_for_ui: Vec<LensProfileUiItem>,
     pub loaded: bool,
     pub version: u32,
 }
 impl Clone for LensProfileDatabase {
     fn clone(&self) -> Self {
         Self { map: self.map.clone(), preset_map: self.preset_map.clone(), loaded: self.loaded, ..Default::default() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(brand: &str, model: &str, lens: &str, checksum: &str) -> LensProfile {
+        let mut profile = LensProfile::default();
+        profile.camera_brand = brand.to_owned();
+        profile.camera_model = model.to_owned();
+        profile.lens_model = lens.to_owned();
+        profile.checksum = Some(checksum.to_owned());
+        profile
+    }
+
+    fn item(name: &str, path: &str, checksum: &str) -> LensProfileUiItem {
+        (name.to_owned(), path.to_owned(), checksum.to_owned(), false, 0.0, 0, String::new())
+    }
+
+    #[test]
+    fn camera_search_includes_compatible_profiles_and_hides_local_rejections() {
+        let mut db = LensProfileDatabase::default();
+        db.map.insert("selected.json".to_owned(), profile("Sony", "A7 IV", "Sony FE 24mm", "selected"));
+        db.map.insert("compatible.json".to_owned(), profile("Sony", "FX3", "Sony FE 24mm", "compatible"));
+        db.map.insert("hidden.json".to_owned(), profile("Sony", "FX3", "Sony FE 24mm", "hidden"));
+        db.map.insert("other.json".to_owned(), profile("Sony", "A6700", "Sony E 24mm", "other"));
+        db.list_for_ui = vec![
+            item("Sony A7 IV Sony FE 24mm", "selected.json", "selected"),
+            item("Sony FX3 Sony FE 24mm", "compatible.json", "compatible"),
+            item("Sony FX3 hidden profile", "hidden.json", "hidden"),
+            item("Sony A6700 Sony E 24mm", "other.json", "other"),
+        ];
+
+        let results = db.search_by_camera(
+            "Sony",
+            "A7 IV",
+            "Sony FE 24mm",
+            "",
+            &HashSet::from([(String::from("sony"), String::from("a7 iv"))]),
+            &HashSet::from([(String::from("sony"), String::from("fx3"))]),
+            &HashSet::from([String::from("hidden")]),
+            &HashSet::new(),
+            0,
+            0
+        );
+
+        let checksums = results.into_iter().map(|item| item.2).collect::<Vec<_>>();
+        assert_eq!(checksums, vec!["selected", "compatible"]);
     }
 }
 
@@ -146,6 +197,9 @@ impl LensProfileDatabase {
             walkdir::WalkDir::new(dir).into_iter().for_each(|e| {
                 if let Ok(entry) = e {
                     let f_name = entry.path().to_string_lossy().replace('\\', "/");
+                    if f_name.ends_with("camera_registry.json") {
+                        return;
+                    }
                     if f_name.ends_with(".json") || f_name.ends_with(".gyroflow") {
                         if let Ok(data) = std::fs::read_to_string(&f_name) {
                             load(DataSource::String(data), &f_name);
@@ -230,6 +284,16 @@ impl LensProfileDatabase {
         }).collect()
     }
 
+    pub fn iter_profiles(&self) -> impl Iterator<Item = &LensProfile> {
+        self.map.values()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn insert_for_test(&mut self, key: &str, mut profile: LensProfile) {
+        profile.path_to_file = key.to_owned();
+        self.map.insert(key.to_owned(), profile);
+    }
+
     pub fn prepare_list_for_ui(&mut self) {
         // (name, path_to_file, crc32, official, rating, aspect_ratio*1000, author)
         let mut set = HashSet::with_capacity(self.map.len());
@@ -276,8 +340,103 @@ impl LensProfileDatabase {
         self.list_for_ui.sort_by(|a, b| a.0.to_ascii_lowercase().cmp(&b.0.to_ascii_lowercase()));
     }
 
-    pub fn search(&self, text: &str, favorites: &HashSet<String>, aspect_ratio: i32, aspect_ratio_swapped: i32) -> Vec<(String, String, String, bool, f64, i32, String)> {
-        let text = text.to_ascii_lowercase()
+    pub fn search(&self, text: &str, favorites: &HashSet<String>, aspect_ratio: i32, aspect_ratio_swapped: i32) -> Vec<LensProfileUiItem> {
+        let text = Self::normalize_search_text(text);
+        let words = text.split_ascii_whitespace().map(str::trim).filter(|x| !x.is_empty()).collect::<Vec<_>>();
+        if words.is_empty() {
+            return Vec::new();
+        }
+
+        let mut filtered = self.list_for_ui.iter().filter(|(name, _, _, _, _, _, author)| {
+            Self::matches_words(name, author, &words)
+        }).collect::<Vec<_>>();
+
+        filtered.sort_by(|a, b| {
+            Self::compare_ui_items(a, b, favorites, aspect_ratio, aspect_ratio_swapped)
+        });
+
+        filtered.into_iter().take(200).cloned().collect()
+    }
+
+    pub fn search_by_camera(
+        &self,
+        brand: &str,
+        model: &str,
+        lens: &str,
+        text: &str,
+        selected_camera_keys: &HashSet<(String, String)>,
+        compatible_camera_keys: &HashSet<(String, String)>,
+        hidden_profiles: &HashSet<String>,
+        favorites: &HashSet<String>,
+        aspect_ratio: i32,
+        aspect_ratio_swapped: i32
+    ) -> Vec<LensProfileUiItem> {
+        let text = Self::normalize_search_text(text);
+        let words = text.split_ascii_whitespace().map(str::trim).filter(|x| !x.is_empty()).collect::<Vec<_>>();
+        let brand_key = crate::camera_registry::CameraRegistry::key(brand);
+        let model_key = crate::camera_registry::CameraRegistry::key(model);
+        let lens_key = crate::camera_registry::CameraRegistry::key(lens);
+        let has_selector_filter = !brand_key.is_empty() || !model_key.is_empty() || !lens_key.is_empty();
+        if !has_selector_filter && words.is_empty() {
+            return Vec::new();
+        }
+
+        let mut camera_keys = selected_camera_keys.clone();
+        camera_keys.extend(compatible_camera_keys.iter().cloned());
+
+        let mut filtered = self.list_for_ui.iter().filter(|item| {
+            let (name, path, checksum, _, _, _, author) = item;
+            if hidden_profiles.contains(checksum) || hidden_profiles.contains(path) {
+                return false;
+            }
+
+            let profile = self.map.get(path);
+            if !brand_key.is_empty() {
+                let Some(profile) = profile else {
+                    return false;
+                };
+
+                if !model_key.is_empty() {
+                    let profile_key = crate::camera_registry::CameraRegistry::camera_key(&profile.camera_brand, &profile.camera_model);
+                    if !camera_keys.contains(&profile_key) {
+                        return false;
+                    }
+                } else if crate::camera_registry::CameraRegistry::key(&profile.camera_brand) != brand_key {
+                    return false;
+                }
+            }
+
+            if !lens_key.is_empty() {
+                let Some(profile) = profile else {
+                    return false;
+                };
+                let profile_lens_key = crate::camera_registry::CameraRegistry::key(&profile.lens_model);
+                if profile_lens_key != lens_key && !profile_lens_key.contains(&lens_key) && !lens_key.contains(&profile_lens_key) {
+                    return false;
+                }
+            }
+
+            words.is_empty() || Self::matches_words(name, author, &words)
+        }).collect::<Vec<_>>();
+
+        filtered.sort_by(|a, b| {
+            let a_exact = self.map.get(&a.1)
+                .map(|profile| selected_camera_keys.contains(&crate::camera_registry::CameraRegistry::camera_key(&profile.camera_brand, &profile.camera_model)))
+                .unwrap_or(false);
+            let b_exact = self.map.get(&b.1)
+                .map(|profile| selected_camera_keys.contains(&crate::camera_registry::CameraRegistry::camera_key(&profile.camera_brand, &profile.camera_model)))
+                .unwrap_or(false);
+            if a_exact && !b_exact { return Ordering::Less; }
+            if b_exact && !a_exact { return Ordering::Greater; }
+
+            Self::compare_ui_items(a, b, favorites, aspect_ratio, aspect_ratio_swapped)
+        });
+
+        filtered.into_iter().take(200).cloned().collect()
+    }
+
+    fn normalize_search_text(text: &str) -> String {
+        text.to_ascii_lowercase()
             .replace("bmpcc4k",  "blackmagic pocket cinema camera 4k")
             .replace("bmpcc6k",  "blackmagic pocket cinema camera 6k")
             .replace("bmpcc",    "blackmagic pocket cinema camera")
@@ -300,47 +459,35 @@ impl LensProfileDatabase {
             .replace("a7s2",     "a7sii")
             .replace("a7s3",     "a7siii")
             .replace(",", " ")
-            .replace(";", " ");
+            .replace(";", " ")
+    }
 
-        let words = text.split_ascii_whitespace().map(str::trim).filter(|x| !x.is_empty()).collect::<Vec<_>>();
-        if words.is_empty() {
-            return Vec::new();
-        }
+    fn matches_words(name: &str, author: &str, words: &[&str]) -> bool {
+        let name = name.to_ascii_lowercase();
+        let author = author.to_ascii_lowercase();
+        words.iter().all(|word| name.contains(word) || author.contains(word))
+    }
 
-        let mut filtered = self.list_for_ui.iter().filter(|(name, _, _, _, _, _, author)| {
-            let name = name.to_ascii_lowercase();
-            let author = author.to_ascii_lowercase();
-            for word in &words {
-                if !name.contains(word) && !author.contains(word) {
-                    return false;
-                }
-            }
-            return true;
-        }).collect::<Vec<_>>();
+    fn compare_ui_items(a: &LensProfileUiItem, b: &LensProfileUiItem, favorites: &HashSet<String>, aspect_ratio: i32, aspect_ratio_swapped: i32) -> Ordering {
+        // Is preset or favorited
+        let a_priority = a.1.ends_with(".gyroflow") || favorites.contains(&a.2);
+        let b_priority = b.1.ends_with(".gyroflow") || favorites.contains(&b.2);
+        if a_priority && !b_priority { return Ordering::Less; }
+        if b_priority && !a_priority { return Ordering::Greater; }
 
-        filtered.sort_by(|a, b| {
-            // Is preset or favorited
-            let a_priority = a.1.ends_with(".gyroflow") || favorites.contains(&a.2);
-            let b_priority = b.1.ends_with(".gyroflow") || favorites.contains(&b.2);
-            if a_priority && !b_priority { return Ordering::Less; }
-            if b_priority && !a_priority { return Ordering::Greater; }
+        // Check aspect match
+        let a_priority2 = a.5 != 0 && aspect_ratio == a.5;
+        let b_priority2 = b.5 != 0 && aspect_ratio == b.5;
+        if a_priority2 && !b_priority2 { return Ordering::Less; }
+        if b_priority2 && !a_priority2 { return Ordering::Greater; }
 
-            // Check aspect match
-            let a_priority2 = a.5 != 0 && aspect_ratio == a.5;
-            let b_priority2 = b.5 != 0 && aspect_ratio == b.5;
-            if a_priority2 && !b_priority2 { return Ordering::Less; }
-            if b_priority2 && !a_priority2 { return Ordering::Greater; }
+        // Check swapped aspect match
+        let a_priority3 = a.5 != 0 && aspect_ratio_swapped == a.5;
+        let b_priority3 = b.5 != 0 && aspect_ratio_swapped == b.5;
+        if a_priority3 && !b_priority3 { return Ordering::Less; }
+        if b_priority3 && !a_priority3 { return Ordering::Greater; }
 
-            // Check swapped aspect match
-            let a_priority3 = a.5 != 0 && aspect_ratio_swapped == a.5;
-            let b_priority3 = b.5 != 0 && aspect_ratio_swapped == b.5;
-            if a_priority3 && !b_priority3 { return Ordering::Less; }
-            if b_priority3 && !a_priority3 { return Ordering::Greater; }
-
-            a.0.cmp(&b.0)
-        });
-
-        filtered.into_iter().take(200).cloned().collect()
+        a.0.cmp(&b.0)
     }
 
     pub fn set_profile_ratings(&mut self, json: &str) {

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -6,6 +6,7 @@ pub mod gyro_source;
 pub mod imu_integration;
 pub mod lens_profile;
 pub mod lens_profile_database;
+pub mod camera_registry;
 #[cfg(feature = "opencv")]
 pub mod calibration;
 pub mod synchronization;

--- a/src/ui/components/SearchField.qml
+++ b/src/ui/components/SearchField.qml
@@ -10,6 +10,7 @@ TextField {
     property var model: [];
     property alias popup: popup;
     property var profilesMenu: null;
+    property bool autoSearch: true;
 
     signal selected(var item);
 
@@ -57,7 +58,9 @@ TextField {
     }
 
     onTextChanged: {
-        controller.search_lens_profile(text, Object.keys(root.profilesMenu.favorites), profilesMenu.currentVideoAspectRatio, profilesMenu.currentVideoAspectRatioSwapped);
+        if (autoSearch) {
+            controller.search_lens_profile(text, Object.keys(root.profilesMenu.favorites), profilesMenu.currentVideoAspectRatio, profilesMenu.currentVideoAspectRatioSwapped);
+        }
     }
     Keys.onDownPressed: {
         if (!popup.opened) {

--- a/src/ui/menu/LensCalibrate.qml
+++ b/src/ui/menu/LensCalibrate.qml
@@ -21,6 +21,11 @@ MenuItem {
     property alias infoList: infoList;
     property alias maxSharpness: maxSharpness;
     property var calibrationInfo: ({});
+    property bool metadataControlsReady: false;
+    property bool updatingCameraSelectors: false;
+    property var cameraBrandModel: [qsTr("Other")];
+    property var cameraModelModel: [qsTr("Other")];
+    property var cameraLensModel: [qsTr("Other")];
 
     property int videoWidth: 0;
     property int videoHeight: 0;
@@ -58,6 +63,140 @@ MenuItem {
             "output_dimension": { "w": 0, "h": 0 }
         };
     }
+    function selectorModel(values: var): var {
+        let model = [qsTr("Other")];
+        for (const value of values || []) {
+            if (value && model.indexOf(value) === -1) {
+                model.push(value);
+            }
+        }
+        return model;
+    }
+    function selectorValue(combo: var): string {
+        return combo.currentIndex > 0? combo.model[combo.currentIndex] : "";
+    }
+    function setSelectorValue(combo: var, value: string): bool {
+        const index = combo.model.indexOf(value);
+        if (index > 0) {
+            combo.currentIndex = index;
+            return true;
+        }
+        combo.currentIndex = 0;
+        return false;
+    }
+    function setMetadataField(key: string, label: string, value: string): void {
+        calib.calibrationInfo[key] = value || "";
+        list.updateEntry(label, value || "---");
+    }
+    function refreshCameraBrands(): void {
+        updatingCameraSelectors = true;
+        cameraBrand.popup.maxItemWidth = 0;
+        cameraModel.popup.maxItemWidth = 0;
+        cameraLens.popup.maxItemWidth = 0;
+        cameraBrandModel = selectorModel(controller.camera_registry_brands());
+        cameraBrand.currentIndex = 0;
+        cameraModelModel = selectorModel([]);
+        cameraModel.currentIndex = 0;
+        cameraLensModel = selectorModel([]);
+        cameraLens.currentIndex = 0;
+        updatingCameraSelectors = false;
+    }
+    function refreshCameraModels(): void {
+        const brand = selectorValue(cameraBrand);
+        updatingCameraSelectors = true;
+        cameraModel.popup.maxItemWidth = 0;
+        cameraLens.popup.maxItemWidth = 0;
+        cameraModelModel = selectorModel(brand? controller.camera_registry_models(brand) : []);
+        cameraModel.currentIndex = 0;
+        cameraLensModel = selectorModel([]);
+        cameraLens.currentIndex = 0;
+        updatingCameraSelectors = false;
+    }
+    function refreshCameraLenses(): void {
+        const brand = selectorValue(cameraBrand);
+        const model = selectorValue(cameraModel);
+        updatingCameraSelectors = true;
+        cameraLens.popup.maxItemWidth = 0;
+        cameraLensModel = selectorModel(brand && model? controller.camera_registry_lenses(brand, model) : []);
+        cameraLens.currentIndex = 0;
+        updatingCameraSelectors = false;
+    }
+    function applySelectorsFromMetadata(): void {
+        if (!metadataControlsReady) {
+            return;
+        }
+
+        const originalBrand = calib.calibrationInfo.camera_brand || "";
+        const originalModel = calib.calibrationInfo.camera_model || "";
+        const lens = calib.calibrationInfo.lens_model || "";
+        const resolvedCamera = controller.camera_registry_resolve_camera(originalBrand, originalModel);
+        const brand = resolvedCamera.brand || originalBrand;
+        const model = resolvedCamera.model || originalModel;
+
+        if (brand && brand !== originalBrand) {
+            calib.setMetadataField("camera_brand", "Camera brand", brand);
+        }
+        if (model && model !== originalModel) {
+            calib.setMetadataField("camera_model", "Camera model", model);
+        }
+
+        updatingCameraSelectors = true;
+        cameraBrand.currentIndex = 0;
+        cameraModelModel = selectorModel([]);
+        cameraModel.currentIndex = 0;
+        cameraLensModel = selectorModel([]);
+        cameraLens.currentIndex = 0;
+        if (setSelectorValue(cameraBrand, brand)) {
+            cameraModelModel = selectorModel(controller.camera_registry_models(brand));
+            const resolvedModel = controller.camera_registry_resolve_model(brand, model) || model;
+            if (resolvedModel && setSelectorValue(cameraModel, resolvedModel)) {
+                cameraLensModel = selectorModel(controller.camera_registry_lenses(brand, resolvedModel));
+                setSelectorValue(cameraLens, lens);
+            }
+        }
+        updatingCameraSelectors = false;
+    }
+    function selectorPopupWidth(combo: var): real {
+        const parentWidth = combo.parent? combo.parent.width : combo.width;
+        const desiredWidth = Math.max(combo.width, combo.popup.maxItemWidth + 16 * dpiScale);
+        return Math.min(desiredWidth, parentWidth);
+    }
+    function selectorPopupX(combo: var): real {
+        const parentWidth = combo.parent? combo.parent.width : combo.width;
+        return Math.max(-combo.x, Math.min(0, parentWidth - combo.x - combo.popup.width));
+    }
+    function cameraNeedsLens(brand: string, model: string): bool {
+        const info = controller.camera_registry_info(brand, model);
+        if (+info.known_lens_count > 0 || +info.crop_factor > 0) {
+            return true;
+        }
+        const fixedLensBrands = ["GoPro", "DJI", "Insta360", "RunCam", "Caddx", "Foxeer", "Garmin", "SJCam", "AEE"];
+        return fixedLensBrands.indexOf(brand) === -1 && !calib.calibrationInfo.camera_setting;
+    }
+    function validateProfileMetadata(): bool {
+        list.commitAll();
+        if (!uploadProfile.checked) {
+            return true;
+        }
+
+        const brand = (calib.calibrationInfo.camera_brand || "").trim();
+        const model = (calib.calibrationInfo.camera_model || "").trim();
+        const lens = (calib.calibrationInfo.lens_model || "").trim();
+        let errors = [];
+
+        if (!brand) errors.push(qsTr("Camera brand is required."));
+        if (!model) errors.push(qsTr("Camera model is required."));
+        if (brand && model && !lens && cameraNeedsLens(brand, model)) errors.push(qsTr("Lens model is required for this camera."));
+        if (lens && /[0-9]+(\.[0-9]+)?\s*[-–]\s*[0-9]+(\.[0-9]+)?\s*mm/i.test(lens) && (!flcb.checked || !(+calib.calibrationInfo.focal_length > 0))) {
+            errors.push(qsTr("Zoom lenses require a focal length."));
+        }
+
+        if (errors.length > 0) {
+            messageBox(Modal.Error, qsTr("Complete the camera setup before uploading this lens profile.") + "\n\n" + errors.join("\n"), [ { text: qsTr("Ok") } ]);
+            return false;
+        }
+        return true;
+    }
     function updateTable(): void {
         const fields = {
             "camera_brand":     QT_TRANSLATE_NOOP("TableList", "Camera brand"),
@@ -82,9 +221,15 @@ MenuItem {
     Component.onCompleted: {
         calib.resetMetadata();
         calib.updateTable();
+        calib.refreshCameraBrands();
+        calib.metadataControlsReady = true;
     }
     Connections {
         target: controller;
+        function onAll_profiles_loaded(): void {
+            calib.refreshCameraBrands();
+            calib.applySelectorsFromMetadata();
+        }
         function onTelemetry_loaded(is_main_video: bool, filename: string, camera: string, additional_data: var): void {
             shutter.value = Math.abs(additional_data.frame_readout_time);
             shutterCb.checked = Math.abs(additional_data.frame_readout_time) > 0;
@@ -118,6 +263,7 @@ MenuItem {
             if (+additional_data.horizontal_stretch > 0.01) xStretch.value = +additional_data.horizontal_stretch;
             if (+additional_data.vertical_stretch   > 0.01) yStretch.value = +additional_data.vertical_stretch;
             calib.updateTable();
+            calib.applySelectorsFromMetadata();
             sizeTimer.start();
         }
         function onRolling_shutter_estimated(rolling_shutter: real): void {
@@ -202,6 +348,58 @@ MenuItem {
             height: 25 * dpiScale;
             value: 15;
             from: 1;
+        }
+    }
+
+    Grid {
+        width: parent.width;
+        columns: window.isMobileLayout? 1 : 3;
+        columnSpacing: 5 * dpiScale;
+        rowSpacing: 5 * dpiScale;
+
+        ComboBox {
+            id: cameraBrand;
+            model: calib.cameraBrandModel;
+            width: window.isMobileLayout? parent.width : (parent.width - 10 * dpiScale) / 3;
+            font.pixelSize: 12 * dpiScale;
+            popup.x: calib.selectorPopupX(cameraBrand);
+            popup.width: calib.selectorPopupWidth(cameraBrand);
+            popup.height: Math.min(popup.implicitHeight, 8 * itemHeight + 4 * dpiScale);
+            onCurrentIndexChanged: {
+                if (calib.metadataControlsReady && !calib.updatingCameraSelectors) {
+                    calib.setMetadataField("camera_brand", "Camera brand", calib.selectorValue(cameraBrand));
+                    calib.refreshCameraModels();
+                }
+            }
+        }
+        ComboBox {
+            id: cameraModel;
+            model: calib.cameraModelModel;
+            width: window.isMobileLayout? parent.width : (parent.width - 10 * dpiScale) / 3;
+            font.pixelSize: 12 * dpiScale;
+            popup.x: calib.selectorPopupX(cameraModel);
+            popup.width: calib.selectorPopupWidth(cameraModel);
+            popup.height: Math.min(popup.implicitHeight, 8 * itemHeight + 4 * dpiScale);
+            onCurrentIndexChanged: {
+                if (calib.metadataControlsReady && !calib.updatingCameraSelectors) {
+                    calib.setMetadataField("camera_model", "Camera model", calib.selectorValue(cameraModel));
+                    calib.refreshCameraLenses();
+                }
+            }
+        }
+        ComboBox {
+            id: cameraLens;
+            model: calib.cameraLensModel;
+            width: window.isMobileLayout? parent.width : (parent.width - 10 * dpiScale) / 3;
+            font.pixelSize: 12 * dpiScale;
+            popup.x: calib.selectorPopupX(cameraLens);
+            popup.width: calib.selectorPopupWidth(cameraLens);
+            popup.height: Math.min(popup.implicitHeight, 8 * itemHeight + 4 * dpiScale);
+            onCurrentIndexChanged: {
+                if (calib.metadataControlsReady && !calib.updatingCameraSelectors) {
+                    calib.setMetadataField("lens_model", "Lens model", calib.selectorValue(cameraLens));
+                }
+            }
         }
     }
 
@@ -310,9 +508,10 @@ MenuItem {
         enabled: infoList.rms > 0 && infoList.rms < 100 && calibrator_window.videoArea.vid.loaded;
         anchors.horizontalCenter: parent.horizontalCenter;
         onClicked: {
-            list.commitAll();
-            fileDialog.selectedFile = controller.export_lens_profile_filename(calib.calibrationInfo);
-            fileDialog.open2();
+            if (calib.validateProfileMetadata()) {
+                fileDialog.selectedFile = controller.export_lens_profile_filename(calib.calibrationInfo);
+                fileDialog.open2();
+            }
         }
     }
     CheckBox {

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -28,9 +28,20 @@ MenuItem {
     property string profileName;
     property string profileOriginalJson;
     property string profileChecksum;
+    property string profilePath;
 
     property bool fetched_from_github: false;
     property bool selected_manually: false;
+    property bool updatingCameraSelectors: false;
+    property bool suppressSearchUpdate: false;
+    property var cameraBrandModel: [qsTr("Any brand"), qsTr("Other")];
+    property var cameraModelModel: [qsTr("Any model"), qsTr("Other")];
+    property var cameraLensModel: [qsTr("Any lens"), qsTr("Other")];
+    property var compatibleCameras: [];
+    property var detectedCamera: ({});
+    property var hiddenProfiles: ({});
+    property var reviewProfiles: [];
+    property int reviewIndex: -1;
 
     FileDialog {
         id: fileDialog;
@@ -53,6 +64,7 @@ MenuItem {
     }
 
     Component.onCompleted: {
+        root.loadHiddenProfiles();
         controller.load_profiles(true);
 
         QT_TRANSLATE_NOOP("TableList", "Camera");
@@ -81,6 +93,8 @@ MenuItem {
             }
 
             lensProfilesListPrepared = true;
+            root.refreshCameraBrands();
+            root.applyDetectedCamera();
 
             root.loadFavorites();
             if (!root.fetched_from_github) {
@@ -91,6 +105,23 @@ MenuItem {
         function onLens_profiles_updated(fromDisk: bool): void {
             profilesUpdateTimer.fromDisk = fromDisk;
             profilesUpdateTimer.start();
+        }
+        function onTelemetry_loaded(is_main_video: bool, filename: string, camera: string, additional_data: var): void {
+            if (!is_main_video || !additional_data.camera_identifier) {
+                return;
+            }
+
+            const camera_id = additional_data.camera_identifier;
+            root.detectedCamera = {
+                "brand": camera_id.brand || "",
+                "model": camera_id.model || "",
+                "lens": camera_id.lens_model || camera_id.lens_info || ""
+            };
+            root.applyDetectedCamera();
+        }
+        function onSearch_lens_profile_finished(profiles: list<var>): void {
+            root.reviewProfiles = profiles;
+            root.reviewIndex = -1;
         }
         function onLens_profile_loaded(json_str: string, filepath: string, checksum: string): void {
             if (json_str) {
@@ -133,6 +164,7 @@ MenuItem {
                     root.profileName = (filepath || obj.name || "").replace(/^.*?[\/\\]([^\/\\]+?)$/, "$1");
                     root.profileOriginalJson = json_str;
                     root.profileChecksum = checksum;
+                    root.profilePath = filepath;
 
                     if (obj.output_dimension && obj.output_dimension.w > 0 && (window.exportSettings.outWidth != obj.output_dimension.w || window.exportSettings.outHeight != obj.output_dimension.h)) {
                         Qt.callLater(window.exportSettings.lensProfileLoaded, obj.output_dimension.w, obj.output_dimension.h);
@@ -197,6 +229,246 @@ MenuItem {
     function updateFavorites(): void {
         settings.setValue("lensProfileFavorites", Object.keys(favorites).filter(v => v).join(","));
     }
+    function loadHiddenProfiles(): void {
+        const stored = settings.value("hiddenLensProfiles", "[]");
+        let values = [];
+        try {
+            values = JSON.parse(stored || "[]");
+        } catch (e) {
+            values = (stored || "").split(",");
+        }
+        let hidden = {};
+        for (const value of values) {
+            if (value) {
+                hidden[value] = 1;
+            }
+        }
+        hiddenProfiles = hidden;
+    }
+    function updateHiddenProfiles(): void {
+        settings.setValue("hiddenLensProfiles", JSON.stringify(Object.keys(hiddenProfiles).filter(v => v)));
+    }
+    function hideProfile(checksum: string, path: string): void {
+        const key = checksum || path;
+        if (!key) {
+            return;
+        }
+        let hidden = {};
+        for (const value of Object.keys(hiddenProfiles)) {
+            hidden[value] = 1;
+        }
+        hidden[key] = 1;
+        hiddenProfiles = hidden;
+        updateHiddenProfiles();
+        root.reviewProfiles = root.reviewProfiles.filter(item => item[2] !== checksum && item[1] !== path);
+        if (root.reviewIndex >= root.reviewProfiles.length) {
+            root.reviewIndex = root.reviewProfiles.length - 1;
+        }
+        root.searchProfiles();
+    }
+    function hideCurrentProfile(): void {
+        root.hideProfile(root.profileChecksum, root.profilePath);
+        officialInfo.thankYou = true;
+        officialInfo.canRate = false;
+        tyTimer.start();
+    }
+    function selectorModel(emptyText: string, values: var): var {
+        let model = [emptyText];
+        for (const value of values || []) {
+            if (value && model.indexOf(value) === -1) {
+                model.push(value);
+            }
+        }
+        model.push(qsTr("Other"));
+        return model;
+    }
+    function selectorValue(combo: var): string {
+        if (combo.currentIndex <= 0 || combo.currentIndex >= combo.model.length - 1) {
+            return "";
+        }
+        return combo.model[combo.currentIndex];
+    }
+    function setSelectorValue(combo: var, value: string): bool {
+        const index = combo.model.indexOf(value);
+        if (index > 0) {
+            combo.currentIndex = index;
+            return true;
+        }
+        return false;
+    }
+    function refreshCameraBrands(): void {
+        updatingCameraSelectors = true;
+        cameraBrand.popup.maxItemWidth = 0;
+        cameraModel.popup.maxItemWidth = 0;
+        cameraLens.popup.maxItemWidth = 0;
+        cameraBrandModel = selectorModel(qsTr("Any brand"), controller.camera_registry_brands());
+        cameraBrand.currentIndex = 0;
+        cameraModelModel = selectorModel(qsTr("Any model"), []);
+        cameraModel.currentIndex = 0;
+        cameraLensModel = selectorModel(qsTr("Any lens"), []);
+        cameraLens.currentIndex = 0;
+        compatibleCameras = [];
+        updatingCameraSelectors = false;
+    }
+    function refreshCameraModels(): void {
+        const brand = selectorValue(cameraBrand);
+        updatingCameraSelectors = true;
+        cameraModel.popup.maxItemWidth = 0;
+        cameraLens.popup.maxItemWidth = 0;
+        cameraModelModel = selectorModel(qsTr("Any model"), brand? controller.camera_registry_models(brand) : []);
+        cameraModel.currentIndex = 0;
+        cameraLensModel = selectorModel(qsTr("Any lens"), []);
+        cameraLens.currentIndex = 0;
+        compatibleCameras = [];
+        updatingCameraSelectors = false;
+    }
+    function refreshCameraLenses(): void {
+        const brand = selectorValue(cameraBrand);
+        const model = selectorValue(cameraModel);
+        updatingCameraSelectors = true;
+        cameraLens.popup.maxItemWidth = 0;
+        cameraLensModel = selectorModel(qsTr("Any lens"), brand && model? controller.camera_registry_lenses(brand, model) : []);
+        cameraLens.currentIndex = 0;
+        compatibleCameras = brand && model? controller.camera_registry_compatible_models(brand, model) : [];
+        updatingCameraSelectors = false;
+    }
+    function updateCameraSearch(): void {
+        if (!updatingCameraSelectors) {
+            searchProfiles();
+        }
+    }
+    function searchProfiles(): void {
+        controller.search_lens_profile_for_camera(
+            selectorValue(cameraBrand),
+            selectorValue(cameraModel),
+            selectorValue(cameraLens),
+            search.text.trim(),
+            Object.keys(root.hiddenProfiles),
+            Object.keys(root.favorites),
+            root.currentVideoAspectRatio,
+            root.currentVideoAspectRatioSwapped
+        );
+    }
+    function compatibleCameraSummary(): string {
+        const visible = root.compatibleCameras.slice(0, 4);
+        let summary = visible.join(", ");
+        if (root.compatibleCameras.length > visible.length) {
+            summary += qsTr(" +%1 more").arg(root.compatibleCameras.length - visible.length);
+        }
+        return qsTr("Compatible: %1").arg(summary);
+    }
+    function selectorPopupWidth(combo: var): real {
+        const parentWidth = combo.parent? combo.parent.width : combo.width;
+        const desiredWidth = Math.max(combo.width, combo.popup.maxItemWidth + 16 * dpiScale);
+        return Math.min(desiredWidth, parentWidth);
+    }
+    function selectorPopupX(combo: var): real {
+        const parentWidth = combo.parent? combo.parent.width : combo.width;
+        return Math.max(-combo.x, Math.min(0, parentWidth - combo.x - combo.popup.width));
+    }
+    function applyDetectedCamera(): void {
+        if (!detectedCamera.brand || !lensProfilesListPrepared) {
+            return;
+        }
+        updatingCameraSelectors = true;
+        cameraBrand.currentIndex = 0;
+        cameraModelModel = selectorModel(qsTr("Any model"), []);
+        cameraModel.currentIndex = 0;
+        cameraLensModel = selectorModel(qsTr("Any lens"), []);
+        cameraLens.currentIndex = 0;
+        compatibleCameras = [];
+        const resolvedCamera = controller.camera_registry_resolve_camera(detectedCamera.brand, detectedCamera.model);
+        const brand = resolvedCamera.brand || detectedCamera.brand;
+        const model = resolvedCamera.model || detectedCamera.model;
+        if (setSelectorValue(cameraBrand, brand)) {
+            cameraModelModel = selectorModel(qsTr("Any model"), controller.camera_registry_models(brand));
+            if (model && setSelectorValue(cameraModel, model)) {
+                cameraLensModel = selectorModel(qsTr("Any lens"), controller.camera_registry_lenses(brand, model));
+                compatibleCameras = controller.camera_registry_compatible_models(brand, model);
+                if (detectedCamera.lens) {
+                    setSelectorValue(cameraLens, detectedCamera.lens);
+                }
+            }
+        }
+        updatingCameraSelectors = false;
+        updateCameraSearch();
+    }
+    function loadProfileItem(item: var): void {
+        const lensPathOrId = item[1];
+        if (lensPathOrId.endsWith(".gyroflow")) {
+            window.videoArea.loadGyroflowData(JSON.parse(controller.get_preset_contents(lensPathOrId)), 0);
+        } else {
+            root.selected_manually = true;
+            controller.load_lens_profile(lensPathOrId);
+        }
+    }
+    function reviewRelative(step: int): void {
+        if (!reviewProfiles.length) {
+            return;
+        }
+        if (reviewIndex < 0) {
+            reviewIndex = step < 0? reviewProfiles.length - 1 : 0;
+        } else {
+            reviewIndex = (reviewIndex + step + reviewProfiles.length) % reviewProfiles.length;
+        }
+        loadProfileItem(reviewProfiles[reviewIndex]);
+    }
+
+    Grid {
+        width: parent.width;
+        columns: window.isMobileLayout? 1 : 3;
+        columnSpacing: 5 * dpiScale;
+        rowSpacing: 5 * dpiScale;
+
+        ComboBox {
+            id: cameraBrand;
+            model: root.cameraBrandModel;
+            width: window.isMobileLayout? parent.width : (parent.width - 10 * dpiScale) / 3;
+            font.pixelSize: 12 * dpiScale;
+            popup.x: root.selectorPopupX(cameraBrand);
+            popup.width: root.selectorPopupWidth(cameraBrand);
+            popup.height: Math.min(popup.implicitHeight, 8 * itemHeight + 4 * dpiScale);
+            onCurrentIndexChanged: {
+                if (!root.updatingCameraSelectors) {
+                    root.refreshCameraModels();
+                    root.updateCameraSearch();
+                }
+            }
+        }
+        ComboBox {
+            id: cameraModel;
+            model: root.cameraModelModel;
+            width: window.isMobileLayout? parent.width : (parent.width - 10 * dpiScale) / 3;
+            font.pixelSize: 12 * dpiScale;
+            popup.x: root.selectorPopupX(cameraModel);
+            popup.width: root.selectorPopupWidth(cameraModel);
+            popup.height: Math.min(popup.implicitHeight, 8 * itemHeight + 4 * dpiScale);
+            onCurrentIndexChanged: {
+                if (!root.updatingCameraSelectors) {
+                    root.refreshCameraLenses();
+                    root.updateCameraSearch();
+                }
+            }
+        }
+        ComboBox {
+            id: cameraLens;
+            model: root.cameraLensModel;
+            width: window.isMobileLayout? parent.width : (parent.width - 10 * dpiScale) / 3;
+            font.pixelSize: 12 * dpiScale;
+            popup.x: root.selectorPopupX(cameraLens);
+            popup.width: root.selectorPopupWidth(cameraLens);
+            popup.height: Math.min(popup.implicitHeight, 8 * itemHeight + 4 * dpiScale);
+            onCurrentIndexChanged: if (!root.updatingCameraSelectors) root.updateCameraSearch();
+        }
+    }
+    BasicText {
+        visible: root.compatibleCameras.length > 0;
+        width: parent.width;
+        text: root.compatibleCameraSummary();
+        color: Qt.darker(styleTextColor, 1.25);
+        font.pixelSize: 11 * dpiScale;
+        elide: Text.ElideRight;
+    }
 
     SearchField {
         id: search;
@@ -205,18 +477,57 @@ MenuItem {
         width: parent.width;
         topPadding: 5 * dpiScale;
         profilesMenu: root;
+        autoSearch: false;
+        onTextChanged: if (!root.suppressSearchUpdate) root.searchProfiles();
         onSelected: (item) => {
-            const lensPathOrId = item[1];
-            if (lensPathOrId.endsWith(".gyroflow")) {
-                window.videoArea.loadGyroflowData(JSON.parse(controller.get_preset_contents(lensPathOrId)), 0);
-            } else {
-                root.selected_manually = true;
-                controller.load_lens_profile(lensPathOrId);
-            }
+            root.suppressSearchUpdate = true;
+            root.loadProfileItem(item);
+            Qt.callLater(() => root.suppressSearchUpdate = false);
         }
         popup.lv.delegate: LensProfileSearchDelegate {
             popup: search.popup;
             profilesMenu: root;
+        }
+    }
+    Row {
+        visible: root.reviewProfiles.length > 1 || ((root.profileChecksum || root.profilePath) && root.reviewProfiles.length > 0);
+        anchors.horizontalCenter: parent.horizontalCenter;
+        spacing: 5 * dpiScale;
+
+        Button {
+            iconName: "chevron-left";
+            text: "";
+            tooltip: qsTr("Previous profile");
+            width: 35 * dpiScale;
+            leftPadding: 5 * dpiScale;
+            rightPadding: 5 * dpiScale;
+            enabled: root.reviewProfiles.length > 1;
+            onClicked: root.reviewRelative(-1);
+        }
+        BasicText {
+            text: (root.reviewIndex >= 0? (root.reviewIndex + 1) : 0) + "/" + root.reviewProfiles.length;
+            height: 35 * dpiScale;
+            verticalAlignment: Text.AlignVCenter;
+        }
+        Button {
+            iconName: "chevron-right";
+            text: "";
+            tooltip: qsTr("Next profile");
+            width: 35 * dpiScale;
+            leftPadding: 5 * dpiScale;
+            rightPadding: 5 * dpiScale;
+            enabled: root.reviewProfiles.length > 1;
+            onClicked: root.reviewRelative(1);
+        }
+        Button {
+            iconName: "close";
+            text: "";
+            tooltip: qsTr("Hide profile locally");
+            width: 35 * dpiScale;
+            leftPadding: 5 * dpiScale;
+            rightPadding: 5 * dpiScale;
+            enabled: !!(root.profileChecksum || root.profilePath);
+            onClicked: root.hideCurrentProfile();
         }
     }
     Row {
@@ -266,9 +577,13 @@ MenuItem {
         Connections {
             target: officialInfo.t;
             function onLinkActivated(link: url): void {
-                controller.rate_profile(root.profileName, root.profileOriginalJson, root.profileChecksum, link === "#good");
-                if (link === "#good")
+                const isGood = link === "#good";
+                controller.rate_profile(root.profileName, root.profileOriginalJson, root.profileChecksum, isGood);
+                if (isGood) {
                     settings.setValue("rated-profile-" + root.profileChecksum, true);
+                } else {
+                    root.hideCurrentProfile();
+                }
                 officialInfo.thankYou = true;
                 officialInfo.canRate = false;
                 tyTimer.start();


### PR DESCRIPTION
/claim #742

This is a focused app-side implementation for #742. It makes the selector flow usable from the current Gyroflow profile bundle immediately, while keeping the `camera_registry.json` release-asset path open for the `gyroflow/lens_profiles` catalog to grow with curated LensFun data.

## What changed
- Added `CameraRegistry`, built from the loaded Gyroflow lens profile database plus optional bundled/downloaded `camera_registry.json` catalog data.
- Shipped a generated `resources/camera_registry.json` with 1,658 camera entries from the current profile bundle, including known lenses, crop factor, sensor class, and source metadata where available.
- Added `cargo run --manifest-path src/core/Cargo.toml --example export_camera_registry` so the registry can be regenerated from the profile bundle for future release assets.
- Exposed brand/model/lens selector APIs to QML and added selector-backed lens profile search.
- Added compatible-camera recommendations for same-brand profiles with matching sensor class or close crop factor.
- Added previous/next review controls plus local hide state for bad submitted profiles.
- Prefills lens profile and calibrator selectors from video metadata when a camera identifier is available.
- Adds calibrator upload validation for missing brand/model, missing lens on cameras that need lens distinction, and zoom lenses without focal length.
- Makes profile updates select release assets by name, so `profiles.cbor.gz` and optional `camera_registry.json` can coexist without depending on asset order.

## Notes
- Local hide is separate from profile rating. The bad-rating link still submits a rating and then hides the profile locally.
- The generated registry is intentionally merged with runtime profile data, so newly downloaded or local profiles can still appear in the selectors without waiting for a catalog rebuild.
- LensFun data can land through the same `camera_registry.json` release asset path without changing the app-side loader again.

## Validation
- `cargo test --manifest-path src/core/Cargo.toml --quiet`
- `cargo check --manifest-path src/core/Cargo.toml --examples`
- `QMAKE=/opt/homebrew/opt/qt/bin/qmake PKG_CONFIG_PATH=/opt/homebrew/lib/pkgconfig:/opt/homebrew/opt/ffmpeg/lib/pkgconfig cargo check`
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check`

## Demo
https://github.com/jamilahmadzai/gyroflow/releases/download/gyroflow-742-demo-9c5922e4/gyroflow-742-demo.mp4

Payout: Algora platform payout to GitHub user `@jamilahmadzai`.

