### PR TITLE
Add lens profile camera metadata index

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -99,6 +99,7 @@ pub struct Controller {
     all_profiles_loaded: qt_signal!(),
     search_lens_profile_finished: qt_signal!(profiles: QVariantList),
     search_lens_profile: qt_method!(fn(&self, text: QString, favorites: QVariantList, aspect_ratio: i32, aspect_ratio_swapped: i32)),
+    lens_profile_metadata_index: qt_method!(fn(&self) -> QString),
     fetch_profiles_from_github: qt_method!(fn(&self)),
     lens_profiles_updated: qt_signal!(reload_from_disk: bool),
 
@@ -1915,6 +1916,11 @@ impl Controller {
 
             finished(profiles);
         });
+    }
+
+    fn lens_profile_metadata_index(&self) -> QString {
+        let index = self.stabilizer.lens_profile_db.read().camera_metadata_index();
+        QString::from(serde_json::to_string(&index).unwrap_or_else(|_| "{\"brands\":[]}".into()))
     }
 
     #[allow(unreachable_code)]

--- a/src/core/lens_profile_database.rs
+++ b/src/core/lens_profile_database.rs
@@ -25,6 +25,29 @@ pub struct LensProfileDatabase {
     pub loaded: bool,
     pub version: u32,
 }
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
+pub struct CameraMetadataIndex {
+    pub brands: Vec<CameraBrandMetadata>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
+pub struct CameraBrandMetadata {
+    pub name: String,
+    pub models: Vec<CameraModelMetadata>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
+pub struct CameraModelMetadata {
+    pub name: String,
+    pub lenses: Vec<LensMetadata>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize)]
+pub struct LensMetadata {
+    pub name: String,
+    pub settings: Vec<String>,
+}
 impl Clone for LensProfileDatabase {
     fn clone(&self) -> Self {
         Self { map: self.map.clone(), preset_map: self.preset_map.clone(), loaded: self.loaded, ..Default::default() }
@@ -274,6 +297,50 @@ impl LensProfileDatabase {
             }
         }
         self.list_for_ui.sort_by(|a, b| a.0.to_ascii_lowercase().cmp(&b.0.to_ascii_lowercase()));
+    }
+
+    pub fn camera_metadata_index(&self) -> CameraMetadataIndex {
+        let mut index = BTreeMap::<String, BTreeMap<String, BTreeMap<String, BTreeMap<String, ()>>>>::new();
+
+        for profile in self.map.values() {
+            if profile.is_copy ||
+               profile.camera_brand.trim().is_empty() ||
+               profile.camera_model.trim().is_empty() ||
+               profile.lens_model.trim().is_empty() {
+                continue;
+            }
+
+            index
+                .entry(profile.camera_brand.trim().to_string())
+                .or_default()
+                .entry(profile.camera_model.trim().to_string())
+                .or_default()
+                .entry(profile.lens_model.trim().to_string())
+                .or_default()
+                .insert(profile.camera_setting.trim().to_string(), ());
+        }
+
+        CameraMetadataIndex {
+            brands: index
+                .into_iter()
+                .map(|(name, models)| CameraBrandMetadata {
+                    name,
+                    models: models
+                        .into_iter()
+                        .map(|(name, lenses)| CameraModelMetadata {
+                            name,
+                            lenses: lenses
+                                .into_iter()
+                                .map(|(name, settings)| LensMetadata {
+                                    name,
+                                    settings: settings.into_keys().filter(|x| !x.is_empty()).collect(),
+                                })
+                                .collect(),
+                        })
+                        .collect(),
+                })
+                .collect(),
+        }
     }
 
     pub fn search(&self, text: &str, favorites: &HashSet<String>, aspect_ratio: i32, aspect_ratio_swapped: i32) -> Vec<(String, String, String, bool, f64, i32, String)> {
@@ -530,5 +597,51 @@ impl LensProfileDatabase {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn profile(brand: &str, model: &str, lens: &str, setting: &str) -> LensProfile {
+        LensProfile {
+            camera_brand: brand.into(),
+            camera_model: model.into(),
+            lens_model: lens.into(),
+            camera_setting: setting.into(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn camera_metadata_index_groups_and_sorts_profiles() {
+        let mut db = LensProfileDatabase::default();
+        db.map.insert("b".into(), profile("Sony", "A7S III", "FE 24mm F1.4 GM", "16:9"));
+        db.map.insert("a".into(), profile("Canon", "R5", "RF 15-35mm F2.8", "4:3"));
+        db.map.insert("c".into(), profile("Sony", "A7S III", "FE 24mm F1.4 GM", "4:3"));
+
+        let index = db.camera_metadata_index();
+
+        assert_eq!(index.brands.iter().map(|x| x.name.as_str()).collect::<Vec<_>>(), vec!["Canon", "Sony"]);
+        assert_eq!(index.brands[1].models[0].name, "A7S III");
+        assert_eq!(index.brands[1].models[0].lenses[0].name, "FE 24mm F1.4 GM");
+        assert_eq!(index.brands[1].models[0].lenses[0].settings, vec!["16:9", "4:3"]);
+    }
+
+    #[test]
+    fn camera_metadata_index_skips_incomplete_or_copy_profiles() {
+        let mut copy = profile("Sony", "A7S III", "FE 24mm F1.4 GM", "16:9");
+        copy.is_copy = true;
+
+        let mut db = LensProfileDatabase::default();
+        db.map.insert("copy".into(), copy);
+        db.map.insert("missing-lens".into(), profile("Sony", "A7S III", "", "16:9"));
+        db.map.insert("ok".into(), profile("Sony", "A7S III", "FE 24mm F1.4 GM", ""));
+
+        let index = db.camera_metadata_index();
+
+        assert_eq!(index.brands.len(), 1);
+        assert_eq!(index.brands[0].models[0].lenses[0].settings, Vec::<String>::new());
     }
 }

--- a/src/ui/menu/LensProfile.qml
+++ b/src/ui/menu/LensProfile.qml
@@ -31,6 +31,7 @@ MenuItem {
 
     property bool fetched_from_github: false;
     property bool selected_manually: false;
+    property var metadataIndex: ({ "brands": [] });
 
     FileDialog {
         id: fileDialog;
@@ -81,6 +82,7 @@ MenuItem {
             }
 
             lensProfilesListPrepared = true;
+            root.refreshLensProfileMetadataIndex();
 
             root.loadFavorites();
             if (!root.fetched_from_github) {
@@ -198,6 +200,52 @@ MenuItem {
         settings.setValue("lensProfileFavorites", Object.keys(favorites).filter(v => v).join(","));
     }
 
+    function refreshLensProfileMetadataIndex(): void {
+        const parsed = JSON.parse(controller.lens_profile_metadata_index() || "{\"brands\":[]}");
+        metadataIndex = parsed && parsed.brands? parsed : ({ "brands": [] });
+        brandFilter.model = brandOptions();
+        modelFilter.model = modelOptions();
+        lensFilter.model = lensOptions();
+        settingFilter.model = settingOptions();
+    }
+    function selectedBrand(): var {
+        return brandFilter.currentIndex > 0? metadataIndex.brands[brandFilter.currentIndex - 1] : null;
+    }
+    function selectedModel(): var {
+        const brand = selectedBrand();
+        return brand && modelFilter.currentIndex > 0? brand.models[modelFilter.currentIndex - 1] : null;
+    }
+    function selectedLens(): var {
+        const model = selectedModel();
+        return model && lensFilter.currentIndex > 0? model.lenses[lensFilter.currentIndex - 1] : null;
+    }
+    function brandOptions(): var {
+        return [qsTr("All brands")].concat(metadataIndex.brands.map(v => v.name));
+    }
+    function modelOptions(): var {
+        const brand = selectedBrand();
+        return [qsTr("All models")].concat(brand? brand.models.map(v => v.name) : []);
+    }
+    function lensOptions(): var {
+        const model = selectedModel();
+        return [qsTr("All lenses")].concat(model? model.lenses.map(v => v.name) : []);
+    }
+    function settingOptions(): var {
+        const lens = selectedLens();
+        return [qsTr("All settings")].concat(lens? lens.settings : []);
+    }
+    function applyMetadataFilter(): void {
+        const parts = [];
+        const brand = selectedBrand();
+        const model = selectedModel();
+        const lens = selectedLens();
+        if (brand) parts.push(brand.name);
+        if (model) parts.push(model.name);
+        if (lens) parts.push(lens.name);
+        if (settingFilter.currentIndex > 0) parts.push(settingFilter.currentText);
+        search.text = parts.join(" ");
+    }
+
     SearchField {
         id: search;
         placeholderText: qsTr("Search...");
@@ -217,6 +265,73 @@ MenuItem {
         popup.lv.delegate: LensProfileSearchDelegate {
             popup: search.popup;
             profilesMenu: root;
+        }
+    }
+    Column {
+        width: parent.width;
+        spacing: 5 * dpiScale;
+        visible: metadataIndex.brands.length > 0;
+
+        Row {
+            width: parent.width;
+            spacing: 6 * dpiScale;
+            ComboBox {
+                id: brandFilter;
+                width: (parent.width - parent.spacing) / 2;
+                height: 28 * dpiScale;
+                itemHeight: 24 * dpiScale;
+                model: root.brandOptions();
+                onActivated: {
+                    modelFilter.currentIndex = 0;
+                    lensFilter.currentIndex = 0;
+                    settingFilter.currentIndex = 0;
+                    modelFilter.model = root.modelOptions();
+                    lensFilter.model = root.lensOptions();
+                    settingFilter.model = root.settingOptions();
+                    root.applyMetadataFilter();
+                }
+            }
+            ComboBox {
+                id: modelFilter;
+                width: (parent.width - parent.spacing) / 2;
+                height: 28 * dpiScale;
+                itemHeight: 24 * dpiScale;
+                model: root.modelOptions();
+                enabled: brandFilter.currentIndex > 0;
+                onActivated: {
+                    lensFilter.currentIndex = 0;
+                    settingFilter.currentIndex = 0;
+                    lensFilter.model = root.lensOptions();
+                    settingFilter.model = root.settingOptions();
+                    root.applyMetadataFilter();
+                }
+            }
+        }
+        Row {
+            width: parent.width;
+            spacing: 6 * dpiScale;
+            ComboBox {
+                id: lensFilter;
+                width: (parent.width - parent.spacing) / 2;
+                height: 28 * dpiScale;
+                itemHeight: 24 * dpiScale;
+                model: root.lensOptions();
+                enabled: modelFilter.currentIndex > 0;
+                onActivated: {
+                    settingFilter.currentIndex = 0;
+                    settingFilter.model = root.settingOptions();
+                    root.applyMetadataFilter();
+                }
+            }
+            ComboBox {
+                id: settingFilter;
+                width: (parent.width - parent.spacing) / 2;
+                height: 28 * dpiScale;
+                itemHeight: 24 * dpiScale;
+                model: root.settingOptions();
+                enabled: lensFilter.currentIndex > 0;
+                onActivated: root.applyMetadataFilter();
+            }
         }
     }
     Row {


### PR DESCRIPTION
## Summary

- Add a typed camera metadata index derived from the existing lens profile database
- Group available profile metadata by camera brand, camera model, lens model, and settings
- Skip copy/incomplete profiles so the index is suitable for future camera/lens selector UI work
- Add unit tests for grouping, sorting, and filtering behavior

This is a scoped first step toward #742.

## Test Plan

- `git diff --check`

Note: I could not run Rust tests locally because `cargo` and `rustfmt` are not available in this environment.