### PR TITLE
Fix queued optical-only autosync

### DIFF
--- a/src/rendering/render_queue.rs
+++ b/src/rendering/render_queue.rs
@@ -1422,20 +1422,49 @@ impl RenderQueue {
         job_id
     }
 
+    fn should_do_queue_autosync(
+        has_sync_points: bool,
+        has_accurate_timestamps: bool,
+        has_motion_data: bool,
+        sync_settings: &serde_json::Value,
+    ) -> bool {
+        let wants_autosync = sync_settings
+            .get("do_autosync")
+            .and_then(|v| v.as_bool())
+            .unwrap_or_default();
+
+        wants_autosync && !has_sync_points && (!has_accurate_timestamps || !has_motion_data)
+    }
+
+    fn autosync_frame_size(input_width: u32, input_height: u32, target_height: i32) -> (u32, u32) {
+        if input_width == 0 || input_height == 0 || target_height <= 0 {
+            return (input_width.max(1), input_height.max(1));
+        }
+
+        let ratio = input_height as f64 / target_height as f64;
+        let width = (input_width as f64 / ratio).round().max(1.0) as u32;
+
+        (width, target_height as u32)
+    }
+
     fn do_autosync<F: Fn(f64) + Send + Sync + Clone + 'static, F2: Fn((String, String)) + Send + Sync + Clone + 'static>(stab: Arc<StabilizationManager>, processing_cb: F, input_file: &gyroflow_core::InputFile, err: F2, proc_height: i32) {
         let (url, duration_ms) = {
             (stab.input_file.read().url.clone(), stab.params.read().duration_ms)
         };
 
-        let (has_sync_points, has_accurate_timestamps) = {
+        let (has_sync_points, has_accurate_timestamps, has_motion_data) = {
             let gyro = stab.gyro.read();
             let md = gyro.file_metadata.read();
-            (!gyro.get_offsets().is_empty(), md.has_accurate_timestamps && !url.to_ascii_lowercase().ends_with(".braw"))
+            (
+                !gyro.get_offsets().is_empty(),
+                md.has_accurate_timestamps && !url.to_ascii_lowercase().ends_with(".braw"),
+                gyro.has_motion(),
+            )
         };
         let fps = stab.params.read().fps;
 
         let sync_settings = stab.lens.read().sync_settings.clone().unwrap_or_default();
-        if !has_sync_points && !has_accurate_timestamps && sync_settings.get("do_autosync").and_then(|v| v.as_bool()).unwrap_or_default() {
+        if Self::should_do_queue_autosync(has_sync_points, has_accurate_timestamps, has_motion_data, &sync_settings) {
             // ----------------------------------------------------------------------------
             // --------------------------------- Autosync ---------------------------------
             processing_cb(0.01);
@@ -1471,8 +1500,6 @@ impl RenderQueue {
 
                     let every_nth_frame = sync_params.every_nth_frame.max(1);
 
-                    let size = stab.params.read().size;
-
                     if let Ok(mut sync) = AutosyncProcess::from_manager(&stab, &timestamps_fract, sync_params, "synchronize".into(), cancel_flag.clone()) {
                         let processing_cb2 = processing_cb.clone();
                         sync.on_progress(move |percent, _ready, _total| {
@@ -1504,8 +1531,6 @@ impl RenderQueue {
                                 stab2.keyframes.write().update_gyro(&gyro);
                             }
                         });
-
-                        let (sw, sh) = ((proc_height as f64 * (size.0 as f64 / size.1 as f64)).round() as u32, proc_height as u32);
 
                         let gpu_decoding = stab.gpu_decoding.load(SeqCst);
 
@@ -1540,6 +1565,7 @@ impl RenderQueue {
                                 let sync2 = sync.clone();
                                 proc.on_frame(move |timestamp_us, input_frame, _output_frame, converter, _rate_control| {
                                     if abs_frame_no % every_nth_frame == 0 {
+                                        let (sw, sh) = Self::autosync_frame_size(input_frame.width(), input_frame.height(), proc_height);
                                         match converter.scale(input_frame, ffmpeg_next::format::Pixel::GRAY8, sw, sh) {
                                             Ok(small_frame) => {
                                                 let (width, height, stride, pixels) = (small_frame.plane_width(0), small_frame.plane_height(0), small_frame.stride(0), small_frame.data(0));
@@ -1736,5 +1762,34 @@ impl RenderQueue {
         if sync_settings.is_object() && !sync_settings.as_object().unwrap().is_empty() {
             stab.lens.write().sync_settings = Some(sync_settings);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RenderQueue;
+
+    #[test]
+    fn queue_autosync_runs_for_optical_only_video_with_accurate_timestamps() {
+        let sync_settings = serde_json::json!({ "do_autosync": true });
+
+        assert!(RenderQueue::should_do_queue_autosync(false, true, false, &sync_settings));
+        assert!(RenderQueue::should_do_queue_autosync(false, false, true, &sync_settings));
+        assert!(!RenderQueue::should_do_queue_autosync(false, true, true, &sync_settings));
+        assert!(!RenderQueue::should_do_queue_autosync(true, true, false, &sync_settings));
+        let disabled_sync_settings = serde_json::json!({ "do_autosync": false });
+        assert!(!RenderQueue::should_do_queue_autosync(false, true, false, &disabled_sync_settings));
+    }
+
+    #[test]
+    fn queue_autosync_full_resolution_keeps_frame_size() {
+        assert_eq!(RenderQueue::autosync_frame_size(1920, 1080, -1), (1920, 1080));
+        assert_eq!(RenderQueue::autosync_frame_size(1920, 1080, 0), (1920, 1080));
+    }
+
+    #[test]
+    fn queue_autosync_processing_resolution_preserves_aspect_ratio() {
+        assert_eq!(RenderQueue::autosync_frame_size(1920, 1080, 720), (1280, 720));
+        assert_eq!(RenderQueue::autosync_frame_size(1440, 1080, 720), (960, 720));
     }
 }


### PR DESCRIPTION
## Summary
- Run queued autosync for optical-only clips when the queue preset enables do_autosync, no sync points exist, and the loaded clip has no motion data even if video timestamps are accurate.
- Keep the existing skip behavior for gyro-backed clips that already have accurate timestamps.
- Compute autosync sampling size from each decoded input frame so Full resolution stays full-size and target heights preserve aspect ratio.

## Validation
- `MDK_ROOT="$PWD/target/debug/build/qml-video-rs-be64ec56ab02f8c2/out/mdk-sdk"; MDK_SDK="$MDK_ROOT/" DYLD_FRAMEWORK_PATH="$MDK_ROOT/lib:$PWD/target/Frameworks" RUSTFLAGS="-L native=/opt/homebrew/lib" cargo test --no-default-features queue_autosync`
- `MDK_ROOT="$PWD/target/debug/build/qml-video-rs-be64ec56ab02f8c2/out/mdk-sdk"; MDK_SDK="$MDK_ROOT/" RUSTFLAGS="-L native=/opt/homebrew/lib" cargo check --no-default-features`
- `git -c core.whitespace=cr-at-eol diff --check`

## Demo
- https://github.com/jamilahmadzai/gyroflow/releases/download/gyroflow-45-queue-autosync-demo-99b007b/gyroflow-45-queue-autosync-demo-h264.mp4

Refs #45
/claim #45
Algora payout: @jamilahmadzai