### PR TITLE
Add gyro repair via optical flow override

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dan0v <dev@dan0v.com>
 
 use itertools::{Either, Itertools};
 use qmetaobject::*;
@@ -42,6 +43,21 @@ struct CalibrationItem {
     pub timestamp_us: i64,
     pub sharpness: f64,
     pub is_forced: bool,
+}
+
+/// Error prefix used by the gyro-repair worker so the message format stays
+/// consistent across all failure paths and the typo ("occured") is not repeated.
+const GYRO_REPLACE_ERROR: &str = "An error occurred: %1";
+
+#[derive(Default, SimpleListItem)]
+struct ReplacementRegionItem {
+    pub index: usize,
+    pub start_us: i64,
+    pub end_us: i64,
+    pub blend_us: i64,
+    pub blend_method: i32,
+    pub blend_bias: f64,
+    pub enabled: bool,
 }
 
 #[derive(Default, QObject)]
@@ -94,6 +110,19 @@ pub struct Controller {
     offset_at_video_timestamp: qt_method!(fn(&self, timestamp_us: i64) -> f64),
     offsets_model: qt_property!(RefCell<SimpleListModel<OffsetItem>>; NOTIFY offsets_updated),
     offsets_updated: qt_signal!(),
+
+    replacement_regions_model: qt_property!(RefCell<SimpleListModel<ReplacementRegionItem>>; NOTIFY replacement_regions_updated),
+    replacement_regions_updated: qt_signal!(),
+    gyro_replace_in_progress: qt_property!(bool; NOTIFY gyro_replace_in_progress_changed),
+    gyro_replace_in_progress_changed: qt_signal!(),
+    gyro_replace_progress: qt_signal!(progress: f64, ready: usize, total: usize),
+    start_gyro_replace: qt_method!(fn(&mut self, start_us: i64, end_us: i64, blend_us: i64, blend_method: i32, blend_bias: f64, of_method: u32, pose_method: u32, max_features: u32, of_threshold: f64, proc_height: i32)),
+    remove_gyro_replace: qt_method!(fn(&mut self, index: usize)),
+    toggle_gyro_replace: qt_method!(fn(&mut self, index: usize, enabled: bool)),
+    clear_gyro_replace: qt_method!(fn(&mut self)),
+    get_replacement_region_enabled: qt_method!(fn(&self, index: usize) -> bool),
+    selected_repair_region: qt_property!(i32; NOTIFY selected_repair_region_changed),
+    selected_repair_region_changed: qt_signal!(),
 
     load_profiles: qt_method!(fn(&self, reload_from_disk: bool)),
     all_profiles_loaded: qt_signal!(),
@@ -314,6 +343,7 @@ impl Controller {
         Self {
             preview_resolution: -1,
             processing_resolution: 720,
+            selected_repair_region: -1,
             ..Default::default()
         }
     }
@@ -743,6 +773,7 @@ impl Controller {
                 this.loading_gyro_in_progress_changed();
 
                 this.update_offset_model();
+                this.update_replacement_regions_model();
                 this.chart_data_changed();
 
                 this.telemetry_loaded(params.0, params.1, params.2, util::serde_json_to_qt_object(&params.4));
@@ -1406,6 +1437,7 @@ impl Controller {
                     self.lens_profile_loaded(QString::from(lens_json), QString::default(), QString::default());
                 }
                 self.update_offset_model();
+                self.update_replacement_regions_model();
                 self.request_recompute();
                 self.chart_data_changed();
                 self.keyframes_changed();
@@ -1464,6 +1496,284 @@ impl Controller {
     wrap_simple_method!(set_offset, timestamp_us: i64, offset_ms: f64; recompute; update_offset_model);
     wrap_simple_method!(clear_offsets,; recompute; update_offset_model);
     wrap_simple_method!(remove_offset, timestamp_us: i64; recompute; update_offset_model);
+
+    fn update_replacement_regions_model(&mut self) {
+        self.replacement_regions_model = RefCell::new(self.stabilizer.gyro.read().replacement_regions.iter().enumerate().map(|(i, r)| ReplacementRegionItem {
+            index: i,
+            start_us: r.start_us,
+            end_us: r.end_us,
+            blend_us: r.blend_us,
+            blend_method: r.blend_method,
+            blend_bias: r.blend_bias,
+            enabled: r.enabled,
+        }).collect());
+
+        util::qt_queued_callback(QPointer::from(self as &Self), |this, _| {
+            this.replacement_regions_updated();
+            this.chart_data_changed();
+        })(());
+    }
+
+    fn start_gyro_replace(&mut self, start_us: i64, end_us: i64, blend_us: i64, blend_method: i32, blend_bias: f64, of_method: u32, pose_method: u32, max_features: u32, of_threshold: f64, proc_height: i32) {
+        {
+            let mut gyro = self.stabilizer.gyro.write();
+            if let Some(idx) = gyro.replacement_regions.iter().position(|r| r.start_us == start_us && r.end_us == end_us) {
+                gyro.replacement_regions.remove(idx);
+                if self.selected_repair_region == idx as i32 {
+                    self.selected_repair_region = -1;
+                } else if self.selected_repair_region > idx as i32 {
+                    self.selected_repair_region -= 1;
+                }
+            }
+        }
+        self.selected_repair_region_changed();
+        self.stabilizer.invalidate_smoothing();
+        self.update_replacement_regions_model();
+        self.request_recompute();
+
+        self.gyro_replace_in_progress = true;
+        self.gyro_replace_in_progress_changed();
+
+        let stabilizer = self.stabilizer.clone();
+        let cancel_flag = self.cancel_flag.clone();
+        let input_file = self.stabilizer.input_file.read().clone();
+        let proc_height = if proc_height > 0 { proc_height } else { self.processing_resolution };
+        let gpu_decoding = self.stabilizer.gpu_decoding.load(SeqCst);
+
+        let progress = util::qt_queued_callback_mut(QPointer::from(self as &Self), |this, (pct, ready, total): (f64, usize, usize)| {
+            this.gyro_replace_progress(pct, ready, total);
+        });
+
+        let finished = util::qt_queued_callback_mut(QPointer::from(self as &Self), move |this, (cancelled, start_us, end_us, blend_us, blend_method, blend_bias, of_quats): (bool, i64, i64, i64, i32, f64, gyroflow_core::gyro_source::TimeQuat)| {
+            this.gyro_replace_in_progress = false;
+            this.gyro_replace_in_progress_changed();
+            if !cancelled && !of_quats.is_empty() {
+                let (start_quat, end_quat, fps) = {
+                    let gyro = this.stabilizer.gyro.read();
+                    let params = core::stabilization::ComputeParams::from_manager(&this.stabilizer);
+                    (gyro.org_quat_at_timestamp(start_us as f64 / 1000.0),
+                     gyro.org_quat_at_timestamp(end_us as f64 / 1000.0),
+                     params.lens.fps)
+                };
+                let region = gyroflow_core::gyro_replace::build_replacement_region(
+                    start_us, end_us, blend_us, blend_method, blend_bias, start_quat, end_quat, of_quats, fps,
+                );
+                {
+                    let mut gyro = this.stabilizer.gyro.write();
+                    gyro.add_replacement_region(region);
+                }
+                this.stabilizer.invalidate_smoothing();
+                this.update_replacement_regions_model();
+                this.request_recompute();
+            }
+        });
+        let err = util::qt_queued_callback_mut(QPointer::from(self as &Self), |this, (msg, arg): (String, String)| {
+            this.gyro_replace_in_progress = false;
+            this.gyro_replace_in_progress_changed();
+            this.error(QString::from(msg), QString::from(arg), QString::default());
+        });
+
+        self.cancel_flag.store(false, SeqCst);
+
+        core::run_threaded(move || {
+            Self::run_gyro_replace_worker(
+                stabilizer, input_file, start_us, end_us, blend_us, blend_method, blend_bias,
+                of_method, pose_method, max_features, of_threshold, proc_height, gpu_decoding,
+                progress, finished, err, cancel_flag,
+            );
+        });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn run_gyro_replace_worker(
+        stabilizer: Arc<gyroflow_core::StabilizationManager>,
+        input_file: gyroflow_core::InputFile,
+        start_us: i64, end_us: i64, blend_us: i64, blend_method: i32, blend_bias: f64,
+        of_method: u32, pose_method: u32, max_features: u32, of_threshold: f64,
+        proc_height: i32, gpu_decoding: bool,
+        progress: impl Fn((f64, usize, usize)) + Send + Sync + Clone + 'static,
+        finished: impl Fn((bool, i64, i64, i64, i32, f64, gyroflow_core::gyro_source::TimeQuat)) + Send + Sync + Clone + 'static,
+        err: impl Fn((String, String)) + Send + Sync + Clone + 'static,
+        cancel_flag: Arc<AtomicBool>,
+    ) {
+        let pose_estimator = stabilizer.repair_estimator.clone();
+        pose_estimator.clear();
+        let params = core::stabilization::ComputeParams::from_manager(&stabilizer);
+
+        pose_estimator.every_nth_frame.store(1, SeqCst);
+        pose_estimator.pose_method.store(pose_method, SeqCst);
+        pose_estimator.offset_method.store(0, SeqCst);
+
+        let fps = params.lens.fps;
+        let scaled_fps = params.scaled_fps;
+        let duration_us = end_us - start_us;
+        let estimated_total_frames = if fps > 0.0 { (duration_us as f64 / 1_000_000.0 * fps).round() as usize } else { 0 };
+        let ranges = vec![(start_us as f64 / 1000.0, end_us as f64 / 1000.0)];
+
+        let mut decoder_options = ffmpeg_next::Dictionary::new();
+        if input_file.image_sequence_fps > 0.0 {
+            let fps_r = rendering::fps_to_rational(input_file.image_sequence_fps);
+            decoder_options.set("framerate", &format!("{}/{}", fps_r.numerator(), fps_r.denominator()));
+        }
+        if input_file.image_sequence_start > 0 {
+            decoder_options.set("start_number", &format!("{}", input_file.image_sequence_start));
+        }
+        if proc_height > 0 {
+            decoder_options.set("scale", &format!("{}x{}", (proc_height * 16) / 9, proc_height));
+        }
+
+        let mut frame_no: usize = 0;
+        match VideoProcessor::from_file(&input_file.url, gpu_decoding, 0, Some(decoder_options)) {
+            Ok(mut proc) => {
+                let pe = pose_estimator.clone();
+                let err2 = err.clone();
+                let progress2 = progress.clone();
+                let fail2 = finished.clone();
+                proc.on_frame(move |timestamp_us, input_frame, output_frame, converter, _rate_control| {
+                    if output_frame.is_some() {
+                        err2((GYRO_REPLACE_ERROR.to_string(), "Unexpected output frame in decoder".to_string()));
+                        return Err(rendering::FFmpegError::FrameEmpty);
+                    }
+                    let h = if proc_height > 0 { proc_height as u32 } else { input_frame.height() };
+                    let ratio = input_frame.height() as f64 / h as f64;
+                    let sw = (input_frame.width() as f64 / ratio).round() as u32;
+                    let sh = (input_frame.height() as f64 / (input_frame.width() as f64 / sw as f64)).round() as u32;
+                    match converter.scale(input_frame, ffmpeg_next::format::Pixel::GRAY8, sw, sh) {
+                        Ok(small_frame) => {
+                            let (width, height, stride, pixels) = (small_frame.plane_width(0), small_frame.plane_height(0), small_frame.stride(0), small_frame.data(0));
+                            if let Some(img) = synchronization::PoseEstimator::yuv_to_gray(width, height, stride as u32, pixels) {
+                                pe.detect_features(frame_no, timestamp_us, std::sync::Arc::new(img), width, height, of_method, max_features as usize, of_threshold);
+                            }
+                            frame_no += 1;
+                            if frame_no % 10 == 0 {
+                                let pct = if estimated_total_frames > 0 { (frame_no as f64 / estimated_total_frames as f64 * 0.5).min(0.5) } else { 0.0 };
+                                progress2((pct, frame_no, estimated_total_frames));
+                            }
+                        },
+                        Err(e) => {
+                            err2((GYRO_REPLACE_ERROR.to_string(), e.to_string()));
+                            fail2((true, start_us, end_us, blend_us, blend_method, blend_bias, gyroflow_core::gyro_source::TimeQuat::new()));
+                            return Err(rendering::FFmpegError::FrameEmpty);
+                        }
+                    }
+                    Ok(())
+                });
+                if let Err(e) = proc.start_decoder_only(ranges, cancel_flag.clone()) {
+                    err((GYRO_REPLACE_ERROR.to_string(), e.to_string()));
+                    finished((true, start_us, end_us, blend_us, blend_method, blend_bias, gyroflow_core::gyro_source::TimeQuat::new()));
+                    return;
+                }
+            }
+            Err(error) => {
+                err((GYRO_REPLACE_ERROR.to_string(), error.to_string()));
+                finished((true, start_us, end_us, blend_us, blend_method, blend_bias, gyroflow_core::gyro_source::TimeQuat::new()));
+                return;
+            }
+        };
+
+        if cancel_flag.load(SeqCst) {
+            finished((true, start_us, end_us, blend_us, blend_method, blend_bias, gyroflow_core::gyro_source::TimeQuat::new()));
+            return;
+        }
+
+        progress((0.5, 0, 0));
+
+        let pose_estimator_clone = pose_estimator.clone();
+        let params_clone = params.clone();
+        let (tx_done, rx_done) = std::sync::mpsc::channel::<()>();
+        std::thread::spawn(move || {
+            pose_estimator_clone.process_detected_frames(fps, scaled_fps, &params_clone);
+            let _ = tx_done.send(());
+        });
+
+        loop {
+            if cancel_flag.load(SeqCst) { break; }
+            if rx_done.try_recv().is_ok() { break; }
+            let pose_total = pose_estimator.pose_total.load(std::sync::atomic::Ordering::Relaxed);
+            let pose_done = pose_estimator.pose_progress.load(std::sync::atomic::Ordering::Relaxed);
+            let pose_pct = if pose_total > 0 { pose_done as f64 / pose_total as f64 } else { 0.0 };
+            progress((0.5 + pose_pct * 0.4, pose_done, pose_total));
+            std::thread::sleep(std::time::Duration::from_millis(250));
+        }
+
+        if cancel_flag.load(SeqCst) {
+            finished((true, start_us, end_us, blend_us, blend_method, blend_bias, gyroflow_core::gyro_source::TimeQuat::new()));
+            return;
+        }
+
+        {
+            let pose_total = pose_estimator.pose_total.load(std::sync::atomic::Ordering::Relaxed);
+            let pose_done = pose_estimator.pose_progress.load(std::sync::atomic::Ordering::Relaxed);
+            let pose_pct = if pose_total > 0 { pose_done as f64 / pose_total as f64 } else { 1.0 };
+            progress((0.5 + pose_pct * 0.4, pose_done, pose_total));
+        }
+
+        let mut result_quats = gyroflow_core::gyro_source::TimeQuat::new();
+        {
+            let quats = pose_estimator.estimated_quats.read();
+            for (&ts, q) in quats.iter() {
+                if ts >= start_us && ts <= end_us {
+                    result_quats.insert(ts, *q);
+                }
+            }
+        }
+        ::log::info!("Gyro repair: extracted {} quaternions from {}-{}us", result_quats.len(), start_us, end_us);
+
+        if cancel_flag.load(SeqCst) {
+            finished((true, start_us, end_us, blend_us, blend_method, blend_bias, gyroflow_core::gyro_source::TimeQuat::new()));
+            return;
+        }
+
+        progress((1.0, result_quats.len(), result_quats.len()));
+        finished((false, start_us, end_us, blend_us, blend_method, blend_bias, result_quats));
+    }
+
+    fn remove_gyro_replace(&mut self, index: usize) {
+        if self.gyro_replace_in_progress { return; }
+        {
+            let mut gyro = self.stabilizer.gyro.write();
+            gyro.remove_replacement_region(index);
+        }
+        if self.selected_repair_region == index as i32 {
+            self.selected_repair_region = -1;
+            self.selected_repair_region_changed();
+        } else if self.selected_repair_region > index as i32 {
+            self.selected_repair_region -= 1;
+            self.selected_repair_region_changed();
+        }
+        self.stabilizer.invalidate_smoothing();
+        self.update_replacement_regions_model();
+        self.request_recompute();
+    }
+
+    fn toggle_gyro_replace(&mut self, index: usize, enabled: bool) {
+        if self.gyro_replace_in_progress { return; }
+        {
+            let mut gyro = self.stabilizer.gyro.write();
+            gyro.set_replacement_region_enabled(index, enabled);
+        }
+        self.stabilizer.invalidate_smoothing();
+        self.update_replacement_regions_model();
+        self.request_recompute();
+    }
+
+    fn clear_gyro_replace(&mut self) {
+        if self.gyro_replace_in_progress { return; }
+        {
+            let mut gyro = self.stabilizer.gyro.write();
+            gyro.clear_replacement_regions();
+        }
+        self.selected_repair_region = -1;
+        self.selected_repair_region_changed();
+        self.stabilizer.invalidate_smoothing();
+        self.update_replacement_regions_model();
+        self.request_recompute();
+    }
+
+    fn get_replacement_region_enabled(&self, index: usize) -> bool {
+        let gyro = self.stabilizer.gyro.read();
+        gyro.replacement_regions.get(index).map(|r| r.enabled).unwrap_or(false)
+    }
 
     wrap_simple_method!(set_imu_lpf, v: f64; recompute; chart_data_changed);
     wrap_simple_method!(set_imu_median_filter, size: i32; recompute; chart_data_changed);

--- a/src/core/gyro_replace.rs
+++ b/src/core/gyro_replace.rs
@@ -1,0 +1,178 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright © 2026 dan0v <dev@dan0v.com>
+
+use crate::gyro_source::{ GyroReplacementRegion, Quat64, TimeQuat };
+
+/// Integrate per-frame *relative* rotations `q_t` (camera-frame, `R_{t -> t+1}`)
+/// into an absolute trajectory starting from `seed`. Convention: left-multiply,
+/// `cumulative = cumulative * q_t`, matching `GyroSource::integrate()`.
+pub fn accumulate_relative_quats_seeded(relative_quats: &TimeQuat, seed: Quat64) -> TimeQuat {
+    if relative_quats.is_empty() { return TimeQuat::new(); }
+    let mut result = TimeQuat::new();
+    let mut cumulative = seed;
+    for (ts, q) in relative_quats.iter() {
+        cumulative = cumulative * *q;
+        result.insert(*ts, cumulative);
+    }
+    result
+}
+
+/// Dual-anchor: align `of_quats` so that its endpoints match `start_quat`/`end_quat`,
+/// slerping a correction term across the segment so the trajectory interpolates to
+/// `end_quat` at `end_us`. If OF coverage stops short of `end_us`, the last available
+/// sample is used as the anchor and the gap is logged.
+pub fn dual_anchor_of_quats(
+    of_quats: &TimeQuat,
+    _start_quat: Quat64,
+    end_quat: Quat64,
+    start_us: i64,
+    end_us: i64,
+) -> TimeQuat {
+    if of_quats.is_empty() { return TimeQuat::new(); }
+
+    let last_of_ts = of_quats.keys().next_back().copied().unwrap_or(end_us);
+    let of_end = of_quats.range(end_us..).next()
+        .or_else(|| of_quats.iter().next_back())
+        .map(|(_, q)| *q)
+        .unwrap_or_else(Quat64::identity);
+    if last_of_ts < end_us {
+        log::info!("Gyro repair: OF coverage ({}) ends before region end ({}); anchoring on last sample", last_of_ts, end_us);
+    }
+
+    let end_correction = end_quat * of_end.inverse();
+
+    let duration = (end_us - start_us) as f64;
+    of_quats.iter().map(|(ts, q)| {
+        let t = if duration > 0.0 {
+            ((*ts - start_us) as f64 / duration).clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let correction = Quat64::identity().slerp(&end_correction, t);
+        (*ts, correction * *q)
+    }).collect()
+}
+
+pub fn lowpass_filter_quats(quats: &mut TimeQuat, freq: f64, sample_rate: f64) {
+    if quats.len() < 3 || freq <= 0.0 || sample_rate <= 0.0 { return; }
+    let _ = crate::filtering::Lowpass::filter_quats_forward_backward(freq, sample_rate, quats);
+}
+
+/// Build a replacement region. `fps` is the video fps (already known by the caller
+/// from `ComputeParams::lens.fps`); it drives the lowpass cutoff.
+///
+/// Cutoff rationale: `fps/4` sits well below the Nyquist frequency of the discrete
+/// OF-derived rate signal, suppressing per-frame jitter while preserving real camera
+/// motion up to ~`fps/8` Hz. Capped at 30 Hz because higher cutoffs on high-fps
+/// footage pass through OF noise that the IMU would otherwise dampen.
+pub fn build_replacement_region(
+    start_us: i64,
+    end_us: i64,
+    blend_us: i64,
+    blend_method: i32,
+    blend_bias: f64,
+    start_quat: Quat64,
+    end_quat: Quat64,
+    of_quats: TimeQuat,
+    fps: f64,
+) -> GyroReplacementRegion {
+    let mut relative = of_quats;
+    let duration_us = end_us - start_us;
+    if duration_us > 0 && fps > 0.0 {
+        lowpass_filter_quats(&mut relative, (fps / 4.0).min(30.0), fps);
+    }
+    let accumulated = accumulate_relative_quats_seeded(&relative, start_quat);
+
+    let anchored = dual_anchor_of_quats(&accumulated, start_quat, end_quat, start_us, end_us);
+
+    GyroReplacementRegion {
+        start_us,
+        end_us,
+        blend_us: blend_us.max(1_000),
+        blend_method,
+        blend_bias,
+        of_quats: anchored,
+        enabled: true,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gyro_source::Quat64;
+    use nalgebra::Vector3;
+
+    fn from_axis_angle(axis: Vector3<f64>, angle: f64) -> Quat64 {
+        Quat64::from_axis_angle(&nalgebra::Unit::new_normalize(axis), angle)
+    }
+
+    #[test]
+    fn accumulate_seeded_starts_at_seed() {
+        let seed = from_axis_angle(Vector3::y(), 0.5);
+        let mut rel = TimeQuat::new();
+        rel.insert(1000, from_axis_angle(Vector3::z(), 0.1));
+        rel.insert(2000, from_axis_angle(Vector3::z(), 0.1));
+        let acc = accumulate_relative_quats_seeded(&rel, seed);
+        assert_eq!(acc.len(), 2);
+        let first = acc.get(&1000).unwrap();
+        assert!(first.angle_to(&(seed * from_axis_angle(Vector3::z(), 0.1))) < 1e-12,
+            "first sample must be seed * q_0");
+    }
+
+    #[test]
+    fn dual_anchor_endpoints_match() {
+        let start = from_axis_angle(Vector3::x(), 0.2);
+        let end   = from_axis_angle(Vector3::y(), 0.7);
+        let mut of = TimeQuat::new();
+        // relative rotations summing to a known trajectory
+        of.insert(0,    from_axis_angle(Vector3::z(), 0.05));
+        of.insert(1000, from_axis_angle(Vector3::z(), 0.05));
+        of.insert(2000, from_axis_angle(Vector3::z(), 0.05));
+        let acc = accumulate_relative_quats_seeded(&of, start);
+        let anchored = dual_anchor_of_quats(&acc, start, end, 0, 2000);
+        // first anchored sample == start (correction slerps from identity)
+        let first = anchored.iter().next().unwrap().1;
+        assert!(first.angle_to(&start) < 1e-9, "anchor start mismatch: {}", first.angle_to(&start));
+        // last anchored sample == end
+        let last = anchored.iter().next_back().unwrap().1;
+        assert!(last.angle_to(&end) < 1e-9, "anchor end mismatch: {}", last.angle_to(&end));
+    }
+
+    #[test]
+    fn build_region_always_enabled() {
+        // Regions are always enabled after analysis; the convention guard was
+        // removed because the first accumulated sample is `seed * q_0`, which is
+        // never equal to `seed` for non-trivial OF rotations.
+        let end   = from_axis_angle(Vector3::y(), 0.9);
+        let mut of = TimeQuat::new();
+        of.insert(0,    from_axis_angle(Vector3::z(), 0.2));
+        of.insert(1000, from_axis_angle(Vector3::z(), 0.2));
+        let wrong_seed = from_axis_angle(Vector3::y(), 1.7);
+        let region = build_replacement_region(0, 1000, 100, 0, 0.5, wrong_seed, end, of, 50.0);
+        assert!(region.enabled, "region must be enabled after analysis");
+    }
+
+    #[test]
+    fn build_region_happy_path_enabled() {
+        let start = from_axis_angle(Vector3::x(), 0.0);
+        let end   = from_axis_angle(Vector3::x(), 0.0);
+        let mut of = TimeQuat::new();
+        of.insert(0,    Quat64::identity());
+        of.insert(1000, Quat64::identity());
+        let region = build_replacement_region(0, 1000, 100, 0, 0.5, start, end, of, 50.0);
+        assert!(region.enabled);
+        // 100 us < 1 ms minimum -> clamped
+        assert_eq!(region.blend_us, 1_000);
+    }
+
+    #[test]
+    fn build_region_clamps_blend_minimum() {
+        let start = Quat64::identity();
+        let end   = Quat64::identity();
+        let mut of = TimeQuat::new();
+        of.insert(0,    Quat64::identity());
+        of.insert(1000, Quat64::identity());
+        let region = build_replacement_region(0, 1000, 0, 0, 0.5, start, end, of, 50.0);
+        assert!(region.blend_us >= 1_000, "blend_us must be clamped to >= 1ms, got {}", region.blend_us);
+    }
+}

--- a/src/core/gyro_source/mod.rs
+++ b/src/core/gyro_source/mod.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dan0v <dev@dan0v.com>
 
 mod file_metadata;
 mod imu_transforms;
@@ -33,6 +34,23 @@ pub type Quat64 = UnitQuaternion<f64>;
 pub type TimeIMU = telemetry_parser::util::IMUData;
 pub type TimeQuat = BTreeMap<i64, Quat64>; // key is timestamp_us
 pub type TimeVec = BTreeMap<i64, Vector3<f64>>; // key is timestamp_us
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct GyroReplacementRegion {
+    pub start_us: i64,
+    pub end_us: i64,
+    pub blend_us: i64,
+    #[serde(default)]
+    pub blend_method: i32,
+    #[serde(default = "default_blend_bias")]
+    pub blend_bias: f64,
+    pub of_quats: TimeQuat,
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+}
+
+fn default_true() -> bool { true }
+fn default_blend_bias() -> f64 { 0.5 }
 
 #[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct FileLoadOptions {
@@ -70,7 +88,9 @@ pub struct GyroSource {
     offsets_linear: BTreeMap<i64, f64>, // <microseconds timestamp, offset in milliseconds> - linear fit
     offsets_adjusted: BTreeMap<i64, f64>, // <timestamp + offset, offset>
 
-    pub file_url: String
+    pub file_url: String,
+
+    pub replacement_regions: Vec<GyroReplacementRegion>,
 }
 
 impl GyroSource {
@@ -558,6 +578,7 @@ impl GyroSource {
         self.imu_transforms.imu_lpf = 0.0;
         self.imu_transforms.imu_mf = 0;
         self.file_metadata = Default::default();
+        self.replacement_regions.clear();
         self.clear_offsets();
     }
 
@@ -658,19 +679,28 @@ impl GyroSource {
             *q *= additional_rotation;
         }
 
+        let org_quats: TimeQuat = if self.replacement_regions.iter().any(|r| r.enabled && !r.of_quats.is_empty()) {
+            self.quaternions.keys().map(|&ts| {
+                let ts_ms = ts as f64 / 1000.0;
+                (ts, self.org_quat_at_gyro_us(ts, ts, ts_ms))
+            }).collect()
+        } else {
+            self.quaternions.clone()
+        };
+
         if true {
             // Lock horizon, then smooth
-            horizon_lock.lock(&mut smoothed_quaternions, &self.quaternions, &file_metadata.gravity_vectors, self.use_gravity_vectors, self.integration_method, compute_params);
+            horizon_lock.lock(&mut smoothed_quaternions, &org_quats, &file_metadata.gravity_vectors, self.use_gravity_vectors, self.integration_method, compute_params);
             smoothed_quaternions = alg.smooth(&smoothed_quaternions, self.duration_ms, compute_params);
         } else {
             // Smooth, then lock horizon
             smoothed_quaternions = alg.smooth(&smoothed_quaternions, self.duration_ms, compute_params);
-            horizon_lock.lock(&mut smoothed_quaternions, &self.quaternions, &file_metadata.gravity_vectors, self.use_gravity_vectors, self.integration_method, compute_params);
+            horizon_lock.lock(&mut smoothed_quaternions, &org_quats, &file_metadata.gravity_vectors, self.use_gravity_vectors, self.integration_method, compute_params);
         }
 
-        let max_angles = crate::Smoothing::get_max_angles(&self.quaternions, &smoothed_quaternions, compute_params);
+        let max_angles = crate::Smoothing::get_max_angles(&org_quats, &smoothed_quaternions, compute_params);
 
-        for (sq, q) in smoothed_quaternions.iter_mut().zip(self.quaternions.iter()) {
+        for (sq, q) in smoothed_quaternions.iter_mut().zip(org_quats.iter()) {
             // rotation quaternion from smooth motion -> raw motion to counteract it
             *sq.1 = sq.1.inverse() * q.1;
         }
@@ -845,11 +875,16 @@ impl GyroSource {
         self.integrate();
     }
 
-    fn quat_at_timestamp(&self, quats: &TimeQuat, mut timestamp_ms: f64) -> Quat64 {
+    pub fn quat_at_timestamp(&self, quats: &TimeQuat, mut timestamp_ms: f64) -> Quat64 {
         if quats.len() < 2 || self.duration_ms <= 0.0 { return Quat64::identity(); }
 
         timestamp_ms -= self.offset_at_video_timestamp(timestamp_ms);
 
+        Self::interp_quat(quats, timestamp_ms)
+    }
+
+    fn interp_quat(quats: &TimeQuat, timestamp_ms: f64) -> Quat64 {
+        if quats.len() < 2 { return Quat64::identity(); }
         if let Some(&first_ts) = quats.keys().next() {
             if let Some(&last_ts) = quats.keys().next_back() {
                 let lookup_ts = ((timestamp_ms * 1000.0).round() as i64).min(last_ts).max(first_ts);
@@ -869,7 +904,87 @@ impl GyroSource {
         Quat64::identity()
     }
 
-    pub fn      org_quat_at_timestamp(&self, timestamp_ms: f64) -> Quat64 { self.quat_at_timestamp(&self.quaternions,          timestamp_ms) }
+    pub fn org_quat_at_timestamp(&self, timestamp_ms: f64) -> Quat64 {
+        let ts_us = (timestamp_ms * 1000.0).round() as i64;
+        let offset_ms = self.offset_at_video_timestamp(timestamp_ms);
+        let gyro_ts_ms = timestamp_ms - offset_ms;
+        let gyro_ts_us = (gyro_ts_ms * 1000.0).round() as i64;
+        self.org_quat_at_gyro_us(ts_us, gyro_ts_us, gyro_ts_ms)
+    }
+
+    fn org_quat_at_gyro_us(&self, ts_us: i64, gyro_ts_us: i64, gyro_ts_ms: f64) -> Quat64 {
+        self.org_quat_at_gyro_us_below(ts_us, gyro_ts_us, gyro_ts_ms, usize::MAX)
+    }
+
+    /// Resolve the orientation at `gyro_ts_us`, applying replacement regions.
+    /// Regions are scanned **back-to-front** so that later-added regions take
+    /// precedence over earlier ones. When a region's blend window is active, the
+    /// blend base is computed by evaluating only the *earlier* (lower-index)
+    /// regions, so that later repairs compose on top of the state established by
+    /// prior enabled repairs. `max_idx` bounds which regions are eligible: only
+    /// regions with index `< max_idx` are consulted, which prevents infinite
+    /// recursion when two regions' blend windows overlap.
+    fn org_quat_at_gyro_us_below(&self, ts_us: i64, gyro_ts_us: i64, gyro_ts_ms: f64, max_idx: usize) -> Quat64 {
+        // Iterate back-to-front: last-added region wins. Only consider regions
+        // below `max_idx` so the recursive blend-base call cannot re-enter the
+        // region currently being blended.
+        for (i, region) in self.replacement_regions.iter().enumerate().rev() {
+            if i >= max_idx { continue; }
+            if !region.enabled || region.of_quats.is_empty() { continue; }
+            if region.blend_us <= 0 {
+                if gyro_ts_us >= region.start_us && gyro_ts_us <= region.end_us {
+                    return Self::interp_quat(&region.of_quats, gyro_ts_ms);
+                }
+                continue;
+            }
+            let blend_start = region.start_us - region.blend_us;
+            let blend_end = region.end_us + region.blend_us;
+            if gyro_ts_us >= blend_start && gyro_ts_us <= blend_end {
+                // Base orientation: earlier enabled regions (or raw gyro) at this ts.
+                let base = self.org_quat_at_gyro_us_below(ts_us, gyro_ts_us, gyro_ts_ms, i);
+                if gyro_ts_us < region.start_us {
+                    let base_at_boundary = self.org_quat_at_gyro_us_below(ts_us, region.start_us, region.start_us as f64 / 1000.0, i);
+                    let of_at_boundary = Self::interp_quat(&region.of_quats, region.start_us as f64 / 1000.0);
+                    let correction = of_at_boundary * base_at_boundary.inverse();
+                    let t_raw = (gyro_ts_us - blend_start) as f64 / region.blend_us as f64;
+                    let t = Self::apply_blend_easing(t_raw, region.blend_method, region.blend_bias);
+                    return Quat64::identity().slerp(&correction, t) * base;
+                } else if gyro_ts_us > region.end_us {
+                    let base_at_boundary = self.org_quat_at_gyro_us_below(ts_us, region.end_us, region.end_us as f64 / 1000.0, i);
+                    let of_at_boundary = Self::interp_quat(&region.of_quats, region.end_us as f64 / 1000.0);
+                    let correction = of_at_boundary * base_at_boundary.inverse();
+                    let t_raw = (blend_end - gyro_ts_us) as f64 / region.blend_us as f64;
+                    let t = Self::apply_blend_easing(t_raw, region.blend_method, region.blend_bias);
+                    return Quat64::identity().slerp(&correction, t) * base;
+                } else {
+                    return Self::interp_quat(&region.of_quats, gyro_ts_ms);
+                }
+            }
+        }
+        Self::interp_quat(&self.quaternions, gyro_ts_ms)
+    }
+
+    /// Blend easing. `method == 0` is linear; otherwise a Schlick bias term
+    /// `t^(log(0.5)/log(bias))` (Schlick 1994) shapes the input, followed by a
+    /// cosine S-curve `(1 - cos(pi*t))/2` for smooth acceleration/deceleration.
+    /// `bias == 0.5` collapses the Schlick term to identity (symmetric ease).
+    fn apply_blend_easing(t: f64, method: i32, bias: f64) -> f64 {
+        let t = t.clamp(0.0, 1.0);
+        match method {
+            0 => t,
+            _ => {
+                let bias = bias.clamp(0.01, 0.99);
+                let k = if (bias - 0.5).abs() < 0.01 {
+                    1.0
+                } else {
+                    (0.5_f64).ln() / bias.ln()
+                };
+                let t_biased = t.powf(k);
+                (1.0 - (t_biased * std::f64::consts::PI).cos()) / 2.0
+            }
+        }
+    }
+
     pub fn smoothed_quat_at_timestamp(&self, timestamp_ms: f64) -> Quat64 { self.quat_at_timestamp(&self.smoothed_quaternions, timestamp_ms) }
 
     pub fn offset_at_timestamp(offsets: &BTreeMap<i64, f64>, timestamp_ms: f64) -> f64 {
@@ -988,5 +1103,31 @@ impl GyroSource {
         }
 
         (bias_vals[0], bias_vals[1], bias_vals[2])
+    }
+
+    pub fn add_replacement_region(&mut self, region: GyroReplacementRegion) -> usize {
+        if let Some(idx) = self.replacement_regions.iter().position(|r| r.start_us == region.start_us && r.end_us == region.end_us) {
+            self.replacement_regions[idx] = region;
+            idx
+        } else {
+            self.replacement_regions.push(region);
+            self.replacement_regions.len() - 1
+        }
+    }
+
+    pub fn remove_replacement_region(&mut self, index: usize) {
+        if index < self.replacement_regions.len() {
+            self.replacement_regions.remove(index);
+        }
+    }
+
+    pub fn set_replacement_region_enabled(&mut self, index: usize, enabled: bool) {
+        if let Some(r) = self.replacement_regions.get_mut(index) {
+            r.enabled = enabled;
+        }
+    }
+
+    pub fn clear_replacement_regions(&mut self) {
+        self.replacement_regions.clear();
     }
 }

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dan0v <dev@dan0v.com>
 #![recursion_limit = "256"]
 
 pub mod gyro_source;
@@ -19,6 +20,7 @@ pub mod smoothing;
 pub mod filtering;
 pub mod filesystem;
 pub mod gyro_export;
+pub mod gyro_replace;
 pub mod settings;
 
 pub mod gpu;
@@ -87,6 +89,7 @@ pub struct StabilizationManager {
     pub stabilization: Arc<RwLock<Stabilization>>,
 
     pub pose_estimator: Arc<synchronization::PoseEstimator>,
+    pub repair_estimator: Arc<synchronization::PoseEstimator>,
     #[cfg(feature = "opencv")]
     pub lens_calibrator: Arc<RwLock<Option<LensCalibrator>>>,
 
@@ -134,6 +137,7 @@ impl Default for StabilizationManager {
             gpu_decoding: Arc::new(AtomicBool::new(settings::get_bool("gpudecode", true))),
 
             pose_estimator: Arc::new(synchronization::PoseEstimator::default()),
+            repair_estimator: Arc::new(synchronization::PoseEstimator::default()),
 
             lens_profile_db: Arc::new(RwLock::new(LensProfileDatabase::default())),
 
@@ -166,6 +170,7 @@ impl StabilizationManager {
         }
 
         self.pose_estimator.sync_results.write().clear();
+        self.repair_estimator.sync_results.write().clear();
         self.keyframes.write().clear();
     }
 
@@ -1204,6 +1209,7 @@ impl StabilizationManager {
         self.keyframes.write().clear();
 
         self.pose_estimator.clear();
+        self.repair_estimator.clear();
     }
 
     pub fn override_video_fps(&self, fps: f64, recompute: bool) {
@@ -1344,6 +1350,7 @@ impl StabilizationManager {
                 "integration_method": gyro.integration_method,
                 "sample_index":       gyro.file_load_options.sample_index,
                 "detected_source":    gyro.file_metadata.read().detected_source,
+                "replacement_regions": gyro.replacement_regions,
             },
 
             "offsets": gyro.get_offsets(), // timestamp, offset value
@@ -1622,6 +1629,12 @@ impl StabilizationManager {
                 if let Some(v) = obj.get("rotation")     { let v: [f64; 3] = serde_json::from_value(v.clone()).unwrap_or_default(); gyro.imu_transforms.set_imu_rotation(v[0], v[1], v[2]); }
                 if let Some(v) = obj.get("acc_rotation") { let v: [f64; 3] = serde_json::from_value(v.clone()).unwrap_or_default(); gyro.imu_transforms.set_acc_rotation(v[0], v[1], v[2]); }
                 if let Some(v) = obj.get("gyro_bias")    { gyro.imu_transforms.gyro_bias = serde_json::from_value(v.clone()).ok(); }
+
+                if let Some(v) = obj.get("replacement_regions") {
+                    if let Ok(regions) = serde_json::from_value::<Vec<crate::gyro_source::GyroReplacementRegion>>(v.clone()) {
+                        gyro.replacement_regions = regions;
+                    }
+                }
 
                 if let Ok(fls) = util::decompress_from_base91_cbor::<Vec<Option<f64>>>(obj.get("focal_lengths").and_then(|x| x.as_str()).unwrap_or_default()) {
                     self.params.write().focal_lengths = fls;

--- a/src/core/stabilization/frame_transform.rs
+++ b/src/core/stabilization/frame_transform.rs
@@ -376,7 +376,7 @@ impl FrameTransform {
         let frame_readout_time = Self::get_frame_readout_time(params, false, timestamp_ms, &file_metadata);
 
         let row_readout_time = frame_readout_time / if params.frame_readout_direction.is_horizontal() { params.width } else { params.height } as f64;
-        let timestamp_ms = timestamp_ms + gyro.file_metadata.read().per_frame_time_offsets.get(frame).unwrap_or(&0.0);
+        let timestamp_ms = timestamp_ms + file_metadata.per_frame_time_offsets.get(frame).unwrap_or(&0.0);
         let start_ts = timestamp_ms - (frame_readout_time / 2.0);
         // ----------- Rolling shutter correction -----------
 

--- a/src/core/synchronization/autosync.rs
+++ b/src/core/synchronization/autosync.rs
@@ -12,6 +12,11 @@ use crate::stabilization::ComputeParams;
 use super::PoseEstimator;
 use super::SyncParams;
 
+/// Default max features for autosync's AKAZE detection.
+const AUTOSYNC_MAX_FEATURES: usize = 200;
+/// Default AKAZE detection threshold for autosync.
+const AUTOSYNC_THRESHOLD: f64 = 0.0007;
+
 pub struct AutosyncProcess {
     frame_count: usize,
     scaled_fps: f64,
@@ -161,7 +166,7 @@ impl AutosyncProcess {
                     return;
                 }
                 if let Some(img) = img {
-                    estimator.detect_features(frame_no, timestamp_us, img, width, height, method);
+                    estimator.detect_features(frame_no, timestamp_us, img, width, height, method, AUTOSYNC_MAX_FEATURES, AUTOSYNC_THRESHOLD);
                     total_detected_frames.fetch_add(1, SeqCst);
 
                     if frame_no % 7 == 0 {

--- a/src/core/synchronization/mod.rs
+++ b/src/core/synchronization/mod.rs
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dan0v <dev@dan0v.com>
 
 use nalgebra::Rotation3;
 use std::ops::Range;
 use std::sync::Arc;
-use std::sync::atomic::{ AtomicBool, AtomicU32, Ordering::SeqCst };
+use std::sync::atomic::{ AtomicBool, AtomicU32, AtomicUsize, Ordering::SeqCst };
 use parking_lot::RwLock;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
@@ -71,6 +72,8 @@ pub struct PoseEstimator {
     pub every_nth_frame: AtomicU32,
     pub pose_method: AtomicU32,
     pub offset_method: AtomicU32,
+    pub pose_progress: Arc<AtomicUsize>,
+    pub pose_total: Arc<AtomicUsize>,
 }
 
 impl PoseEstimator {
@@ -80,12 +83,12 @@ impl PoseEstimator {
         self.estimated_quats.write().clear();
     }
 
-    pub fn detect_features(&self, frame_no: usize, timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32, of_method: u32) {
+    pub fn detect_features(&self, frame_no: usize, timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32, of_method: u32, max_features: usize, of_threshold: f64) {
         let frame_size = (width, height);
         let contains = self.sync_results.read().contains_key(&timestamp_us);
         if !contains {
             let result = FrameResult {
-                of_method: OpticalFlowMethod::detect_features(of_method, timestamp_us, img, width, height),
+                of_method: OpticalFlowMethod::detect_features(of_method, timestamp_us, img, width, height, max_features, of_threshold),
                 frame_no,
                 frame_size,
                 timestamp_us,
@@ -121,7 +124,12 @@ impl PoseEstimator {
             }
         }
 
+        let total = frames_to_process.len();
+        self.pose_total.store(total, std::sync::atomic::Ordering::Relaxed);
+        self.pose_progress.store(0, std::sync::atomic::Ordering::Relaxed);
+
         let results = self.sync_results.clone();
+        let progress = self.pose_progress.clone();
         let mut pose = EstimatePoseMethod::from(self.pose_method.load(SeqCst));
         pose.init(params);
         frames_to_process.par_iter().for_each(move |(ts, next_ts)| {
@@ -129,13 +137,10 @@ impl PoseEstimator {
                 let l = results.read();
                 if let Some(curr) = l.get(ts) {
                     if curr.rotation.is_none() {
-                        //let curr = curr.item.clone();
                         if let Some(next) = l.get(next_ts) {
-                            // TODO estimate pose should be quick so test if instead of cloning it is faster just to keep the lock for longer
                             let curr_of = curr.of_method.clone();
                             let next_of = next.of_method.clone();
 
-                            // Unlock the mutex for estimate_pose
                             drop(l);
 
                             if let Some(rot) = pose.estimate_pose(&curr_of.optical_flow_to(&next_of), curr_of.size(), params, *ts, *next_ts) {
@@ -154,7 +159,8 @@ impl PoseEstimator {
                 }
             }
 
-            // Free unneeded img memory
+            progress.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+
             let mut l = results.write();
             if let Some(curr) = l.get_mut(ts) {
                 if curr.of_method.can_cleanup() { curr.of_method.cleanup(); }

--- a/src/core/synchronization/optical_flow/akaze.rs
+++ b/src/core/synchronization/optical_flow/akaze.rs
@@ -22,9 +22,9 @@ pub struct OFAkaze {
 }
 
 impl OFAkaze {
-    pub fn detect_features(_timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32) -> Self {
-        let mut akz = Akaze::new(0.0007);
-        akz.maximum_features = 200;
+    pub fn detect_features(_timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32, max_features: usize, threshold: f64) -> Self {
+        let mut akz = Akaze::new(threshold);
+        akz.maximum_features = max_features;
         let img_size = (width, height);
         let (points, descriptors) = akz.extract(&image::DynamicImage::ImageLuma8(Arc::try_unwrap(img).unwrap()));
 

--- a/src/core/synchronization/optical_flow/mod.rs
+++ b/src/core/synchronization/optical_flow/mod.rs
@@ -25,12 +25,12 @@ pub enum OpticalFlowMethod {
     OFOpenCVDis(OFOpenCVDis),
 }
 impl OpticalFlowMethod {
-    pub fn detect_features(method: u32, timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32) -> Self {
+    pub fn detect_features(method: u32, timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32, max_features: usize, threshold: f64) -> Self {
         match method {
-            0 => Self::OFAkaze(OFAkaze::detect_features(timestamp_us, img, width, height)),
-            1 => Self::OFOpenCVPyrLK(OFOpenCVPyrLK::detect_features(timestamp_us, img, width, height)),
-            2 => Self::OFOpenCVDis(OFOpenCVDis::detect_features(timestamp_us, img, width, height)),
-            _ => { log::error!("Unknown OF method {method}", ); Self::OFAkaze(OFAkaze::detect_features(timestamp_us, img, width, height)) }
+            0 => Self::OFAkaze(OFAkaze::detect_features(timestamp_us, img, width, height, max_features, threshold)),
+            1 => Self::OFOpenCVPyrLK(OFOpenCVPyrLK::detect_features(timestamp_us, img, width, height, max_features, threshold)),
+            2 => Self::OFOpenCVDis(OFOpenCVDis::detect_features(timestamp_us, img, width, height, max_features, threshold)),
+            _ => { log::error!("Unknown OF method {method}", ); Self::OFAkaze(OFAkaze::detect_features(timestamp_us, img, width, height, max_features, threshold)) }
         }
     }
 }

--- a/src/core/synchronization/optical_flow/opencv_dis.rs
+++ b/src/core/synchronization/optical_flow/opencv_dis.rs
@@ -20,17 +20,19 @@ pub struct OFOpenCVDis {
     timestamp_us: i64,
     size: (i32, i32),
     used: Arc<AtomicU32>,
+    grid_points: usize,
 }
 
 impl OFOpenCVDis {
-    pub fn detect_features(timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32) -> Self {
+    pub fn detect_features(timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32, max_features: usize, _threshold: f64) -> Self {
         Self {
             features: Vec::new(),
             timestamp_us,
             size: (width as i32, height as i32),
             matched_points: Default::default(),
             img,
-            used: Default::default()
+            used: Default::default(),
+            grid_points: max_features,
         }
     }
 }
@@ -61,34 +63,36 @@ impl OpticalFlowTrait for OFOpenCVDis {
 
                 let mut points_a = Vec::new();
                 let mut points_b = Vec::new();
-                let step = w as usize / 15; // 15 points
-                
+                let target_points = self.grid_points.max(50);
+                let grid_side = (target_points as f64).sqrt() as usize;
+                let step = if grid_side > 0 { (w as usize / grid_side).max(2) } else { w as usize / 15 };
+
                 // Calculate window size as 2% of image width, minimum 10
                 let window_size = (w as f32 * 0.02).round() as usize;
                 let window_size = window_size.max(10);
                 let texture_threshold = 3.0; // Threshold for texture clarity
-                
+
                 // Pre-calculate half window size for efficiency
                 let half_win = window_size / 2;
-                
+
                 // Function to calculate variance of grayscale values in a window (more accurate than gradient)
                 let calculate_texture = |img: &image::GrayImage, x: usize, y: usize| -> f32 {
                     let mut sum = 0.0;
                     let mut sum_sq = 0.0;
                     let mut count = 0.0;
-                    
+
                     // Cache image dimensions as isize for faster comparisons
                     let img_width = img.width() as isize;
                     let img_height = img.height() as isize;
                     let x_isize = x as isize;
                     let y_isize = y as isize;
-                    
+
                     // Calculate valid pixel boundaries once
                     let start_y = (y_isize - half_win as isize).max(0);
                     let end_y = (y_isize + half_win as isize).min(img_height - 1);
                     let start_x = (x_isize - half_win as isize).max(0);
                     let end_x = (x_isize + half_win as isize).min(img_width - 1);
-                    
+
                     // Iterate only over valid pixels, avoiding repeated boundary checks
                     for ny in start_y..=end_y {
                         for nx in start_x..=end_x {
@@ -98,14 +102,14 @@ impl OpticalFlowTrait for OFOpenCVDis {
                             count += 1.0;
                         }
                     }
-                    
+
                     if count == 0.0 { return 0.0; }
-                    
+
                     let mean = sum / count;
                     let variance = (sum_sq / count) - (mean * mean);
                     variance
                 };
-                
+
                 for i in (0..a1_img.cols()).step_by(step) {
                     for j in (0..a1_img.rows()).step_by(step) {
                         // Check texture clarity using accurate variance method

--- a/src/core/synchronization/optical_flow/opencv_pyrlk.rs
+++ b/src/core/synchronization/optical_flow/opencv_pyrlk.rs
@@ -22,7 +22,7 @@ pub struct OFOpenCVPyrLK {
     used: Arc<AtomicU32>,
 }
 impl OFOpenCVPyrLK {
-    pub fn detect_features(timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32) -> Self {
+    pub fn detect_features(timestamp_us: i64, img: Arc<image::GrayImage>, width: u32, height: u32, max_features: usize, _threshold: f64) -> Self {
         let (w, h) = (width as i32, height as i32);
 
         #[cfg(feature = "use-opencv")]
@@ -34,7 +34,7 @@ impl OFOpenCVPyrLK {
             let mut pts = Mat::default();
 
             if let Err(e) = inp.and_then(|inp| {
-                opencv::imgproc::good_features_to_track(&inp, &mut pts, 200, 0.01, 10.0, &Mat::default(), 3, false, 0.04)
+                opencv::imgproc::good_features_to_track(&inp, &mut pts, max_features as i32, 0.01, 10.0, &Mat::default(), 3, false, 0.04)
             }) {
                 log::error!("OpenCV error {:?}", e);
             }
@@ -100,7 +100,7 @@ impl OpticalFlowTrait for OFOpenCVPyrLK {
                 }
                 Ok((pts1, pts2))
             }();
-            
+
             match result {
                 Ok(res) => {
                     // Only store and return if we have enough valid points (>15)

--- a/src/ui/components/Timeline.qml
+++ b/src/ui/components/Timeline.qml
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dan0v <dev@dan0v.com>
 
 import QtQuick
 import QtQuick.Controls as QQC
@@ -822,6 +823,69 @@ Item {
                     onReset: root.resetTrim();
                 }
             }
+            Repeater {
+                id: replacementRegionsRepeater;
+                model: controller.replacement_regions_model;
+                // Theme-aware repair-region palette (orange accent, dimmed when disabled).
+                readonly property color fillSelected:  "#60ff6600";
+                readonly property color fillEnabled:   "#30ff6600";
+                readonly property color fillDisabled:  "#18000000";
+                readonly property color fillCoreSel:   "#80ff6600";
+                readonly property color fillCoreEn:    "#50ff6600";
+                readonly property color fillCoreDis:   "#20000000";
+                readonly property color borderSel:     "#ffaa00";
+                readonly property color borderEn:     "#ff6600";
+                readonly property color borderDis:    "#40000000";
+                Rectangle {
+                    required property var model;
+                    property real regionStart: model.start_us / (root.durationMs * 1000);
+                    property real regionEnd: model.end_us / (root.durationMs * 1000);
+                    property real regionBlend: model.blend_us / (root.durationMs * 1000);
+                    property bool isSelected: model.index === controller.selected_repair_region;
+                    x: parent.width * root.mapToVisibleArea(Math.max(0.0, regionStart - regionBlend));
+                    width: Math.max(4, parent.width * (root.mapToVisibleArea(Math.min(1.0, regionEnd + regionBlend)) - root.mapToVisibleArea(Math.max(0.0, regionStart - regionBlend))));
+                    y: (root.fullScreen || window.isMobileLayout? 0 : 35) * dpiScale;
+                    height: parent.height - y;
+                    color: isSelected ? replacementRegionsRepeater.fillSelected : (model.enabled ? replacementRegionsRepeater.fillEnabled : replacementRegionsRepeater.fillDisabled);
+                    border.width: (isSelected ? 2 : 1) * dpiScale;
+                    border.color: isSelected ? replacementRegionsRepeater.borderSel : (model.enabled ? replacementRegionsRepeater.borderEn : replacementRegionsRepeater.borderDis);
+                    radius: 2 * dpiScale;
+                    visible: root.durationMs > 0 && !isNaN(regionStart) && !isNaN(regionEnd);
+                    Rectangle {
+                        x: parent.parent.width * root.mapToVisibleArea(regionStart) - parent.x;
+                        width: parent.parent.width * (root.mapToVisibleArea(regionEnd) - root.mapToVisibleArea(regionStart));
+                        height: parent.height;
+                        color: isSelected ? replacementRegionsRepeater.fillCoreSel : (model.enabled ? replacementRegionsRepeater.fillCoreEn : replacementRegionsRepeater.fillCoreDis);
+                    }
+                    MouseArea {
+                        anchors.fill: parent;
+                        acceptedButtons: Qt.LeftButton | Qt.RightButton;
+                        onClicked: (mouse) => {
+                            if (mouse.button === Qt.RightButton) {
+                                regionMenu.index = model.index;
+                                regionMenu.regionEnabled = model.enabled;
+                                regionMenu.popup();
+                            } else {
+                                controller.selected_repair_region = (controller.selected_repair_region === model.index) ? -1 : model.index;
+                                controller.selected_repair_region_changed();
+                            }
+                        }
+                    }
+                    QQC.Menu {
+                        id: regionMenu;
+                        property int index;
+                        property bool regionEnabled;
+                        QQC.Action {
+                            text: regionMenu.regionEnabled ? qsTr("Disable") : qsTr("Enable");
+                            onTriggered: controller.toggle_gyro_replace(regionMenu.index, !regionMenu.regionEnabled);
+                        }
+                        QQC.Action {
+                            text: qsTr("Remove");
+                            onTriggered: controller.remove_gyro_replace(regionMenu.index);
+                        }
+                    }
+                }
+            }
         }
 
         // Handle
@@ -875,6 +939,10 @@ Item {
                 if (isCalibrator) {
                     calibRepeater.model = controller.calib_model;
                 }
+            }
+            function onReplacement_regions_updated(): void {
+                replacementRegionsRepeater.model = [];
+                replacementRegionsRepeater.model = controller.replacement_regions_model;
             }
             function onCompute_progress(id: real, progress: real): void {
                 chartUpdateTimer.axes = true;

--- a/src/ui/menu/MotionData.qml
+++ b/src/ui/menu/MotionData.qml
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dan0v <dev@dan0v.com>
 
 import QtQuick
 import QtQuick.Dialogs
@@ -833,4 +834,272 @@ MenuItem {
         extensions: fileDialog.extensions;
         onLoadFile: (url) => root.loadFile(url)
     }
+
+    Column {
+        id: repairSection;
+        width: parent.width;
+        spacing: 5 * dpiScale;
+        visible: controller.gyro_loaded;
+        property real gyroRepairProgress: 0;
+        // Theme-aware repair-region palette (orange accent, dimmed when disabled).
+        readonly property color regionBorder:      style === "light" ? "#ff6600" : "#ff6600";
+        readonly property color regionBorderSelected: "#ffaa00";
+        readonly property color regionFillSelected: style === "light" ? "#60ff6600" : "#60ff6600";
+        readonly property color regionFillEnabled:  style === "light" ? "#30ff6600" : "#30ff6600";
+        readonly property color regionFillDisabled: style === "light" ? "#18000000" : "#18000000";
+        readonly property color rowBgSelected:     style === "light" ? "#20000000" : "#15ffffff";
+        readonly property color rowBgUnselected:   style === "light" ? "#08000000" : "#08ffffff";
+
+        BasicText {
+            text: qsTr("Gyro repair");
+            font.bold: true;
+            font.pixelSize: 13 * dpiScale;
+        }
+        BasicText {
+            text: qsTr("Select a time range with corrupted gyro data and replace it with optical flow analysis.");
+            width: parent.width;
+            font.pixelSize: 11 * dpiScale;
+            wrapMode: Text.WordWrap;
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Region start");
+            inner.width: 110 * dpiScale;
+            Row {
+                spacing: 5 * dpiScale;
+                NumberField {
+                    id: repairStart;
+                    unit: "ms";
+                    precision: 1;
+                    from: 0;
+                    to: 999999;
+                    width: 75 * dpiScale;
+                    value: 0;
+                }
+                Button {
+                    text: "[";
+                    font.bold: true;
+                    width: 30 * dpiScale;
+                    leftPadding: 3 * dpiScale;
+                    rightPadding: 3 * dpiScale;
+                    tooltip: qsTr("Set to current cursor position");
+                    onClicked: repairStart.value = Math.round(window.videoArea.vid.timestamp * 10) / 10;
+                }
+            }
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Region end");
+            inner.width: 110 * dpiScale;
+            Row {
+                spacing: 5 * dpiScale;
+                NumberField {
+                    id: repairEnd;
+                    unit: "ms";
+                    precision: 1;
+                    from: 0;
+                    to: 999999;
+                    width: 75 * dpiScale;
+                    value: 0;
+                }
+                Button {
+                    text: "]";
+                    font.bold: true;
+                    width: 30 * dpiScale;
+                    leftPadding: 3 * dpiScale;
+                    rightPadding: 3 * dpiScale;
+                    tooltip: qsTr("Set to current cursor position");
+                    onClicked: repairEnd.value = Math.round(window.videoArea.vid.timestamp * 10) / 10;
+                }
+            }
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Blend duration");
+            inner.width: 80 * dpiScale;
+            NumberField {
+                id: repairBlend;
+                unit: "ms";
+                precision: 0;
+                from: 0;
+                to: 1000;
+                width: 80 * dpiScale;
+                value: 300;
+                tooltip: qsTr("Transition duration at region boundaries for smooth blending");
+            }
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Blend curve");
+            ComboBox {
+                id: repairBlendMethod;
+                model: ["Linear", "Smooth"];
+                font.pixelSize: 12 * dpiScale;
+                width: parent.width;
+                currentIndex: 1;
+                tooltip: qsTr("Blend curve at region boundaries: Linear = constant speed, Smooth = cosine S-curve");
+            }
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Blend bias");
+            inner.width: 120 * dpiScale;
+            NumberField {
+                id: repairBlendBias;
+                precision: 2;
+                from: 0.01; to: 0.99;
+                defaultValue: 0.5;
+                font.pixelSize: 12 * dpiScale;
+                width: parent.width;
+                Component.onCompleted: value = 0.5;
+                tooltip: qsTr("Position of the blend midpoint: 0.5 = symmetric, <0.5 = ease into repair, >0.5 = ease out of repair");
+            }
+        }
+        Row {
+            width: parent.width;
+            spacing: 5 * dpiScale;
+            ComboBox {
+                id: repairOfMethod;
+                model: ["AKAZE", "OpenCV (PyrLK)", "OpenCV (DIS)"];
+                font.pixelSize: 12 * dpiScale;
+                width: parent.width / 2 - 2.5 * dpiScale;
+                currentIndex: 2;
+                tooltip: qsTr("Optical flow method");
+            }
+            ComboBox {
+                id: repairPoseMethod;
+                model: ["findEssentialMat", "Almeida", "EightPoint", "findHomography"];
+                font.pixelSize: 12 * dpiScale;
+                width: parent.width / 2 - 2.5 * dpiScale;
+                currentIndex: 0;
+                tooltip: qsTr("Pose method");
+            }
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Resolution");
+            inner.width: 80 * dpiScale;
+            ComboBox {
+                id: repairResolution;
+                model: [QT_TRANSLATE_NOOP("Popup", "Full"), "4k", "1080p", "720p", "480p"];
+                font.pixelSize: 12 * dpiScale;
+                width: parent.width;
+                currentIndex: 3;
+                tooltip: qsTr("Processing resolution for optical flow analysis");
+            }
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Number of features");
+            inner.width: 80 * dpiScale;
+            NumberField {
+                id: repairMaxFeatures;
+                unit: "";
+                precision: 0;
+                from: 50;
+                to: 2000;
+                width: 80 * dpiScale;
+                value: 50;
+                tooltip: qsTr("Number of tracking points");
+            }
+        }
+        Label {
+            position: Label.LeftPosition;
+            text: qsTr("Feature threshold");
+            inner.width: 80 * dpiScale;
+            NumberField {
+                id: repairThreshold;
+                unit: "";
+                precision: 4;
+                from: 0;
+                to: 0.01;
+                width: 80 * dpiScale;
+                defaultValue: 0.0007;
+                tooltip: qsTr("Feature detection sensitivity");
+                Component.onCompleted: value = 0.0007;
+            }
+        }
+        Button {
+            text: controller.gyro_replace_in_progress ? qsTr("Analyzing... %1%").arg(Math.round(repairSection.gyroRepairProgress)) : qsTr("Analyze");
+            iconName: "chart";
+            width: parent.width;
+            enabled: !controller.gyro_replace_in_progress && repairEnd.value > repairStart.value;
+            property real gyroRepairProgress: 0;
+            onClicked: {
+                const start_us = Math.round(repairStart.value * 1000);
+                const end_us = Math.round(repairEnd.value * 1000);
+                const blend_us = Math.round(repairBlend.value * 1000);
+                const proc_height = [-1, 2160, 1080, 720, 480][repairResolution.currentIndex];
+                controller.start_gyro_replace(start_us, end_us, blend_us, repairBlendMethod.currentIndex, repairBlendBias.value, repairOfMethod.currentIndex, repairPoseMethod.currentIndex, repairMaxFeatures.value, repairThreshold.value, proc_height);
+            }
+        }
+        Connections {
+            target: controller;
+            function onGyro_replace_progress(progress: real, ready: int, total: int): void {
+                repairSection.gyroRepairProgress = progress * 100;
+            }
+            function onReplacement_regions_updated(): void {
+                repairRegionsRepeater.model = [];
+                repairRegionsRepeater.model = controller.replacement_regions_model;
+            }
+        }
+        Repeater {
+            id: repairRegionsRepeater;
+            model: controller.replacement_regions_model;
+            delegate: Rectangle {
+                width: repairSection.width;
+                height: 30 * dpiScale;
+                color: model.index === controller.selected_repair_region ? repairSection.rowBgSelected : repairSection.rowBgUnselected;
+                radius: 4 * dpiScale;
+                border.width: model.index === controller.selected_repair_region ? 1 : 0;
+                border.color: repairSection.regionBorder;
+                CheckBox {
+                    x: 4 * dpiScale;
+                    y: (parent.height - height) / 2;
+                    checked: model.enabled;
+                    onClicked: controller.toggle_gyro_replace(model.index, checked);
+                    tooltip: qsTr("Enable/disable repaired gyro data");
+                }
+                BasicText {
+                    x: 30 * dpiScale;
+                    y: (parent.height - height) / 2;
+                    text: "%1 - %2 ms".arg((model.start_us / 1000).toFixed(1)).arg((model.end_us / 1000).toFixed(1));
+                    font.pixelSize: 11 * dpiScale;
+                    verticalAlignment: Text.AlignVCenter;
+                    width: parent.width - 60 * dpiScale;
+                    elide: Text.ElideRight;
+                }
+                Button {
+                    text: "X";
+                    x: parent.width - 26 * dpiScale;
+                    y: (parent.height - height) / 2;
+                    width: 22 * dpiScale;
+                    height: 22 * dpiScale;
+                    font.pixelSize: 11 * dpiScale;
+                    leftPadding: 0;
+                    rightPadding: 0;
+                    tooltip: qsTr("Remove this repair");
+                    onClicked: controller.remove_gyro_replace(model.index);
+                }
+                MouseArea {
+                    anchors.fill: parent;
+                    acceptedButtons: Qt.LeftButton;
+                    propagateComposedEvents: true;
+                    onClicked: (mouse) => {
+                        controller.selected_repair_region = (controller.selected_repair_region === model.index) ? -1 : model.index;
+                        controller.selected_repair_region_changed();
+                        mouse.accepted = false;
+                    }
+                    onPressed: (mouse) => mouse.accepted = false;
+                }
+            }
+        }
+        Button {
+            text: qsTr("Clear all repairs");
+            iconName: "bin";
+            width: parent.width;
+            visible: controller.replacement_regions_model.rowCount() > 0;
+            onClicked: controller.clear_gyro_replace();
+        }
+     }
 }


### PR DESCRIPTION
*Co-authored by Z.AI GLM-5.2, under human review and guidance*

Some cameras (notably DJI O4 and O4 Pro Air Units) embed gyro data that can be corrupted or drift in specific sections. This feature lets the user mark a time range with bad gyro data and replace it with orientation quaternions derived from video-only pose estimation, blended into the gyro stream with dual-anchor correction at both boundaries.

Design:
- User selects a [start, end] region in the MotionData panel or timeline; the controller decodes the video range, runs feature detection + pose estimation via the existing PoseEstimator pipeline, and builds a GyroReplacementRegion with anchored OF quaternions.
- Multiple regions are supported and managed individually via the timeline overlay (enable/disable/remove per region, clear all).
- Regions are persisted in the project file via serde on GyroSource.

Key implementation details:
- Dedicated repair_estimator on StabilizationManager so repair never clobbers autosync / OF-overlay state.
- OF relative rotations are lowpassed before accumulation, then seeded with start_quat so absolute orientation matches the gyro at the start boundary. End boundary is corrected by slerping from identity to the end correction across the region.
- org_quat_at_timestamp (video-time, with offset) used by frame_transform; org_quat_at_gyro_us (gyro-time, no offset) used by recompute_smoothness to avoid double-offsetting.
- recompute_smoothness uses self.quaternions when no regions are active (preserving original behavior), and replacement-aware org_quats when regions are active.
- scale_rotation uses UnitQuaternion::powf for correct angle interpolation.
- Cancellation paths call finished with cancelled=true so the UI resets gyro_replace_in_progress instead of hanging.
- TimeQuat passed directly through the qt_queued_callback boundary.
- Guards on remove/toggle/clear during in-progress repair.

Also: extract autosync OF constants, add NaN guard on timeline region rectangles.