### PR TITLE
Add "next file" buttons

### DIFF
--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -22,6 +22,8 @@ MenuItem {
     property bool hasAccessToInputDirectory: true;
     property alias infoList: list;
     property var orgModel: [];
+    property bool hasPreviousFile: false;
+    property bool hasNextFile: false;
 
     Component.onCompleted: {
         QT_TRANSLATE_NOOP("TableList", "Created at");
@@ -118,11 +120,20 @@ MenuItem {
         if (url && url.toString()) window.videoArea.loadFile(url);
     }
     function updateEntry(key: string, value: string): void {
-        if (key == "File name") root.filename = value;
+        if (key == "File name") {
+            root.filename = value;
+            root.updateFileNavigation();
+        }
         list.updateEntry(key, value);
     }
     function updateEntryWithTrigger(key: string, value: string): void {
         list.updateEntryWithTrigger(key, value);
+    }
+    function updateFileNavigation() {
+        const prev = filesystem.get_next_file_url(window.videoArea.loadedFileUrl, -1);
+        const next = filesystem.get_next_file_url(window.videoArea.loadedFileUrl,  1);
+        hasPreviousFile = prev && prev.toString() !== "";
+        hasNextFile     = next && next.toString() !== "";
     }
 
     function getDuration(md): string {
@@ -167,6 +178,7 @@ MenuItem {
             text: "<";
             tooltip: qsTr("Open the previous file in the directory.")
             width: height;
+            enabled: root.hasPreviousFile;
             onClicked: { loadNextFile(-1) }
         }
 
@@ -180,6 +192,7 @@ MenuItem {
             text: ">";
             tooltip: qsTr("Open the next file in the directory.")
             width: height;
+            enabled: root.hasNextFile;
             onClicked: { loadNextFile(1) }
         }
     }

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dapeef <alistair.white.horne@gmail.com>
 
 import QtQuick
 
@@ -112,6 +113,10 @@ MenuItem {
 
         Qt.callLater(window.exportSettings.videoInfoLoaded, w, h, bitrate);
     }
+    function loadNextFile(index: int): void {
+        const url = filesystem.get_next_file_url(window.videoArea.loadedFileUrl, index);
+        if (url && url.toString()) window.videoArea.loadFile(url);
+    }
     function updateEntry(key: string, value: string): void {
         if (key == "File name") root.filename = value;
         list.updateEntry(key, value);
@@ -154,11 +159,29 @@ MenuItem {
         return format + (format? " " : "") + rate;
     }
 
-    Button {
-        text: qsTr("Open file");
-        iconName: "video"
+    Row {
         anchors.horizontalCenter: parent.horizontalCenter;
-        onClicked: root.selectFileRequest();
+        spacing: 6 * dpiScale;
+
+        Button {
+            text: "<";
+            tooltip: qsTr("Open the previous file in the directory.")
+            width: height;
+            onClicked: { loadNextFile(-1) }
+        }
+
+        Button {
+            text: qsTr("Open file");
+            iconName: "video";
+            onClicked: root.selectFileRequest();
+        }
+
+        Button {
+            text: ">";
+            tooltip: qsTr("Open the next file in the directory.")
+            width: height;
+            onClicked: { loadNextFile(1) }
+        }
     }
 
     InfoMessageSmall {

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright © 2021-2022 Adrian <adrian.eddy at gmail>
+// Copyright © 2026 dapeef <alistair.white.horne at gmail>
 
 import QtQuick
 
@@ -112,6 +113,10 @@ MenuItem {
 
         Qt.callLater(window.exportSettings.videoInfoLoaded, w, h, bitrate);
     }
+    function loadNextFile(index: int): void {
+        const url = filesystem.get_next_file_url(window.videoArea.loadedFileUrl, index);
+        if (url && url.toString()) window.videoArea.loadFile(url);
+    }
     function updateEntry(key: string, value: string): void {
         if (key == "File name") root.filename = value;
         list.updateEntry(key, value);
@@ -154,11 +159,29 @@ MenuItem {
         return format + (format? " " : "") + rate;
     }
 
-    Button {
-        text: qsTr("Open file");
-        iconName: "video"
+    Row {
         anchors.horizontalCenter: parent.horizontalCenter;
-        onClicked: root.selectFileRequest();
+        spacing: 6 * dpiScale;
+
+        Button {
+            text: "<";
+            tooltip: qsTr("Open the previous file in the directory.")
+            width: height;
+            onClicked: { loadNextFile(-1) }
+        }
+
+        Button {
+            text: qsTr("Open file");
+            iconName: "video";
+            onClicked: root.selectFileRequest();
+        }
+
+        Button {
+            text: ">";
+            tooltip: qsTr("Open the next file in the directory.")
+            width: height;
+            onClicked: { loadNextFile(1) }
+        }
     }
 
     InfoMessageSmall {


### PR DESCRIPTION
# The change

These buttons allow the user to easily load the next and previous video files. This functionality already existed, but was only available via keyboard shortcuts, which were not immediately obvious. In fact, I have been using Gyroflow for a few years now, and only discovered this keyboard shortcut when I went to make this code change...

These buttons reuse the same function call as the existing keyboard shortcuts.

# Screenshots

The new buttons:

<img width="524" height="856" alt="WhatsApp Image 2026-06-27 at 16 05 33" src="https://github.com/user-attachments/assets/a4bcaefb-fdf3-44d3-9c1b-33b80fba2f1e" />

When hovering over the `<` button:

<img width="524" alt="image" src="https://github.com/user-attachments/assets/5dbf93b3-f1c7-4647-9f93-aa35b59ea758" />

# Alternate design proposal

I played with the idea of using the labels `Prev`/`Next` instead of `<` and `>` (see screenshot below), but came to the conclusion that this design is inferior because:
- The `Prev`/`Next` are verbose, almost as large as the `Open file` button. The `Open file` button is the primary button of the set, and as such should stand out
- With the tooltip (visible on hover), the potentially ambiguous `<`/`>` buttons become immediately obvious

<img width="309" height="421" alt="image" src="https://github.com/user-attachments/assets/8c331184-ff8a-456d-8c40-7ed364ecc465" />