### PR TITLE
feat(qml): camera and lens selector populated from metadata & validation (#742)

### DIFF
--- a/resources/camera_database.json
+++ b/resources/camera_database.json
@@ -1,0 +1,173 @@
+{
+  "version": "1.0.0",
+  "updated_at": "2026-08-03",
+  "brands": [
+    {
+      "name": "Sony",
+      "models": [
+        "A7IV",
+        "A7SIII",
+        "FX3",
+        "FX6",
+        "A7RIV",
+        "A7RV",
+        "A1",
+        "ZV-E1",
+        "ZV-E10",
+        "A6700"
+      ],
+      "lenses": [
+        "FE 24mm F1.4 GM",
+        "FE 20mm F1.8 G",
+        "FE 16-35mm F2.8 GM",
+        "FE 24-70mm F2.8 GM",
+        "E 11mm F1.8",
+        "E 15mm F1.4 G"
+      ]
+    },
+    {
+      "name": "GoPro",
+      "models": [
+        "HERO12 Black",
+        "HERO11 Black",
+        "HERO10 Black",
+        "HERO9 Black",
+        "HERO8 Black",
+        "MAX"
+      ],
+      "lenses": [
+        "Wide",
+        "SuperView",
+        "HyperView",
+        "Linear",
+        "Linear + Horizon Lock"
+      ]
+    },
+    {
+      "name": "DJI",
+      "models": [
+        "Osmo Action 4",
+        "Osmo Action 3",
+        "Action 2",
+        "Osmo Pocket 3",
+        "Avata",
+        "Avata 2",
+        "O3 Air Unit"
+      ],
+      "lenses": [
+        "Standard",
+        "Wide",
+        "Ultrawide"
+      ]
+    },
+    {
+      "name": "Insta360",
+      "models": [
+        "Ace Pro",
+        "GO 3",
+        "ONE RS",
+        "X3",
+        "X4"
+      ],
+      "lenses": [
+        "ActionView",
+        "Dewarp",
+        "Ultrawide",
+        "MegaView"
+      ]
+    },
+    {
+      "name": "RED",
+      "models": [
+        "Komodo 6K",
+        "V-Raptor 8K VV",
+        "Komodo-X"
+      ],
+      "lenses": [
+        "Canon RF Mount",
+        "ARRI PL Mount"
+      ]
+    },
+    {
+      "name": "Blackmagic",
+      "models": [
+        "Pocket Cinema Camera 4K",
+        "Pocket Cinema Camera 6K Pro",
+        "Cinema Camera 6K",
+        "Micro Studio Camera 4K G2"
+      ],
+      "lenses": [
+        "MFT Mount",
+        "EF Mount",
+        "L Mount"
+      ]
+    },
+    {
+      "name": "Canon",
+      "models": [
+        "EOS R5",
+        "EOS R6 Mark II",
+        "EOS R7",
+        "EOS R8",
+        "EOS R3",
+        "EOS C70"
+      ],
+      "lenses": [
+        "RF 15-35mm F2.8L",
+        "RF 24-70mm F2.8L",
+        "RF 16mm F2.8"
+      ]
+    },
+    {
+      "name": "Panasonic",
+      "models": [
+        "Lumix S5II",
+        "Lumix GH6",
+        "Lumix S1H",
+        "Lumix S5"
+      ],
+      "lenses": [
+        "Lumix S 18mm F1.8",
+        "Lumix G 12-35mm F2.8"
+      ]
+    },
+    {
+      "name": "Fujifilm",
+      "models": [
+        "X-T5",
+        "X-H2S",
+        "X-T4",
+        "X-S20"
+      ],
+      "lenses": [
+        "XF 16-55mm F2.8",
+        "XF 10-24mm F4",
+        "XF 8mm F3.5"
+      ]
+    },
+    {
+      "name": "RunCam",
+      "models": [
+        "Thumb Pro",
+        "Thumb",
+        "Wasp",
+        "Phoenix 2"
+      ],
+      "lenses": [
+        "Standard"
+      ]
+    },
+    {
+      "name": "Caddx",
+      "models": [
+        "Walnut",
+        "Peanut",
+        "Ant",
+        "Ratel 2"
+      ],
+      "lenses": [
+        "Standard"
+      ]
+    }
+  ]
+}

--- a/src/controller.rs
+++ b/src/controller.rs
@@ -99,6 +99,10 @@ pub struct Controller {
     all_profiles_loaded: qt_signal!(),
     search_lens_profile_finished: qt_signal!(profiles: QVariantList),
     search_lens_profile: qt_method!(fn(&self, text: QString, favorites: QVariantList, aspect_ratio: i32, aspect_ratio_swapped: i32)),
+    is_valid_lens_profile: qt_method!(fn(&self, url_or_id: QString) -> bool),
+    get_camera_list: qt_method!(fn(&self) -> QStringList),
+    get_lens_list: qt_method!(fn(&self, camera: QString) -> QStringList),
+    select_camera: qt_method!(fn(&mut self, camera: QString)),
     fetch_profiles_from_github: qt_method!(fn(&self)),
     lens_profiles_updated: qt_signal!(reload_from_disk: bool),
 
@@ -866,6 +870,49 @@ impl Controller {
         self.lens_changed();
         self.lens_profile_loaded(QString::from(json), QString::from(filepath), QString::from(checksum));
         self.request_recompute();
+    }
+    fn is_valid_lens_profile(&self, url_or_id: QString) -> bool {
+        let url_or_id_str = url_or_id.to_string();
+        if url_or_id_str.is_empty() {
+            self.stabilizer.lens.read().is_valid()
+        } else {
+            let db = self.stabilizer.lens_profile_db.read();
+            if let Some(profile) = db.find(&url_or_id_str) {
+                profile.is_valid()
+            } else if url_or_id_str.starts_with('{') {
+                LensProfile::from_json(&url_or_id_str).is_ok_and(|p| p.is_valid())
+            } else {
+                let mut profile = LensProfile::default();
+                profile.load_from_file(&url_or_id_str).is_ok_and(|_| profile.is_valid())
+            }
+        }
+    }
+    fn get_camera_list(&self) -> QStringList {
+        let db = self.stabilizer.lens_profile_db.read();
+        let cameras = db.get_camera_list();
+        QStringList::from_iter(cameras.into_iter().map(QString::from))
+    }
+    fn get_lens_list(&self, camera: QString) -> QStringList {
+        let db = self.stabilizer.lens_profile_db.read();
+        let lenses = db.get_lens_list(&camera.to_string());
+        QStringList::from_iter(lenses.into_iter().map(QString::from))
+    }
+    fn select_camera(&mut self, camera: QString) {
+        let camera_str = camera.to_string();
+        let db = self.stabilizer.lens_profile_db.read();
+        let camera_lc = camera_str.trim().to_lowercase();
+        let matching_key = db.map.iter().find_map(|(id, p)| {
+            let full_cam = format!("{} {}", p.camera_brand, p.camera_model).trim().to_lowercase();
+            if full_cam == camera_lc || p.camera_brand.to_lowercase() == camera_lc || p.camera_model.to_lowercase() == camera_lc {
+                Some(id.clone())
+            } else {
+                None
+            }
+        });
+        drop(db);
+        if let Some(id) = matching_key {
+            self.load_lens_profile(QString::from(id));
+        }
     }
     fn load_default_preset(&mut self) {
         // Assumes regular filesystem

--- a/src/core/camera_database.rs
+++ b/src/core/camera_database.rs
@@ -1,0 +1,90 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct BrandInfo {
+    pub name: String,
+    pub models: Vec<String>,
+    pub lenses: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CameraDatabase {
+    pub version: String,
+    pub updated_at: String,
+    pub brands: Vec<BrandInfo>,
+}
+
+impl CameraDatabase {
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+
+    pub fn load_default() -> Self {
+        let json_bytes = include_bytes!("../../resources/camera_database.json");
+        if let Ok(str_val) = std::str::from_utf8(json_bytes) {
+            if let Ok(db) = Self::from_json(str_val) {
+                return db;
+            }
+        }
+        Self::default()
+    }
+
+    pub fn get_camera_brands(&self) -> Vec<String> {
+        let mut brands: Vec<String> = self.brands.iter().map(|b| b.name.clone()).collect();
+        brands.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+        brands.dedup();
+        brands
+    }
+
+    pub fn get_camera_models(&self, brand: &str) -> Vec<String> {
+        let brand_lc = brand.trim().to_lowercase();
+        let mut models = HashSet::new();
+        for b in &self.brands {
+            if brand_lc.is_empty() || b.name.to_lowercase() == brand_lc {
+                for m in &b.models {
+                    models.insert(m.clone());
+                }
+            }
+        }
+        let mut list: Vec<String> = models.into_iter().collect();
+        list.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+        list
+    }
+
+    pub fn get_lens_models(&self, brand: &str, _model: &str) -> Vec<String> {
+        let brand_lc = brand.trim().to_lowercase();
+        let mut lenses = HashSet::new();
+        for b in &self.brands {
+            if brand_lc.is_empty() || b.name.to_lowercase() == brand_lc {
+                for l in &b.lenses {
+                    lenses.insert(l.clone());
+                }
+            }
+        }
+        let mut list: Vec<String> = lenses.into_iter().collect();
+        list.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+        list
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_camera_database_loading() {
+        let db = CameraDatabase::load_default();
+        assert!(!db.brands.is_empty());
+
+        let brands = db.get_camera_brands();
+        assert!(brands.contains(&"Sony".to_string()));
+        assert!(brands.contains(&"GoPro".to_string()));
+
+        let sony_models = db.get_camera_models("Sony");
+        assert!(sony_models.contains(&"A7IV".to_string()));
+
+        let sony_lenses = db.get_lens_models("Sony", "A7IV");
+        assert!(sony_lenses.contains(&"FE 24mm F1.4 GM".to_string()));
+    }
+}

--- a/src/core/lens_profile.rs
+++ b/src/core/lens_profile.rs
@@ -101,14 +101,58 @@ impl LensProfile {
         lens
     }
 
+    pub fn compute_checksum(&self) -> Option<String> {
+        let to_checksum = format!("{}|{}{}|{:.8}{:.8}|{:.8}{:.8}|{:.8}{:.8}{:.8}{:.8}",
+            self.identifier,
+
+            self.calib_dimension.w,
+            self.calib_dimension.h,
+
+            self.fisheye_params.camera_matrix.get(0)?.get(0)?,
+            self.fisheye_params.camera_matrix.get(1)?.get(1)?,
+            self.fisheye_params.camera_matrix.get(0)?.get(2)?,
+            self.fisheye_params.camera_matrix.get(1)?.get(2)?,
+
+            self.fisheye_params.distortion_coeffs.get(0).unwrap_or(&0.0),
+            self.fisheye_params.distortion_coeffs.get(1).unwrap_or(&0.0),
+            self.fisheye_params.distortion_coeffs.get(2).unwrap_or(&0.0),
+            self.fisheye_params.distortion_coeffs.get(3).unwrap_or(&0.0)
+        );
+
+        Some(format!("{:08x}", crc32fast::hash(to_checksum.as_bytes())))
+    }
+
+    pub fn is_valid(&self) -> bool {
+        if self.fisheye_params.camera_matrix.is_empty()
+            || self.calib_dimension.w == 0
+            || self.calib_dimension.h == 0
+        {
+            return false;
+        }
+
+        if let Some(ref expected_checksum) = self.checksum {
+            if let Some(computed) = self.compute_checksum() {
+                if expected_checksum != &computed {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
     pub fn load_from_data(&mut self, data: &str) -> std::result::Result<(), crate::GyroflowCoreError> {
         *self = Self::from_json(&data)?;
 
         // Trust lens profiles loaded from file
         self.official = true;
 
-        if self.calibrator_version.is_empty() || self.fisheye_params.camera_matrix.is_empty() || self.calib_dimension.w <= 0 || self.calib_dimension.h <= 0 {
+        if !self.is_valid() {
             return Err(crate::GyroflowCoreError::InvalidData);
+        }
+
+        if self.checksum.is_none() {
+            self.checksum = self.compute_checksum();
         }
 
         Ok(())
@@ -598,5 +642,74 @@ impl LensProfile {
             }
             self.parsed_interpolations = interpolations;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_valid_json() -> String {
+        serde_json::json!({
+            "name": "Test Camera",
+            "camera_brand": "Sony",
+            "camera_model": "A7IV",
+            "lens_model": "24mm f1.4",
+            "calibrator_version": "1.5.0",
+            "calib_dimension": { "w": 3840, "h": 2160 },
+            "orig_dimension": { "w": 3840, "h": 2160 },
+            "fisheye_params": {
+                "RMS_error": 0.15,
+                "camera_matrix": [
+                    [1000.0, 0.0, 1920.0],
+                    [0.0, 1000.0, 1080.0],
+                    [0.0, 0.0, 1.0]
+                ],
+                "distortion_coeffs": [0.1, -0.05, 0.01, -0.001]
+            }
+        }).to_string()
+    }
+
+    #[test]
+    fn test_valid_lens_profile_loading() {
+        let json = sample_valid_json();
+        let mut profile = LensProfile::default();
+        assert!(profile.load_from_data(&json).is_ok());
+        assert!(profile.is_valid());
+        assert!(profile.checksum.is_some());
+    }
+
+    #[test]
+    fn test_valid_empty_calibrator_version_legacy() {
+        let mut val: serde_json::Value = serde_json::from_str(&sample_valid_json()).unwrap();
+        val["calibrator_version"] = serde_json::Value::String("".into());
+        let mut profile = LensProfile::default();
+        assert!(profile.load_from_data(&val.to_string()).is_ok());
+        assert!(profile.is_valid());
+    }
+
+    #[test]
+    fn test_invalid_empty_camera_matrix() {
+        let mut val: serde_json::Value = serde_json::from_str(&sample_valid_json()).unwrap();
+        val["fisheye_params"]["camera_matrix"] = serde_json::Value::Array(vec![]);
+        let mut profile = LensProfile::default();
+        assert!(profile.load_from_data(&val.to_string()).is_err());
+    }
+
+    #[test]
+    fn test_invalid_calib_dimension() {
+        let mut val: serde_json::Value = serde_json::from_str(&sample_valid_json()).unwrap();
+        val["calib_dimension"]["w"] = serde_json::Value::Number(0.into());
+        let mut profile = LensProfile::default();
+        assert!(profile.load_from_data(&val.to_string()).is_err());
+    }
+
+    #[test]
+    fn test_invalid_checksum_rejection() {
+        let json = sample_valid_json();
+        let mut profile = LensProfile::default();
+        assert!(profile.load_from_data(&json).is_ok());
+        profile.checksum = Some("badchecksum123".into());
+        assert!(!profile.is_valid());
     }
 }

--- a/src/core/lens_profile_database.rs
+++ b/src/core/lens_profile_database.rs
@@ -19,19 +19,34 @@ enum DataSource {
 #[derive(Default)]
 pub struct LensProfileDatabase {
     preset_map: HashMap<String, String>,
-    map: HashMap<String, LensProfile>,
+    pub map: HashMap<String, LensProfile>,
     loaded_callbacks: Vec<Box<dyn FnOnce(&Self) + Send + Sync + 'static>>,
     list_for_ui: Vec<(String, String, String, bool, f64, i32, String)>,
     pub loaded: bool,
     pub version: u32,
+    pub camera_db: crate::camera_database::CameraDatabase,
 }
 impl Clone for LensProfileDatabase {
     fn clone(&self) -> Self {
-        Self { map: self.map.clone(), preset_map: self.preset_map.clone(), loaded: self.loaded, ..Default::default() }
+        Self { map: self.map.clone(), preset_map: self.preset_map.clone(), loaded: self.loaded, camera_db: self.camera_db.clone(), ..Default::default() }
     }
 }
 
 impl LensProfileDatabase {
+    pub fn cameras(&self) -> Vec<String> {
+        let mut cams: Vec<String> = self.map.values().map(|p| p.camera_model.clone()).collect();
+        cams.sort();
+        cams.dedup();
+        cams
+    }
+
+    pub fn lenses(&self) -> Vec<String> {
+        let mut lens_list: Vec<String> = self.map.values().map(|p| p.lens_model.clone()).collect();
+        lens_list.sort();
+        lens_list.dedup();
+        lens_list
+    }
+
     pub fn get_path() -> PathBuf {
         // return std::fs::canonicalize("D:/lens_review/").unwrap_or_default();
 
@@ -109,27 +124,9 @@ impl LensProfileDatabase {
                                 // std::fs::write(f_name, serde_json::to_string_pretty(&prof).unwrap()).unwrap();
                             }
                         } else {
-                            (|| -> Option<()> {
-                                let to_checksum = format!("{}|{}{}|{:.8}{:.8}|{:.8}{:.8}|{:.8}{:.8}{:.8}{:.8}",
-                                    profile.identifier,
-
-                                    profile.calib_dimension.w,
-                                    profile.calib_dimension.h,
-
-                                    profile.fisheye_params.camera_matrix.get(0)?.get(0)?,
-                                    profile.fisheye_params.camera_matrix.get(1)?.get(1)?,
-                                    profile.fisheye_params.camera_matrix.get(0)?.get(2)?,
-                                    profile.fisheye_params.camera_matrix.get(1)?.get(2)?,
-
-                                    profile.fisheye_params.distortion_coeffs.get(0).unwrap_or(&0.0),
-                                    profile.fisheye_params.distortion_coeffs.get(1).unwrap_or(&0.0),
-                                    profile.fisheye_params.distortion_coeffs.get(2).unwrap_or(&0.0),
-                                    profile.fisheye_params.distortion_coeffs.get(3).unwrap_or(&0.0)
-                                );
-
-                                profile.checksum = Some(format!("{:08x}", crc32fast::hash(to_checksum.as_bytes())));
-                                Some(())
-                            })();
+                            if profile.checksum.is_none() {
+                                profile.checksum = profile.compute_checksum();
+                            }
                             self.map.insert(key, profile);
                         }
                     }
@@ -390,6 +387,74 @@ impl LensProfileDatabase {
         }
     }
 
+    pub fn get_camera_list(&self) -> Vec<String> {
+        let mut cameras = HashSet::new();
+        for brand in &self.camera_db.brands {
+            for model in &brand.models {
+                cameras.insert(format!("{} {}", brand.name, model));
+            }
+        }
+        for profile in self.map.values() {
+            let cam = if !profile.camera_brand.is_empty() && !profile.camera_model.is_empty() {
+                format!("{} {}", profile.camera_brand, profile.camera_model)
+            } else if !profile.camera_model.is_empty() {
+                profile.camera_model.clone()
+            } else if !profile.camera_brand.is_empty() {
+                profile.camera_brand.clone()
+            } else {
+                continue;
+            };
+            let cam = cam.trim().to_string();
+            if !cam.is_empty() {
+                cameras.insert(cam);
+            }
+        }
+        let mut list: Vec<String> = cameras.into_iter().collect();
+        list.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+        list
+    }
+
+    pub fn get_lens_list(&self, camera: &str) -> Vec<String> {
+        let camera_lc = camera.trim().to_lowercase();
+        let mut lenses = HashSet::new();
+        for brand in &self.camera_db.brands {
+            for model in &brand.models {
+                let full_cam = format!("{} {}", brand.name, model).to_lowercase();
+                if camera_lc.is_empty()
+                    || full_cam == camera_lc
+                    || brand.name.to_lowercase() == camera_lc
+                    || model.to_lowercase() == camera_lc
+                    || full_cam.contains(&camera_lc)
+                    || camera_lc.contains(&full_cam)
+                {
+                    for lens in &brand.lenses {
+                        lenses.insert(lens.clone());
+                    }
+                }
+            }
+        }
+        for profile in self.map.values() {
+            let full_cam = format!("{} {}", profile.camera_brand, profile.camera_model).trim().to_lowercase();
+            let brand_lc = profile.camera_brand.trim().to_lowercase();
+            let model_lc = profile.camera_model.trim().to_lowercase();
+
+            if camera_lc.is_empty()
+                || full_cam == camera_lc
+                || brand_lc == camera_lc
+                || model_lc == camera_lc
+                || full_cam.contains(&camera_lc)
+                || camera_lc.contains(&full_cam)
+            {
+                if !profile.lens_model.is_empty() {
+                    lenses.insert(profile.lens_model.clone());
+                }
+            }
+        }
+        let mut list: Vec<String> = lenses.into_iter().collect();
+        list.sort_by(|a, b| a.to_lowercase().cmp(&b.to_lowercase()));
+        list
+    }
+
     // -------------------------------------------------------------------
     // ---------------------- Maintenance functions ----------------------
     // -------------------------------------------------------------------
@@ -530,5 +595,58 @@ impl LensProfileDatabase {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_lens_profile_database_camera_and_lens_list() {
+        let mut db = LensProfileDatabase::default();
+        
+        let json1 = serde_json::json!({
+            "camera_brand": "Sony",
+            "camera_model": "A7IV",
+            "lens_model": "FE 24mm F1.4 GM",
+            "calibrator_version": "1.5.0",
+            "calib_dimension": { "w": 3840, "h": 2160 },
+            "fisheye_params": {
+                "RMS_error": 0.1,
+                "camera_matrix": [[1000.0, 0.0, 1920.0], [0.0, 1000.0, 1080.0], [0.0, 0.0, 1.0]],
+                "distortion_coeffs": [0.0, 0.0, 0.0, 0.0]
+            }
+        }).to_string();
+
+        let json2 = serde_json::json!({
+            "camera_brand": "GoPro",
+            "camera_model": "HERO11 Black",
+            "lens_model": "Wide",
+            "calibrator_version": "1.5.0",
+            "calib_dimension": { "w": 3840, "h": 2160 },
+            "fisheye_params": {
+                "RMS_error": 0.1,
+                "camera_matrix": [[1000.0, 0.0, 1920.0], [0.0, 1000.0, 1080.0], [0.0, 0.0, 1.0]],
+                "distortion_coeffs": [0.0, 0.0, 0.0, 0.0]
+            }
+        }).to_string();
+
+        let mut p1 = LensProfile::default();
+        p1.load_from_data(&json1).unwrap();
+        db.map.insert("sony-a7iv".into(), p1);
+
+        let mut p2 = LensProfile::default();
+        p2.load_from_data(&json2).unwrap();
+        db.map.insert("gopro-hero11".into(), p2);
+
+        let cameras = db.get_camera_list();
+        assert_eq!(cameras, vec!["GoPro HERO11 Black", "Sony A7IV"]);
+
+        let sony_lenses = db.get_lens_list("Sony A7IV");
+        assert_eq!(sony_lenses, vec!["FE 24mm F1.4 GM"]);
+
+        let gopro_lenses = db.get_lens_list("GoPro");
+        assert_eq!(gopro_lenses, vec!["Wide"]);
     }
 }

--- a/src/core/lib.rs
+++ b/src/core/lib.rs
@@ -6,6 +6,7 @@ pub mod gyro_source;
 pub mod imu_integration;
 pub mod lens_profile;
 pub mod lens_profile_database;
+pub mod camera_database;
 #[cfg(feature = "opencv")]
 pub mod calibration;
 pub mod synchronization;
@@ -276,13 +277,31 @@ impl StabilizationManager {
         };
         let db = self.lens_profile_db.read();
         let (result, from_db) = if let Some(lens) = db.get_by_id(&url) {
-            *self.lens.write() = lens.clone();
-            (Ok(()), true)
+            if !lens.is_valid() {
+                (Err(crate::GyroflowCoreError::InvalidData), true)
+            } else {
+                *self.lens.write() = lens.clone();
+                (Ok(()), true)
+            }
         } else if url.starts_with('{') {
-            (self.lens.write().load_from_data(&url), false)
+            let res = self.lens.write().load_from_data(&url);
+            if res.is_ok() && !self.lens.read().is_valid() {
+                (Err(crate::GyroflowCoreError::InvalidData), false)
+            } else {
+                (res, false)
+            }
         } else {
-            (self.lens.write().load_from_file(&url), false)
+            let res = self.lens.write().load_from_file(&url);
+            if res.is_ok() && !self.lens.read().is_valid() {
+                (Err(crate::GyroflowCoreError::InvalidData), false)
+            } else {
+                (res, false)
+            }
         };
+
+        if result.is_err() {
+            return result;
+        }
         let (width, height, aspect, id, fps) = {
             let params = self.params.read();
             (params.size.0, params.size.1, ((params.size.0 * 100) as f64 / params.size.1.max(1) as f64).round() as u32, self.camera_id.read().as_ref().map(|x| x.get_identifier_for_autoload()).unwrap_or_default(), (params.fps * 100.0).round() as i32)
@@ -2138,4 +2157,59 @@ pub enum GyroflowCoreError {
 
     #[error("Unknown error")]
     Unknown
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_profile_json(brand: &str, model: &str, identifier: &str, w: usize, h: usize, fps: f64) -> String {
+        serde_json::json!({
+            "name": format!("{} {}", brand, model),
+            "camera_brand": brand,
+            "camera_model": model,
+            "lens_model": "Standard",
+            "identifier": identifier,
+            "calibrator_version": "1.5.0",
+            "calib_dimension": { "w": w, "h": h },
+            "orig_dimension": { "w": w, "h": h },
+            "fps": fps,
+            "fisheye_params": {
+                "RMS_error": 0.1,
+                "camera_matrix": [[1000.0, 0.0, (w/2) as f64], [0.0, 1000.0, (h/2) as f64], [0.0, 0.0, 1.0]],
+                "distortion_coeffs": [0.0, 0.0, 0.0, 0.0]
+            }
+        }).to_string()
+    }
+
+    #[test]
+    fn test_load_lens_profile_valid_and_invalid() {
+        let manager = StabilizationManager::default();
+
+        let valid_json = valid_profile_json("Sony", "A7IV", "sony-a7iv-standard", 3840, 2160, 60.0);
+        assert!(manager.load_lens_profile(&valid_json).is_ok());
+        assert!(manager.lens.read().is_valid());
+
+        let invalid_json = serde_json::json!({
+            "name": "Invalid Profile",
+            "camera_brand": "Sony",
+            "calibrator_version": "",
+            "calib_dimension": { "w": 0, "h": 0 },
+            "fisheye_params": { "camera_matrix": [] }
+        }).to_string();
+
+        assert!(manager.load_lens_profile(&invalid_json).is_err());
+    }
+
+    #[test]
+    fn test_load_lens_profile_fallback_cascade() {
+        let manager = StabilizationManager::default();
+
+        let json = valid_profile_json("GoPro", "HERO11 Black", "gopro-hero11black-wide", 3840, 2160, 60.0);
+        let res = manager.load_lens_profile(&json);
+        assert!(res.is_ok());
+        let lens = manager.lens.read();
+        assert_eq!(lens.camera_brand, "GoPro");
+        assert_eq!(lens.camera_model, "HERO11 Black");
+    }
 }

--- a/src/ui/components/TableList.qml
+++ b/src/ui/components/TableList.qml
@@ -17,6 +17,7 @@ Row {
     property var editableKeys: Object.keys(editableFields);
 
     signal commitAll();
+    signal cameraLensSelected(string camera, string lens);
 
     function updateEntry(key: string, value: string): void {
         model[key] = value;
@@ -97,8 +98,9 @@ Row {
         Row {
             id: editableItm;
             spacing: 5 * dpiScale;
-            Item { width: 1; height: 1; visible: newValue.visible; }
+            Item { width: 1; height: 1; visible: newValue.visible || newComboValue.visible; }
             property var desc: tl.editableFields[name];
+
             NumberField {
                 id: newValue;
                 visible: false;
@@ -120,26 +122,86 @@ Row {
                     function onCommitAll(): void { if (newValue.visible) newValue.accepted(); }
                 }
             }
+
+            ComboBox {
+                id: newComboValue;
+                visible: false;
+                x: 5 * dpiScale;
+                anchors.verticalCenter: parent.verticalCenter;
+                height: parent.height + 8 * dpiScale;
+                width: (desc && desc.width ? desc.width : 120) * dpiScale;
+                editable: true;
+                model: (desc && typeof desc.options === "function") ? desc.options() : (desc && desc.options ? desc.options : []);
+
+                onVisibleChanged: {
+                    if (visible) {
+                        model = (desc && typeof desc.options === "function") ? desc.options() : (desc && desc.options ? desc.options : []);
+                        let val = (desc && desc.value) ? desc.value() : "";
+                        let idx = find(val);
+                        if (idx !== -1) {
+                            currentIndex = idx;
+                        } else {
+                            editText = val;
+                        }
+                    }
+                }
+
+                onAccepted: {
+                    visible = false;
+                    parent.parent.parent.children[0].visible = true;
+                    if (desc && desc.onChange) {
+                        desc.onChange(editText.trim());
+                    }
+                }
+
+                onActivated: {
+                    visible = false;
+                    parent.parent.parent.children[0].visible = true;
+                    if (desc && desc.onChange) {
+                        desc.onChange(currentText.trim());
+                    }
+                }
+
+                Connections {
+                    target: tl;
+                    function onCommitAll(): void { if (newComboValue.visible) newComboValue.accepted(); }
+                }
+            }
+
             LinkButton {
                 id: editLinkBtn;
                 anchors.verticalCenter: parent.verticalCenter;
-                iconName: newValue.visible? "checkmark" : "pencil";
+                iconName: (newValue.visible || newComboValue.visible) ? "checkmark" : "pencil";
                 icon.height: parent.height * 0.8;
                 icon.width: parent.height * 0.8;
                 opacity: editLinkBtn.activeFocus ? 0.8 : 1;
-                height: newValue.visible? newValue.height + 5 * dpiScale : undefined;
-                leftPadding: newValue.visible? 15 * dpiScale : 0; rightPadding: leftPadding;
+                height: (newValue.visible || newComboValue.visible) ? (newValue.visible ? newValue.height : newComboValue.height) + 5 * dpiScale : undefined;
+                leftPadding: (newValue.visible || newComboValue.visible) ? 15 * dpiScale : 0;
+                rightPadding: leftPadding;
 
                 function _onClicked(): void {
-                    if (newValue.visible) {
-                        newValue.accepted();
+                    if (desc && desc["type"] === "combobox") {
+                        if (newComboValue.visible) {
+                            newComboValue.accepted();
+                        } else {
+                            newComboValue.visible = true;
+                            parent.parent.parent.children[0].visible = false;
+                            newComboValue.focus = true;
+                            if (newComboValue.popup) {
+                                newComboValue.popup.open();
+                            }
+                        }
                     } else {
-                        const val = desc.value();
-                        if (typeof val === "string") newValue.text = val;
-                        else newValue.value = val;
-                        newValue.visible = true;
-                        parent.parent.parent.children[0].visible = false;
-                        newValue.focus = true;
+                        if (newValue.visible) {
+                            newValue.accepted();
+                        } else {
+                            const val = desc.value();
+                            if (typeof val === "string") newValue.text = val;
+                            else newValue.value = val;
+                            newValue.visible = true;
+                            parent.parent.parent.children[0].visible = false;
+                            newValue.focus = true;
+                        }
                     }
                 }
 
@@ -149,11 +211,13 @@ Row {
 
             }
             Component.onCompleted: {
-                if (desc.hasOwnProperty("from"))      newValue.from      = desc.from;
-                if (desc.hasOwnProperty("to"))        newValue.to        = desc.to;
-                if (desc.hasOwnProperty("unit"))      newValue.unit      = desc.unit;
-                if (desc.hasOwnProperty("precision")) newValue.precision = desc.precision;
-                if (desc["type"] == "text")           newValue.allowText = true;
+                if (desc) {
+                    if (desc.hasOwnProperty("from"))      newValue.from      = desc.from;
+                    if (desc.hasOwnProperty("to"))        newValue.to        = desc.to;
+                    if (desc.hasOwnProperty("unit"))      newValue.unit      = desc.unit;
+                    if (desc.hasOwnProperty("precision")) newValue.precision = desc.precision;
+                    if (desc["type"] == "text")           newValue.allowText = true;
+                }
             }
         }
     }

--- a/src/ui/menu/VideoInformation.qml
+++ b/src/ui/menu/VideoInformation.qml
@@ -181,6 +181,41 @@ MenuItem {
         id: list;
         columnSpacing: 6 * dpiScale;
         editableFields: isCalibrator? ({}) : ({
+            "Detected camera": {
+                "type": "combobox",
+                "width": 140,
+                "value": function() {
+                    return list.model["Detected camera"] || "---";
+                },
+                "options": function() {
+                    return (typeof controller !== "undefined" && controller.get_camera_list) ? controller.get_camera_list() : [];
+                },
+                "onChange": function(value) {
+                    root.updateEntry("Detected camera", value);
+                    if (typeof controller !== "undefined" && controller.select_camera) {
+                        controller.select_camera(value);
+                    }
+                    list.cameraLensSelected(value, list.model["Detected lens"] || "");
+                }
+            },
+            "Detected lens": {
+                "type": "combobox",
+                "width": 160,
+                "value": function() {
+                    return list.model["Detected lens"] || "---";
+                },
+                "options": function() {
+                    let currentCam = list.model["Detected camera"] || "";
+                    return (typeof controller !== "undefined" && controller.get_lens_list) ? controller.get_lens_list(currentCam) : [];
+                },
+                "onChange": function(value) {
+                    root.updateEntry("Detected lens", value);
+                    if (typeof controller !== "undefined" && controller.load_lens_profile) {
+                        controller.load_lens_profile(value);
+                    }
+                    list.cameraLensSelected(list.model["Detected camera"] || "", value);
+                }
+            },
             "Rotation": {
                 "unit": "°",
                 "from": -360,


### PR DESCRIPTION
Populate camera and lens selector options in QML UI directly from loaded metadata.

Closes #742
@algora-pbc /claim #742