### PR TITLE
core/gpu: fix host Metal command queue lifetime handling, FFI-reachable panics, and env var races

### DIFF
--- a/src/core/gpu/mod.rs
+++ b/src/core/gpu/mod.rs
@@ -13,6 +13,58 @@ pub mod wgpu_interop;
 
 pub mod drawing;
 use std::hash::Hasher;
+use std::sync::atomic::{ AtomicBool, Ordering };
+use std::sync::OnceLock;
+
+/// GPU backends whose availability can be toggled at runtime.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Backend {
+    OpenCL,
+    Wgpu,
+    Metal,
+}
+
+// Runtime override flags. These are the race-free replacement for reading the
+// NO_OPENCL / NO_WGPU / NO_METAL environment variables on render threads: the host
+// can flip a backend off from any thread via `set_backend_disabled` and it is picked
+// up atomically, without the data race caused by std::env::set_var on other platforms.
+static DISABLE_OPENCL: AtomicBool = AtomicBool::new(false);
+static DISABLE_WGPU: AtomicBool = AtomicBool::new(false);
+static DISABLE_METAL: AtomicBool = AtomicBool::new(false);
+
+fn backend_flag(backend: Backend) -> &'static AtomicBool {
+    match backend {
+        Backend::OpenCL => &DISABLE_OPENCL,
+        Backend::Wgpu => &DISABLE_WGPU,
+        Backend::Metal => &DISABLE_METAL,
+    }
+}
+
+fn backend_env_disabled(backend: Backend) -> bool {
+    // Read the environment variable exactly once and cache it, so render threads
+    // never call getenv concurrently with a host set_var (which is UB on Unix).
+    static OPENCL: OnceLock<bool> = OnceLock::new();
+    static WGPU: OnceLock<bool> = OnceLock::new();
+    static METAL: OnceLock<bool> = OnceLock::new();
+    let (cell, var) = match backend {
+        Backend::OpenCL => (&OPENCL, "NO_OPENCL"),
+        Backend::Wgpu => (&WGPU, "NO_WGPU"),
+        Backend::Metal => (&METAL, "NO_METAL"),
+    };
+    *cell.get_or_init(|| !std::env::var(var).unwrap_or_default().is_empty())
+}
+
+/// Disable or re-enable a GPU backend at runtime. Thread-safe and race-free;
+/// subsequent calls to `is_backend_disabled` observe the new value.
+pub fn set_backend_disabled(backend: Backend, disabled: bool) {
+    backend_flag(backend).store(disabled, Ordering::SeqCst);
+}
+
+/// Whether a GPU backend is currently disabled, combining the runtime flag with the
+/// (once-read) NO_OPENCL / NO_WGPU / NO_METAL environment variable.
+pub fn is_backend_disabled(backend: Backend) -> bool {
+    backend_flag(backend).load(Ordering::SeqCst) || backend_env_disabled(backend)
+}
 
 #[derive(Debug, Default)]
 pub struct BufferDescription<'a> {
@@ -151,7 +203,7 @@ impl<'a> Buffers<'a> {
 
 pub fn initialize_contexts() -> Option<(String, String)> {
     #[cfg(feature = "use-opencl")]
-    if std::env::var("NO_OPENCL").unwrap_or_default().is_empty() {
+    if !is_backend_disabled(Backend::OpenCL) {
         let cl = std::panic::catch_unwind(|| {
             opencl::OclWrapper::initialize_context(None)
         });
@@ -170,7 +222,7 @@ pub fn initialize_contexts() -> Option<(String, String)> {
         }
     }
 
-    if std::env::var("NO_WGPU").unwrap_or_default().is_empty() {
+    if !is_backend_disabled(Backend::Wgpu) {
         let wgpu = std::panic::catch_unwind(|| {
             wgpu::WgpuWrapper::initialize_context()
         });

--- a/src/core/gpu/wgpu.rs
+++ b/src/core/gpu/wgpu.rs
@@ -42,12 +42,13 @@ pub struct WgpuWrapper  {
     queue: wgpu::Queue,
     pub device: wgpu::Device,
 
-    // True when `device`/`queue` were built from a command queue owned by the host
-    // application (via queue_from_raw). In that case we must never drive GPU work on
-    // that queue outside of an active host render call, otherwise committing on a
-    // queue the host has since torn down crashes (observed on Metal in DaVinci Resolve
-    // when switching pages). See the Drop impl below.
-    host_queue: bool,
+    // Set to the host command queue pointer when `device`/`queue` were built from a
+    // queue owned by the host application (via queue_from_raw), otherwise None. When set,
+    // we must never drive GPU work on that queue outside of an active host render call,
+    // otherwise committing on a queue the host has since torn down crashes (observed on
+    // Metal in DaVinci Resolve when switching pages). See the Drop impl below. The pointer
+    // is also used by the cache to evict wrappers bound to a stale host queue.
+    pub host_queue_ptr: Option<u64>,
 
     pixel_format: wgpu::TextureFormat,
     padded_out_stride: u32,
@@ -73,7 +74,7 @@ impl Drop for WgpuWrapper {
         // polling would commit/wait on a queue whose lifetime is controlled by the host
         // and may already be torn down (e.g. after a Resolve page switch), which crashes
         // inside the Metal driver. Just drop the wrapped device/queue handles instead.
-        if !self.host_queue {
+        if self.host_queue_ptr.is_none() {
             let _ = self.device.poll(wgpu::PollType::Wait { submission_index: None, timeout: None });
         }
     }
@@ -187,7 +188,7 @@ impl WgpuWrapper {
 
         if let Some(adapter) = lock.get(adapter_id) {
             log::debug!("WGPU initializing adapter #{adapter_id}: {:?}", adapter.get_info());
-            let (device, queue, host_queue) = match &buffers.input.data {
+            let (device, queue, host_queue_ptr) = match &buffers.input.data {
                 #[cfg(any(target_os = "macos", target_os = "ios"))]
                 BufferSource::Metal { command_queue, .. } |
                 BufferSource::MetalBuffer { command_queue, .. } if !(*command_queue).is_null() => {
@@ -223,7 +224,7 @@ impl WgpuWrapper {
                             memory_hints: wgpu::MemoryHints::Performance,
                             trace: wgpu::Trace::Off,
                             experimental_features: wgpu::ExperimentalFeatures::disabled(),
-                        }).map(|(device, queue)| (device, queue, true)).map_err(|e| WgpuError::RequestDevice(e))?
+                        }).map(|(device, queue)| (device, queue, Some(*command_queue as u64))).map_err(|e| WgpuError::RequestDevice(e))?
                     }
                 },
                 _ => {
@@ -267,7 +268,7 @@ impl WgpuWrapper {
                         break;
                     }
                     let (device, queue) = result?;
-                    (device, queue, false)
+                    (device, queue, None)
                 }
             };
 
@@ -446,7 +447,7 @@ impl WgpuWrapper {
             Ok(Self {
                 device,
                 queue,
-                host_queue,
+                host_queue_ptr,
                 staging_buffer: Some(staging_buffer),
                 out_texture,
                 in_texture,

--- a/src/core/gpu/wgpu.rs
+++ b/src/core/gpu/wgpu.rs
@@ -17,6 +17,7 @@ pub enum WgpuError {
     RequestDevice(wgpu::RequestDeviceError),
     ParamCheck,
     NoAvailableAdapter,
+    NullCommandQueue,
 }
 
 enum PipelineType {
@@ -184,7 +185,8 @@ impl WgpuWrapper {
                         use wgpu::hal::api::Metal;
 
                         let mtl_cq: Retained<ProtocolObject<dyn MTLCommandQueue>> =
-                            Retained::retain(*command_queue as *mut ProtocolObject<dyn MTLCommandQueue>).unwrap();
+                            Retained::retain(*command_queue as *mut ProtocolObject<dyn MTLCommandQueue>)
+                                .ok_or(WgpuError::NullCommandQueue)?;
                         let mtl_dev = mtl_cq.device();
 
                         let max_buffer_bits = if cfg!(any(target_os = "android", target_os = "ios")) { 29 } else { 31 };

--- a/src/core/gpu/wgpu.rs
+++ b/src/core/gpu/wgpu.rs
@@ -42,6 +42,13 @@ pub struct WgpuWrapper  {
     queue: wgpu::Queue,
     pub device: wgpu::Device,
 
+    // True when `device`/`queue` were built from a command queue owned by the host
+    // application (via queue_from_raw). In that case we must never drive GPU work on
+    // that queue outside of an active host render call, otherwise committing on a
+    // queue the host has since torn down crashes (observed on Metal in DaVinci Resolve
+    // when switching pages). See the Drop impl below.
+    host_queue: bool,
+
     pixel_format: wgpu::TextureFormat,
     padded_out_stride: u32,
     in_size: u64,
@@ -62,7 +69,13 @@ impl Drop for WgpuWrapper {
         self.pipeline = PipelineType::None;
         self.bind_group = None;
 
-        let _ = self.device.poll(wgpu::PollType::Wait { submission_index: None, timeout: None });
+        // Only poll when we own the queue. For host-provided queues (queue_from_raw),
+        // polling would commit/wait on a queue whose lifetime is controlled by the host
+        // and may already be torn down (e.g. after a Resolve page switch), which crashes
+        // inside the Metal driver. Just drop the wrapped device/queue handles instead.
+        if !self.host_queue {
+            let _ = self.device.poll(wgpu::PollType::Wait { submission_index: None, timeout: None });
+        }
     }
 }
 
@@ -174,7 +187,7 @@ impl WgpuWrapper {
 
         if let Some(adapter) = lock.get(adapter_id) {
             log::debug!("WGPU initializing adapter #{adapter_id}: {:?}", adapter.get_info());
-            let (device, queue) = match &buffers.input.data {
+            let (device, queue, host_queue) = match &buffers.input.data {
                 #[cfg(any(target_os = "macos", target_os = "ios"))]
                 BufferSource::Metal { command_queue, .. } |
                 BufferSource::MetalBuffer { command_queue, .. } if !(*command_queue).is_null() => {
@@ -210,7 +223,7 @@ impl WgpuWrapper {
                             memory_hints: wgpu::MemoryHints::Performance,
                             trace: wgpu::Trace::Off,
                             experimental_features: wgpu::ExperimentalFeatures::disabled(),
-                        }).map_err(|e| WgpuError::RequestDevice(e))?
+                        }).map(|(device, queue)| (device, queue, true)).map_err(|e| WgpuError::RequestDevice(e))?
                     }
                 },
                 _ => {
@@ -253,7 +266,8 @@ impl WgpuWrapper {
                         result = device.map_err(|e| WgpuError::RequestDevice(e));
                         break;
                     }
-                    result?
+                    let (device, queue) = result?;
+                    (device, queue, false)
                 }
             };
 
@@ -432,6 +446,7 @@ impl WgpuWrapper {
             Ok(Self {
                 device,
                 queue,
+                host_queue,
                 staging_buffer: Some(staging_buffer),
                 out_texture,
                 in_texture,

--- a/src/core/gpu/wgpu_interop.rs
+++ b/src/core/gpu/wgpu_interop.rs
@@ -74,6 +74,7 @@ pub fn init_texture(device: &wgpu::Device, backend: wgpu::Backend, buf: &BufferD
                     device.create_texture(&desc)
                 } else {
                     create_texture_from_metal(&device, texture, buf.size.0 as u32, buf.size.1 as u32, format, usage)
+                        .unwrap_or_else(|| device.create_texture(&desc))
                 }),
                 wgpu_buffer: None,
                 native_texture: None
@@ -89,7 +90,7 @@ pub fn init_texture(device: &wgpu::Device, backend: wgpu::Backend, buf: &BufferD
 
                 TextureHolder {
                     wgpu_texture: None,
-                    wgpu_buffer: Some(create_buffer_from_metal(&device, buffer, (buf.size.2 * buf.size.1) as u64, usage)),
+                    wgpu_buffer: create_buffer_from_metal(&device, buffer, (buf.size.2 * buf.size.1) as u64, usage),
                     native_texture: None
                 }
             } else {
@@ -114,6 +115,7 @@ pub fn init_texture(device: &wgpu::Device, backend: wgpu::Backend, buf: &BufferD
                         device.create_texture(&desc)
                     } else {
                         create_texture_from_metal(&device, Retained::as_ptr(native_texture.as_ref().unwrap()) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, usage)
+                            .unwrap_or_else(|| device.create_texture(&desc))
                     }),
                     wgpu_buffer: None,
                     native_texture: native_texture.map(|t| NativeTexture::Metal(SendableMetalTexture(t)))
@@ -317,13 +319,15 @@ pub fn handle_input_texture(device: &wgpu::Device, buf: &BufferDescription, queu
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         BufferSource::Metal { texture, .. } => {
             if buf.texture_copy {
-                temp_texture = Some(create_texture_from_metal(device, *texture, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_SRC));
+                temp_texture = create_texture_from_metal(device, *texture, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_SRC);
 
-                encoder.copy_texture_to_texture(
-                    TexelCopyTextureInfo { texture: temp_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                    TexelCopyTextureInfo { texture: in_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                    size
-                );
+                if let Some(tt) = temp_texture.as_ref() {
+                    encoder.copy_texture_to_texture(
+                        TexelCopyTextureInfo { texture: tt, mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                        TexelCopyTextureInfo { texture: in_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                        size
+                    );
+                }
             }
         },
         #[cfg(not(any(target_os = "macos", target_os = "ios")))]
@@ -343,23 +347,27 @@ pub fn handle_input_texture(device: &wgpu::Device, buf: &BufferDescription, queu
         BufferSource::MetalBuffer { buffer, .. } => {
             if buf.texture_copy {
                 if let Some(NativeTexture::Metal(mtl_texture)) = &in_texture.native_texture {
-                    temp_texture = Some(create_texture_from_metal(device, Retained::as_ptr(&mtl_texture.0) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_SRC));
+                    temp_texture = create_texture_from_metal(device, Retained::as_ptr(&mtl_texture.0) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_SRC);
 
-                    encoder.copy_texture_to_texture(
-                        TexelCopyTextureInfo { texture: temp_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                        TexelCopyTextureInfo { texture: in_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                        size
-                    );
-                } else {
-                    let metal_usage = MTLTextureUsage::ShaderRead;
-                    if let Some(texture) = create_metal_texture_from_buffer(*buffer, buf.size.0 as u32, buf.size.1 as u32, buf.size.2 as u32, format, metal_usage) {
-                        temp_texture = Some(create_texture_from_metal(device, Retained::as_ptr(&texture) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_SRC));
-
+                    if let Some(tt) = temp_texture.as_ref() {
                         encoder.copy_texture_to_texture(
-                            TexelCopyTextureInfo { texture: temp_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                            TexelCopyTextureInfo { texture: tt, mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
                             TexelCopyTextureInfo { texture: in_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
                             size
                         );
+                    }
+                } else {
+                    let metal_usage = MTLTextureUsage::ShaderRead;
+                    if let Some(texture) = create_metal_texture_from_buffer(*buffer, buf.size.0 as u32, buf.size.1 as u32, buf.size.2 as u32, format, metal_usage) {
+                        temp_texture = create_texture_from_metal(device, Retained::as_ptr(&texture) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_SRC);
+
+                        if let Some(tt) = temp_texture.as_ref() {
+                            encoder.copy_texture_to_texture(
+                                TexelCopyTextureInfo { texture: tt, mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                                TexelCopyTextureInfo { texture: in_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                                size
+                            );
+                        }
                     }
                 }
             }
@@ -398,13 +406,15 @@ pub fn handle_output_texture(device: &wgpu::Device, buf: &BufferDescription, _qu
         #[cfg(any(target_os = "macos", target_os = "ios"))]
         BufferSource::Metal { texture, .. } => {
             if buf.texture_copy {
-                temp_texture = Some(create_texture_from_metal(&device, *texture, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_DST));
+                temp_texture = create_texture_from_metal(&device, *texture, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_DST);
 
-                encoder.copy_texture_to_texture(
-                    TexelCopyTextureInfo { texture: out_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                    TexelCopyTextureInfo { texture: temp_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                    size
-                );
+                if let Some(tt) = temp_texture.as_ref() {
+                    encoder.copy_texture_to_texture(
+                        TexelCopyTextureInfo { texture: out_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                        TexelCopyTextureInfo { texture: tt, mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                        size
+                    );
+                }
             }
         },
         #[cfg(not(any(target_os = "macos", target_os = "ios")))]
@@ -424,23 +434,27 @@ pub fn handle_output_texture(device: &wgpu::Device, buf: &BufferDescription, _qu
         BufferSource::MetalBuffer { buffer, .. } => {
             if buf.texture_copy {
                 if let Some(NativeTexture::Metal(mtl_texture)) = &out_texture.native_texture {
-                    temp_texture = Some(create_texture_from_metal(device, Retained::as_ptr(&mtl_texture.0) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_DST));
+                    temp_texture = create_texture_from_metal(device, Retained::as_ptr(&mtl_texture.0) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_DST);
 
-                    encoder.copy_texture_to_texture(
-                        TexelCopyTextureInfo { texture: out_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                        TexelCopyTextureInfo { texture: temp_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                        size
-                    );
+                    if let Some(tt) = temp_texture.as_ref() {
+                        encoder.copy_texture_to_texture(
+                            TexelCopyTextureInfo { texture: out_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                            TexelCopyTextureInfo { texture: tt, mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                            size
+                        );
+                    }
                 } else {
                     let metal_usage = MTLTextureUsage::RenderTarget;
                     if let Some(texture) = create_metal_texture_from_buffer(*buffer, buf.size.0 as u32, buf.size.1 as u32, buf.size.2 as u32, format, metal_usage) {
-                        temp_texture = Some(create_texture_from_metal(device, Retained::as_ptr(&texture) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_DST));
+                        temp_texture = create_texture_from_metal(device, Retained::as_ptr(&texture) as *mut std::ffi::c_void, buf.size.0 as u32, buf.size.1 as u32, format, wgpu::TextureUsages::COPY_DST);
 
-                        encoder.copy_texture_to_texture(
-                            TexelCopyTextureInfo { texture: out_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                            TexelCopyTextureInfo { texture: temp_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
-                            size
-                        );
+                        if let Some(tt) = temp_texture.as_ref() {
+                            encoder.copy_texture_to_texture(
+                                TexelCopyTextureInfo { texture: out_texture.wgpu_texture.as_ref().unwrap(), mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                                TexelCopyTextureInfo { texture: tt, mip_level: 0, origin: Origin3d::ZERO, aspect: TextureAspect::All },
+                                size
+                            );
+                        }
                     }
                 }
             }

--- a/src/core/gpu/wgpu_interop_metal.rs
+++ b/src/core/gpu/wgpu_interop_metal.rs
@@ -8,9 +8,13 @@ use objc2::runtime::ProtocolObject;
 use objc2_metal::*;
 
 pub fn check_metal_stride(device: &Device, format: wgpu::TextureFormat, stride: usize) -> bool {
+    let metal_format = match format_wgpu_to_metal(format) {
+        Some(f) => f,
+        None => { log::error!("Unsupported pixel format for Metal stride check: {format:?}"); return false; }
+    };
     let alignment = unsafe { device.as_hal::<Metal>().and_then(|device| {
         let raw_device = device.raw_device();
-        Some(raw_device.minimumLinearTextureAlignmentForPixelFormat(format_wgpu_to_metal(format)) as usize)
+        Some(raw_device.minimumLinearTextureAlignmentForPixelFormat(metal_format) as usize)
     }).unwrap_or(16) };
 
     if stride % alignment != 0 {
@@ -21,33 +25,49 @@ pub fn check_metal_stride(device: &Device, format: wgpu::TextureFormat, stride: 
 }
 
 pub fn create_metal_texture_from_buffer(buffer: *mut std::ffi::c_void, width: u32, height: u32, stride: u32, format: wgpu::TextureFormat, usage: MTLTextureUsage) -> Option<Retained<ProtocolObject<dyn MTLTexture>>> {
+    if buffer.is_null() {
+        log::error!("create_metal_texture_from_buffer received a null MTLBuffer pointer");
+        return None;
+    }
+    let metal_format = match format_wgpu_to_metal(format) {
+        Some(f) => f,
+        None => { log::error!("Unsupported pixel format for Metal texture: {format:?}"); return None; }
+    };
     let buf: &ProtocolObject<dyn MTLBuffer> = unsafe { &*(buffer as *const ProtocolObject<dyn MTLBuffer>) };
     let texture_descriptor = MTLTextureDescriptor::new();
     unsafe { texture_descriptor.setWidth(width as usize) };
     unsafe { texture_descriptor.setHeight(height as usize) };
     unsafe { texture_descriptor.setDepth(1) };
     texture_descriptor.setTextureType(MTLTextureType::Type2D);
-    texture_descriptor.setPixelFormat(format_wgpu_to_metal(format));
+    texture_descriptor.setPixelFormat(metal_format);
     texture_descriptor.setStorageMode(buf.storageMode());
     texture_descriptor.setUsage(usage | MTLTextureUsage::ShaderRead | MTLTextureUsage::ShaderWrite | MTLTextureUsage::RenderTarget);
 
     buf.newTextureWithDescriptor_offset_bytesPerRow(&texture_descriptor, 0, stride as usize)
 }
 
-fn retain_texture(ptr: *mut std::ffi::c_void) -> Retained<ProtocolObject<dyn MTLTexture>> {
+fn retain_texture(ptr: *mut std::ffi::c_void) -> Option<Retained<ProtocolObject<dyn MTLTexture>>> {
+    if ptr.is_null() {
+        log::error!("retain_texture received a null MTLTexture pointer");
+        return None;
+    }
     unsafe {
         Retained::retain(ptr as *mut ProtocolObject<dyn MTLTexture>)
-    }.unwrap()
+    }
 }
 
-fn retain_buffer(ptr: *mut std::ffi::c_void) -> Retained<ProtocolObject<dyn MTLBuffer>> {
+fn retain_buffer(ptr: *mut std::ffi::c_void) -> Option<Retained<ProtocolObject<dyn MTLBuffer>>> {
+    if ptr.is_null() {
+        log::error!("retain_buffer received a null MTLBuffer pointer");
+        return None;
+    }
     unsafe {
         Retained::retain(ptr as *mut ProtocolObject<dyn MTLBuffer>)
-    }.unwrap()
+    }
 }
 
-pub fn create_texture_from_metal(device: &Device, image: *mut std::ffi::c_void, width: u32, height: u32, format: wgpu::TextureFormat, usage: wgpu::TextureUsages) -> wgpu::Texture {
-    let image = retain_texture(image);
+pub fn create_texture_from_metal(device: &Device, image: *mut std::ffi::c_void, width: u32, height: u32, format: wgpu::TextureFormat, usage: wgpu::TextureUsages) -> Option<wgpu::Texture> {
+    let image = retain_texture(image)?;
 
     let size = wgpu::Extent3d {
         width,
@@ -71,7 +91,7 @@ pub fn create_texture_from_metal(device: &Device, image: *mut std::ffi::c_void, 
         )
     };
 
-    unsafe {
+    Some(unsafe {
         device.create_texture_from_hal::<Metal>(
             texture,
             &wgpu::TextureDescriptor {
@@ -86,13 +106,13 @@ pub fn create_texture_from_metal(device: &Device, image: *mut std::ffi::c_void, 
             },
             wgpu::TextureUses::UNINITIALIZED
         )
-    }
+    })
 }
 
-pub fn create_buffer_from_metal(device: &Device, buffer: *mut std::ffi::c_void, size: u64, usage: wgpu::BufferUsages) -> wgpu::Buffer {
-    let buffer = retain_buffer(buffer);
+pub fn create_buffer_from_metal(device: &Device, buffer: *mut std::ffi::c_void, size: u64, usage: wgpu::BufferUsages) -> Option<wgpu::Buffer> {
+    let buffer = retain_buffer(buffer)?;
     let buffer = unsafe { <Metal as wgpu::hal::Api>::Device::buffer_from_raw(buffer, size) };
-    unsafe {
+    Some(unsafe {
         device.create_buffer_from_hal::<Metal>(
             buffer,
             &wgpu::BufferDescriptor {
@@ -102,13 +122,13 @@ pub fn create_buffer_from_metal(device: &Device, buffer: *mut std::ffi::c_void, 
                 usage,
             },
         )
-    }
+    })
 }
 
-pub fn format_wgpu_to_metal(format: wgpu::TextureFormat) -> MTLPixelFormat {
+pub fn format_wgpu_to_metal(format: wgpu::TextureFormat) -> Option<MTLPixelFormat> {
     use wgpu::TextureFormat as Tf;
     use wgpu::{AstcBlock, AstcChannel};
-    match format {
+    Some(match format {
         Tf::R8Unorm => MTLPixelFormat::R8Unorm,
         Tf::R8Snorm => MTLPixelFormat::R8Snorm,
         Tf::R8Uint => MTLPixelFormat::R8Uint,
@@ -230,6 +250,6 @@ pub fn format_wgpu_to_metal(format: wgpu::TextureFormat) -> MTLPixelFormat {
                 AstcBlock::B12x12 => MTLPixelFormat::ASTC_12x12_HDR,
             },
         },
-        _ => { panic!("Unsupported pixel format {:?}", format); }
-    }
+        _ => { log::error!("Unsupported pixel format {:?}", format); return None; }
+    })
 }

--- a/src/core/stabilization/mod.rs
+++ b/src/core/stabilization/mod.rs
@@ -534,7 +534,22 @@ impl Stabilization {
                     match wgpu {
                         Ok(Ok(wgpu)) => {
                             if self.share_wgpu_instances {
-                                CACHED_WGPU.with(|x| x.0.borrow_mut().put(hash, wgpu));
+                                let current_host_queue = wgpu.host_queue_ptr;
+                                CACHED_WGPU.with(|x| {
+                                    let mut cache = x.0.borrow_mut();
+                                    // Evict any previously cached wrapper bound to a different host
+                                    // command queue. When the host rebuilds its GPU pipeline (e.g. a
+                                    // Resolve page switch) it hands us a new queue; the old wrappers
+                                    // still retain the previous, now-stale queue and must be dropped.
+                                    if let Some(current) = current_host_queue {
+                                        let stale: Vec<u32> = cache.iter()
+                                            .filter(|(_, w)| w.host_queue_ptr.map_or(false, |p| p != current))
+                                            .map(|(k, _)| *k)
+                                            .collect();
+                                        for k in stale { cache.pop(&k); }
+                                    }
+                                    cache.put(hash, wgpu);
+                                });
                             } else {
                                 self.wgpu = Some(wgpu);
                             }

--- a/src/core/stabilization/mod.rs
+++ b/src/core/stabilization/mod.rs
@@ -400,10 +400,10 @@ impl Stabilization {
         let mut ret = Vec::new();
 
         #[cfg(feature = "use-opencl")]
-        if std::env::var("NO_OPENCL").unwrap_or_default().is_empty() {
+        if !is_backend_disabled(Backend::OpenCL) {
             ret.extend(opencl::OclWrapper::list_devices().into_iter().map(|x| format!("[OpenCL] {x}")));
         }
-        if std::env::var("NO_WGPU").unwrap_or_default().is_empty() {
+        if !is_backend_disabled(Backend::Wgpu) {
             ret.extend(wgpu::WgpuWrapper::list_devices().into_iter().map(|x| format!("[wgpu] {x}")));
         }
         ret
@@ -475,7 +475,7 @@ impl Stabilization {
             let mut next_backend = self.next_backend.take().unwrap_or_default();
 
             #[cfg(feature = "use-opencl")]
-            if std::env::var("NO_OPENCL").unwrap_or_default().is_empty() && next_backend != "wgpu" && opencl::is_buffer_supported(buffers) {
+            if !is_backend_disabled(Backend::OpenCL) && next_backend != "wgpu" && opencl::is_buffer_supported(buffers) {
                 if self.share_wgpu_instances && CACHED_OPENCL.with(|x| x.borrow().contains(&hash)) {
                     self.cl = None;
                     self.initialized_backend = BackendType::OpenCL(hash);
@@ -518,7 +518,7 @@ impl Stabilization {
                     }
                 }
             }
-            if self.initialized_backend.is_none() && T::wgpu_format().is_some() && next_backend != "opencl" && std::env::var("NO_WGPU").unwrap_or_default().is_empty() && wgpu::is_buffer_supported(buffers) {
+            if self.initialized_backend.is_none() && T::wgpu_format().is_some() && next_backend != "opencl" && !is_backend_disabled(Backend::Wgpu) && wgpu::is_buffer_supported(buffers) {
                 if self.share_wgpu_instances && CACHED_WGPU.with(|x| x.0.borrow().contains(&hash)) {
                     self.wgpu = None;
                     self.initialized_backend = BackendType::Wgpu(hash);


### PR DESCRIPTION
## Context

DaVinci Resolve Studio 21.0.2 (macOS arm64) crashed with SIGSEGV in `[_MTLCommandQueue commitCommandBuffer:wake:]` on a Gyroflow OFX render thread, during Color page playback right after an Edit -> Color page switch. Companion plugin-side hardening: gyroflow/gyroflow-plugins#61.

Root cause analysis: when the OFX host provides its Metal command queue, `WgpuWrapper` wraps it via `queue_from_raw` and the wrapper is cached (thread-local LRU). Two problems follow:

1. `WgpuWrapper::Drop` unconditionally called `device.poll(Wait)`, which commits/waits on the wrapped queue. For a host-owned queue that the host has since torn down (Resolve rebuilds its GPU pipeline on page switches), that commit crashes inside the Metal driver — matching the observed crash.
2. Stale wrappers bound to an old host queue stay in the LRU cache (retaining the queue and its GPU resources) until aged out.

## Changes

- **gpu/wgpu: don't poll host-provided queues on drop.** New `host_queue_ptr` field, set only when the device is built from a host command queue; `Drop` skips the poll in that case. Internally-owned queues keep the existing poll.
- **stabilization: evict cached wgpu wrappers bound to a stale host queue.** When a render comes in with a different host queue pointer, wrappers bound to the old queue are evicted immediately (their Drop is now safe per the previous commit).
- **gpu/metal: replace FFI-reachable panics with clean error paths.** `Retained::retain(...).unwrap()` on host pointers (command queue, textures, buffers) and the `panic!` tail of `format_wgpu_to_metal` could unwind across the OpenFX C ABI (UB in the host process). These now return `Option`/`Result` with logging; no behavior change in the nominal case.
- **gpu: replace NO_OPENCL/NO_WGPU env reads with race-free runtime flags.** Render threads read these via `std::env::var` while the OFX plugin calls `set_var` at runtime; concurrent `setenv`/`getenv` is UB on Unix. New atomic `set_backend_disabled`/`is_backend_disabled` API; env vars are still honored, read once via `OnceLock`. The plugin side switches to this API in a follow-up to #61.

## Testing

- `cargo check` on gyroflow-core (features `bundle-lens-profiles,use-opencl,cache-gyro-metadata`) clean on macOS arm64 (rustc 1.94.1), rebased on current master.
- The OFX plugin built against this branch loads and renders correctly in Resolve Studio 21.0.2.
- The original crash needs a live Resolve session to reproduce reliably, so the lifetime fixes are validated by analysis + the crash dump rather than a before/after repro. Happy to attach the full crash dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NnShHBDs8UYxcRKSAaZzEF
