### PR TITLE
Fix install-deps when the path contains spaces

### DIFF
--- a/_scripts/windows.just
+++ b/_scripts/windows.just
@@ -16,7 +16,7 @@ install-deps:
     }
 
     mkdir "{{ExtDir}}" -ErrorAction SilentlyContinue
-    cd {{ExtDir}}
+    cd "{{ExtDir}}"
 
     $Python = "python";
     if (Get-Command "python3.10.exe" -ErrorAction SilentlyContinue) {


### PR DESCRIPTION
`just install-deps` fails on Windows whenever the repository sits under a path
containing a space:

```
Set-Location : A positional parameter cannot be found that accepts argument 'Sclosa\Projetos\gyroflow\gyroflow\ext'.
```

PowerShell splits the unquoted path into separate arguments, so `cd` receives
the first word only and everything after it is treated as extra parameters. The
line right above it already quotes the same variable (`mkdir "{{ExtDir}}"`), so
this looks like a plain oversight.

Quoting it fixes the setup for anyone whose checkout lives under, say,
`C:\Users\First Last\...` or a localized `Documents` folder - a common enough
case that the toolchain setup currently fails before it starts.

Only occurrence in the file; the rest of the script already quotes its paths.
