### PR TITLE
Fix first BRAW file stuck on 'Loading' overlay

### DIFF
--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -737,6 +737,12 @@ Item {
                     property bool errorShown: false;
                     onMetadataChanged: {
                         if (vid.videoWidth > 0) {
+                            // The video size may arrive after the "size"/metadataLoaded event
+                            // (e.g. the first BRAW decode, while the GPU decoder is still
+                            // initializing), so correct the one-shot "loaded" latch here.
+                            if (!loaded) {
+                                loaded = true;
+                            }
                             // Trigger seek to buffer the video frames
                             if (vid.duration == 0) {
                                 vid.play();


### PR DESCRIPTION
## Problem

Opening the **first** `.braw` file in a fresh gyroflow session leaves the UI stuck on the "Loading <file>..." overlay indefinitely. Re-opening the same file, or opening a different BRAW file, loads fine.

## Root cause

The "Loading" overlay (and the video's visibility) is gated on a local QML flag `vid.loaded` (`src/ui/VideoArea.qml`), which is set in exactly one place:

```qml
onMetadataLoaded: (md) => { Qt.callLater(fileLoaded, md); }
function fileLoaded(md) {
    loaded = vid.videoWidth > 0;   // one-shot latch
    ...
}
```

`onMetadataLoaded` is emitted by the MDK wrapper on the early `"size"` event. But the real width/height is delivered **later**, via `videoLoaded(width, height)` → `metadataChanged`, which only fires once the decoder reaches the `Prepared` media status. For the first BRAW decode the GPU (OpenCL) decoder is still initializing, so at the moment `fileLoaded()` runs, `vid.videoWidth` is still `0` and `loaded` latches to `false`. The later `metadataChanged` (which carries the real width) never re-sets `loaded`, so the overlay is stuck. On a re-open the decoder is already warm, the width arrives in time, and `loaded` latches to `true`.

In short: the code is **not polling** for the decoder to finish — it's a one-shot latch that can miss the size on a slow first decode.

## Fix

Correct the latch in `onMetadataChanged`: when a real video width arrives, mark the video as loaded.

```qml
onMetadataChanged: {
    if (vid.videoWidth > 0) {
        if (!loaded) {
            loaded = true;
        }
        // ...existing buffering/seek logic...
    } else if (!errorShown) { ... }
}
```

This is the actual root-cause fix and also covers any decoder that is slow to report its size.

## Testing

- First BRAW file in a fresh session now loads (overlay clears, video shows) instead of hanging.
- Re-opening / subsequent files still load as before.
- Non-BRAW files unaffected (they report their size before the `size` event, so behavior is unchanged).