### PR TITLE
Retry the decode if the first frame never arrives (fixes first BRAW load hang)

### DIFF
--- a/src/ui/VideoArea.qml
+++ b/src/ui/VideoArea.qml
@@ -433,6 +433,9 @@ Item {
         vid.errorShown = false;
         render_queue.editing_job_id = 0;
         controller.load_video(url, vid);
+        // Arm the "first frame never arrived" retry for this load.
+        vid.loadRetryCount = 0;
+        loadRetryTimer.restart();
         if (!isCalibrator) {
             const suffix = window.advanced.defaultSuffix.text;
             window.outputFile.setFilename(filesystem.filename_with_suffix(filename, suffix).replace(/%0[0-9]+d/, ""));
@@ -644,6 +647,11 @@ Item {
                     Ease on opacity { }
                     anchors.fill: parent;
                     property bool loaded: false;
+                    // Number of automatic re-decode attempts made for the current file.
+                    // Some decoders (notably the BRAW GPU/OpenCL decoder) fail to produce
+                    // their first frame on the very first decode in a fresh process but work
+                    // fine on a retry, so we transparently re-issue the load a few times.
+                    property int loadRetryCount: 0;
 
                     property bool stabEnabled: stabEnabledBtn.checked;
                     transform: [
@@ -698,6 +706,7 @@ Item {
                     }
                     function fileLoaded(md: var): void {
                         loaded = vid.videoWidth > 0;
+                        if (loaded) loadRetryTimer.stop(); // loaded fine, cancel any pending retry
                         videoLoader.active = false;
                         vidInfo.loader = false;
                         timeline.resetTrim();
@@ -768,6 +777,33 @@ Item {
                                     vid.volume = volumeSlider.value / 100.0;
                                 }
                             });
+                        }
+                    }
+
+                    // If the video has not produced a frame within a few seconds of being
+                    // opened, re-issue the decode. This works around decoders (e.g. the
+                    // BRAW GPU/OpenCL decoder) that hang on their first decode in a fresh
+                    // process but succeed once re-issued. Normal files load well within the
+                    // window, so this is a no-op for them.
+                    Timer {
+                        id: loadRetryTimer;
+                        interval: 8000;
+                        repeats: false;
+                        onTriggered: {
+                            if (vid.videoWidth > 0) return; // loaded fine, nothing to do
+                            if (vid.loadRetryCount < 3) {
+                                vid.loadRetryCount++;
+                                console.log("gyroflow: video not loaded after", loadRetryTimer.interval / 1000,
+                                          "s, re-issuing decode (attempt", vid.loadRetryCount + ")");
+                                controller.load_video(root.loadedFileUrl, vid);
+                                loadRetryTimer.restart();
+                            } else if (!vid.errorShown) {
+                                vid.errorShown = true;
+                                messageBox(Modal.Error, qsTr("Failed to load the selected file, it may be unsupported or invalid."), [ { "text": qsTr("Ok") } ]);
+                                dropText.loadingFile = "";
+                                root.pendingGyroflowData = null;
+                                stabEnabledBtn.checked = true;
+                            }
                         }
                     }
 


### PR DESCRIPTION
## Problem

Opening the **first** `.braw` file in a fresh gyroflow session leaves the UI stuck on the "Loading <file>..." overlay indefinitely. Re-opening the same file, or opening a different BRAW file, loads fine.

## Root cause

The "Loading" overlay (and the video's visibility) is gated on the video actually producing a frame. In the MDK wrapper (`MDKPlayer.cpp`), frames are only rendered once the media reaches the `Prepared` status (`m_videoLoaded` is set in `onMediaStatusChanged`), and the first-frame render callback only runs after that.

For the **first** BRAW decode in a fresh process, the BRAW SDK's one-time GPU (OpenCL) decoder initialization never completes, so the media never reaches `Prepared`, no frame is ever rendered, and the overlay is stuck. On a re-open the decoder is already warm, the media reaches `Prepared`, the first frame renders, and everything proceeds normally.

In short: the first BRAW decode in a process hangs in the SDK's one-time GPU init; a second decode in the same process works.

## Fix

Arm a single-shot 8-second timer whenever a file is opened. If the video still has no size after that window (i.e. no first frame arrived), re-issue the load — up to 3 attempts. Because a re-issued decode in the same process works (the one-time GPU init is already done), this transparently recovers the stuck first load. If it still fails after the retries, the normal "failed to load" message is shown.

Files that load normally report their size well within the 8s window, so the timer is a no-op for them; it is cancelled as soon as a valid size is reported.

## Testing

- First BRAW file in a fresh session: after ~8s the load is re-issued and the file loads (overlay clears, video shows) instead of hanging forever.
- Normal (non-BRAW) files: unaffected — they load well within the window.
- Genuinely broken files: after 3 attempts the standard "failed to load" message is shown.