### PR TITLE
Fix shutdown crashes from destroyed Rust thread-local state

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,8 +71,6 @@ tar = "0.4.45"
 lru = "0.18"
 chrono = "0.4"
 
-log-panics = { version = "2.1", features = ["with-backtrace"] }
-
 keep-awake = { git = "https://github.com/AdrianEddy/keep-awake-rs.git", rev = "4f2a93f" }
 
 [patch.crates-io]

--- a/src/core/stabilization/mod.rs
+++ b/src/core/stabilization/mod.rs
@@ -3,6 +3,7 @@
 
 use std::collections::BTreeMap;
 use std::cell::RefCell;
+use std::sync::mpsc;
 
 use crate::GyroflowCoreError;
 
@@ -47,12 +48,47 @@ impl From<&str> for Interpolation {
     }
 }
 
-struct ThreadLocalWgpuCache(RefCell<lru::LruCache<u32, wgpu::WgpuWrapper>>);
+type WgpuCache = lru::LruCache<u32, wgpu::WgpuWrapper>;
+
+lazy_static::lazy_static! {
+    // Keep GPU destruction off Qt-owned render threads without creating a
+    // Rust thread from a TLS destructor. `std::thread::spawn` is not valid
+    // after Rust's own thread-local `Thread` has already been destroyed.
+    static ref WGPU_DROP_QUEUE: mpsc::Sender<WgpuCache> = {
+        let (tx, rx) = mpsc::channel::<WgpuCache>();
+        std::thread::Builder::new()
+            .name("gyroflow-wgpu-drop".into())
+            .spawn(move || {
+                while let Ok(cache) = rx.recv() {
+                    drop(cache);
+                }
+            })
+            .expect("failed to start wgpu drop worker");
+        tx
+    };
+}
+
+fn queue_wgpu_drop(cache: WgpuCache) {
+    if let Err(err) = WGPU_DROP_QUEUE.send(cache) {
+        // Never fall back to destroying Vulkan objects on the calling thread.
+        std::mem::forget(err.0);
+    }
+}
+
+struct ThreadLocalWgpuCache(RefCell<WgpuCache>);
+impl ThreadLocalWgpuCache {
+    fn new() -> Self {
+        // Ensure the worker is created while Rust's thread metadata is valid,
+        // rather than on first access from this type's TLS destructor.
+        lazy_static::initialize(&WGPU_DROP_QUEUE);
+        Self(RefCell::new(WgpuCache::new(std::num::NonZeroUsize::new(15).unwrap())))
+    }
+}
 impl Drop for ThreadLocalWgpuCache {
     fn drop(&mut self) {
         // Workaround for a Vulkan hang on device destroy (https://github.com/gfx-rs/wgpu/issues/4973)
-        let inner = self.0.replace(lru::LruCache::new(std::num::NonZeroUsize::new(1).unwrap()));
-        std::thread::spawn(move || drop(inner));
+        let inner = self.0.replace(WgpuCache::new(std::num::NonZeroUsize::new(1).unwrap()));
+        queue_wgpu_drop(inner);
     }
 }
 
@@ -60,7 +96,7 @@ lazy_static::lazy_static! {
     pub static ref GPU_LIST: parking_lot::RwLock<Vec<String>> = parking_lot::RwLock::new(Vec::new());
 }
 thread_local! {
-    static CACHED_WGPU: ThreadLocalWgpuCache = ThreadLocalWgpuCache(RefCell::new(lru::LruCache::new(std::num::NonZeroUsize::new(15).unwrap())));
+    static CACHED_WGPU: ThreadLocalWgpuCache = ThreadLocalWgpuCache::new();
     #[cfg(feature = "use-opencl")]
     static CACHED_OPENCL: RefCell<lru::LruCache<u32, opencl::OclWrapper>> = RefCell::new(lru::LruCache::new(std::num::NonZeroUsize::new(15).unwrap()));
 }
@@ -71,8 +107,8 @@ thread_local! {
 /// avoid the Vulkan-on-destroy hang (gfx-rs/wgpu#4973).
 pub fn clear_gpu_cache_current_thread() {
     CACHED_WGPU.with(|x| {
-        let inner = x.0.replace(lru::LruCache::new(std::num::NonZeroUsize::new(15).unwrap()));
-        std::thread::spawn(move || drop(inner));
+        let inner = x.0.replace(WgpuCache::new(std::num::NonZeroUsize::new(15).unwrap()));
+        queue_wgpu_drop(inner);
     });
     #[cfg(feature = "use-opencl")]
     CACHED_OPENCL.with(|x| {

--- a/src/gyroflow.rs
+++ b/src/gyroflow.rs
@@ -62,7 +62,10 @@ fn entry() {
     util::init_logging();
     util::update_rlimit();
     util::set_android_context();
-    log_panics::init();
+    // `log_panics` calls `std::thread::current()` from its hook. That is not
+    // valid when a Qt-owned thread panics during TLS teardown, and causes a
+    // nested panic followed by abort. Keep panic logging thread-agnostic.
+    std::panic::set_hook(Box::new(|info| ::log::error!(target: "panic", "{info}")));
 
     cpp!(unsafe [] {
         qApp->setOrganizationName("Gyroflow");

--- a/src/util.rs
+++ b/src/util.rs
@@ -240,10 +240,14 @@ pub fn init_logging() {
     let log_config = [ "mp4parse", "wgpu", "naga", "akaze", "ureq", "rustls", "mdk" ]
         .into_iter()
         .fold(ConfigBuilder::new(), |mut cfg, x| { cfg.add_filter_ignore_str(x); cfg })
+        // Qt and MDK can log while destroying a foreign render thread, after
+        // Rust's own thread-local `Thread` has already been destroyed.
+        .set_thread_level(LevelFilter::Off)
         .build();
     let file_log_config = [ "mp4parse", "wgpu", "naga", "akaze", "ureq", "rustls" ]
         .into_iter()
         .fold(ConfigBuilder::new(), |mut cfg, x| { cfg.add_filter_ignore_str(x); cfg })
+        .set_thread_level(LevelFilter::Off)
         .build();
 
     #[cfg(target_os = "android")]


### PR DESCRIPTION
Fixes #1047.

Gyroflow could abort while shutting down Qt-owned render threads with:

> use of std::thread::current() is not possible after the thread's local
> data has been destroyed

Two shutdown paths could access Rust thread-local state after it had already been destroyed:

- The WGPU cache TLS destructor spawned a new Rust thread to destroy cached GPU objects.
- MDK could emit a final log message during render-thread teardown, causing  `simplelog` and the `log-panics` hook to request the current Rust thread.

This PR:

- Uses a process-lifetime worker to destroy cached WGPU objects away from Qt render threads.
- Initializes that worker before TLS teardown.
- Routes explicit GPU cache clearing through the same worker.
- Disables thread-ID formatting in the application loggers.
- Replaces `log-panics` with a thread-agnostic panic hook.

The patched application was tested on the system that originally reproduced #1047. A normal Qt shutdown completed with exit code 0, including late MDK teardown logging, without a panic, abort, or new core dump.
